### PR TITLE
Update to Agda 2.6.3

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,24 +1,8 @@
-# Agda ledger
+# Contributing to the formal ledger specifications
 
-## Building the derivations
+## Style guidelines
 
-Run `nix-build` with the desired derivation, for example:
-
-```
-nix-build -A agda
-nix-build -A agdaLedger
-nix-build -A ledger.executableSpec
-nix-build -A ledger.docs
-nix-build -A midnight.executableSpec
-nix-build -A midnight.docs
-```
-## How to run the ledger in ghci
-
-```
-nix-shell --command "cabal repl --build-depends 'agda-ledger-executable-spec, agda-ledger-executable-spec-midnight'"
-λ> :m HSLedgerTest
-λ> main
-```
+We are currently aspiring to follow the [Agda standard library style guide](https://github.com/agda/agda-stdlib/blob/master/notes/style-guide.md) as much as reasonable. Since some of our code will be rendered into a PDF the formatting of the PDF takes priority over formatting over the code, so deviations are to be expected.
 
 ## Setup with emacs
 
@@ -41,6 +25,10 @@ To install it locally and use that install with emacs, you can do the following:
 You can then use `M-x my/toggle-ledger-agda` or `C-c C-x C-t` to switch between your regular install of Agda and the locally installed version.
 
 There are other options as well, but this should work with all kinds of custom emacs setups or distributions (assuming there isn't already some other stuff going on with your Agda setup).
+
+## Setup with nix-shell
+
+`nix-shell` provides Agda complete with the correct dependencies. So you should be able to run your preferred editor within `nix-shell` and it should see the required `agda` executable.
 
 ## Updating nixpkgs
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,14 +11,16 @@ We rely on a patched Agda and stdlib, which makes setup more difficult. You can 
 To install it locally and use that install with emacs, you can do the following:
 
 - Put the version of Agda specified in the nix file somewhere: `nix-build -A agda -o ~/IOHK/ledger-agda`.
-- Put the following into your init file (highlight and `M-x eval-region` to load it without restarting emacs):
+- Put the following into your init file (highlight and `M-x eval-region` to load it without restarting emacs). Note that this assumes that your regular install of Agda is in your path with the name `agda` and version `2.6.2.2`, otherwise you'll have to edit these variables.
 ```
 (setq my/ledger-agda-name "~/IOHK/ledger-agda")
 (defun my/toggle-ledger-agda ()
   (interactive)
   (if (string-equal agda2-program-name "agda")
-      (setq agda2-program-name (concat my/ledger-agda-name "/bin/agda"))
-    (setq agda2-program-name "agda"))
+      (setq agda2-version      "2.6.3"
+            agda2-program-name (concat my/ledger-agda-name "/bin/agda"))
+    (setq agda2-version      "2.6.2.2"
+          agda2-program-name "agda"))
   (agda2-restart))
 (with-eval-after-load 'agda2-mode (define-key agda2-mode-map (kbd "C-c C-x C-t") 'my/toggle-ledger-agda))
 ```

--- a/README.md
+++ b/README.md
@@ -1,0 +1,22 @@
+# Formal ledger specifications
+
+This repository contains the formal ledger specifications that are intended to eventually replace the existing formal specifications of the Cardano ledger found [here](https://github.com/input-output-hk/cardano-ledger). This project is currently incomplete and work in progress.
+
+## Building the specifications
+
+This repository currently contains two specifications the work in progress specification for Cardano (up to and including the Conway era) and a small example that was produced for the Midnight project (but is unrelated to any actual Midnight code/features). Each specification is executable and contains some documentation in the form of a PDF document. They can be built as follows:
+
+```
+nix-build -A ledger.executableSpec
+nix-build -A ledger.docs
+nix-build -A midnight.executableSpec
+nix-build -A midnight.docs
+```
+
+The `executableSpec` is a `cabal` package, which can be loaded into GHCI like this:
+
+```
+nix-shell --command "cabal repl --build-depends 'agda-ledger-executable-spec, agda-ledger-executable-spec-midnight'"
+λ> :m HSLedgerTest
+λ> main
+```

--- a/default.nix
+++ b/default.nix
@@ -9,26 +9,24 @@ with pkgs;
 let
   customAgda = (import
     (builtins.fetchTarball
-      https://github.com/nixos/nixpkgs/tarball/a7ecde854aee5c4c7cd6177f54a99d2c1ff28a31)
-    ({
-      # 21.11
-      overlays = [
-        (import (fetchFromGitHub {
-          repo = "agda";
-          owner = "input-output-hk";
-          rev = "d5ea03b96328f38741efef4535197076ff0e05d5";
-          sha256 = "WiadZWZvPWcR49JkiXPiMKW3plRjBlR94wyg/aoEoG8=";
-        })).overlay
-      ];
-    } // (if pkgs.system == "aarch64-darwin" then { system = "x86_64-darwin"; } else { })));
+      https://github.com/nixos/nixpkgs/tarball/7343f7630c9d7211c98f0c043f380a9037b69252)
+    { overlays = [
+        (self: super: {
+          haskellPackages = super.haskellPackages.override {
+            overrides = haskellSelf: haskellSuper: {
+              Agda = haskellSuper."Agda_2_6_3";
+            };
+          };
+        })
+      ];});
 
   agdaStdlib = customAgda.agdaPackages.standard-library.overrideAttrs (oldAttrs: {
-    version = "1.7";
+    version = "1.7.2";
     src = customAgda.fetchFromGitHub {
       repo = "agda-stdlib";
-      owner = "input-output-hk";
-      rev = "f8fdb925c74e8d3b0c88e2a5520bc11e606d34c6";
-      sha256 = "BoK/IZsOn8gnUolI8DOZa6IOoXF8E95s2e8vZyUpMZs=";
+      owner = "agda";
+      rev = "668f0bbd498cfae253605fd7132c3b9ed52cc4ac";
+      sha256 = "4jNFpDtVWecwpuzZMtQb0kJ9s4LkjBYx+1c0n/Ft9tw=";
     };
   });
 
@@ -55,6 +53,7 @@ in
 rec {
 
   agda = agdaWithPkgs;
+  agda2 = customAgda.agda.withPackages { pkgs = [ agdaStdlib ]; ghc = pkgs.ghc; };
   agdaLedger = customAgda.agdaPackages.mkDerivation {
     pname = "Agda-ledger";
     version = "0.1";

--- a/shell.nix
+++ b/shell.nix
@@ -7,12 +7,15 @@
 
 with pkgs;
 
-mkShell {
+let specs = callPackage ./default.nix {};
+
+in mkShell {
   nativeBuildInputs = [
+    specs.agda
     cabal-install
     (haskellPackages.ghcWithPackages (pkgs: with pkgs; [
-      (callPackage ./default.nix { }).ledger.executableSpec
-      (callPackage ./default.nix { }).midnight.executableSpec
+      specs.ledger.executableSpec
+      specs.midnight.executableSpec
     ]))
   ];
 }

--- a/src/Axiom/Set.agda
+++ b/src/Axiom/Set.agda
@@ -12,7 +12,6 @@ open import Data.Product.Algebra using (×-comm)
 open import Relation.Binary using () renaming (Decidable to Dec₂)
 open import Relation.Nullary
 open import Relation.Nullary.Decidable using (⌊_⌋)
-open import Relation.Nullary.Negation
 open import Relation.Unary using () renaming (Decidable to Dec₁)
 
 private variable ℓ : Level

--- a/src/Axiom/Set/List.agda
+++ b/src/Axiom/Set/List.agda
@@ -11,7 +11,6 @@ open import Axiom.Set
 import Data.List
 import Data.List.Relation.Unary.All as All
 import Data.List.Relation.Unary.Any as Any
-import Data.List.Relation.Unary.Any.Properties as Any
 import Function.Inverse as I
 import Function.Properties.Inverse as I
 import Function.Related.Propositional as R
@@ -25,7 +24,6 @@ open import Function.Equality using (_⟶_; _⟨$⟩_)
 open import Function.Related hiding (⌊_⌋)
 open import Interface.DecEq
 open import Relation.Binary using () renaming (Decidable to Dec₂)
-open import Relation.Nullary
 open import Relation.Nullary.Decidable
 
 ∃-cong' : ∀ {k a₁ a₂ b₁ b₂}

--- a/src/Axiom/Set/Map.agda
+++ b/src/Axiom/Set/Map.agda
@@ -18,7 +18,7 @@ import Data.Sum
 open import Data.List.Ext.Properties
 open import Data.Product.Properties
 open import Interface.DecEq
-open import Relation.Nullary.Negation using (¬?)
+open import Relation.Nullary.Decidable using (¬?)
 open import Relation.Unary using () renaming (Decidable to Dec₁)
 
 open Equivalence

--- a/src/Axiom/Set/Map.agda
+++ b/src/Axiom/Set/Map.agda
@@ -7,18 +7,15 @@ open import Axiom.Set
 module Axiom.Set.Map (th : Theory {lzero}) where
 open Theory th
 open import Axiom.Set.Rel th hiding (_∣'_; _∣^'_)
-open import Axiom.Set.Factor th
 open import Axiom.Set.Properties th
 
 open import Prelude hiding (filter)
 
-import Data.List
 import Data.Product
 import Data.Sum
 open import Data.List.Ext.Properties
 open import Data.Product.Properties
 open import Interface.DecEq
-open import Relation.Nullary.Decidable using (¬?)
 open import Relation.Unary using () renaming (Decidable to Dec₁)
 
 open Equivalence

--- a/src/Axiom/Set/Rel.agda
+++ b/src/Axiom/Set/Rel.agda
@@ -17,7 +17,7 @@ import Data.Sum
 open import Data.List.Ext.Properties
 open import Data.Product.Properties
 open import Interface.DecEq
-open import Relation.Nullary.Negation using (¬?)
+open import Relation.Nullary.Decidable using (¬?)
 open import Relation.Unary using () renaming (Decidable to Dec₁)
 open import Relation.Nullary
 

--- a/src/Axiom/Set/Rel.agda
+++ b/src/Axiom/Set/Rel.agda
@@ -6,18 +6,15 @@ open import Axiom.Set
 
 module Axiom.Set.Rel (th : Theory {lzero}) where
 open Theory th
-open import Axiom.Set.Factor th
 open import Axiom.Set.Properties th
 
 open import Prelude hiding (filter)
 
-import Data.List
 import Data.Product
 import Data.Sum
 open import Data.List.Ext.Properties
 open import Data.Product.Properties
 open import Interface.DecEq
-open import Relation.Nullary.Decidable using (¬?)
 open import Relation.Unary using () renaming (Decidable to Dec₁)
 open import Relation.Nullary
 

--- a/src/Axiom/Set/Sum.agda
+++ b/src/Axiom/Set/Sum.agda
@@ -20,7 +20,7 @@ open import Data.List.Relation.Binary.Permutation.Propositional
 open import Data.List.Relation.Unary.Unique.Propositional
 open import Interface.DecEq
 open import Relation.Binary hiding (Rel)
-open import Relation.Nullary.Negation using (¬?)
+open import Relation.Nullary.Decidable using (¬?)
 open import Relation.Unary using () renaming (Decidable to Dec₁)
 
 open Equivalence

--- a/src/Axiom/Set/Sum.agda
+++ b/src/Axiom/Set/Sum.agda
@@ -13,7 +13,6 @@ open import Axiom.Set.Properties th
 open import Axiom.Set.Rel th
 open import Axiom.Set.Map th
 
-import Data.Sum
 open import Algebra.Properties.CommutativeSemigroup
 open import Data.List.Ext.Properties
 open import Data.List.Relation.Binary.Permutation.Propositional
@@ -22,8 +21,6 @@ open import Interface.DecEq
 open import Relation.Binary hiding (Rel)
 open import Relation.Nullary.Decidable using (¬?)
 open import Relation.Unary using () renaming (Decidable to Dec₁)
-
-open Equivalence
 
 open import Tactic.AnyOf
 open import Tactic.Defaults

--- a/src/Interface/Decidable/Instance.agda
+++ b/src/Interface/Decidable/Instance.agda
@@ -8,17 +8,14 @@ open import Data.Bool
 open import Data.Empty
 open import Data.Product
 open import Data.Unit
-open import Data.List
-open import Data.List.Properties
 
 open import Relation.Binary renaming (Decidable to Decidable²)
 open import Relation.Binary.PropositionalEquality
-open import Relation.Nullary
 open import Relation.Nullary.Decidable
 open import Relation.Unary using () renaming (Decidable to Decidable¹)
 
 private variable a b : Level
-                 A P X Y : Set a
+                 A X Y : Set a
 
 record Dec₁ {a} {A : Set a} (P : A → Set b) : Set (a ⊔ b) where
   field P? : Decidable¹ P

--- a/src/Interface/Decidable/Instance.agda
+++ b/src/Interface/Decidable/Instance.agda
@@ -15,8 +15,6 @@ open import Relation.Binary renaming (Decidable to Decidable²)
 open import Relation.Binary.PropositionalEquality
 open import Relation.Nullary
 open import Relation.Nullary.Decidable
-open import Relation.Nullary.Implication
-open import Relation.Nullary.Product
 open import Relation.Unary using () renaming (Decidable to Decidable¹)
 
 private variable a b : Level

--- a/src/Ledger.agda-lib
+++ b/src/Ledger.agda-lib
@@ -3,3 +3,5 @@ depend:
   standard-library
   stdlib-meta
 include: .
+flags:
+  -WnoUnsupportedIndexedMatch

--- a/src/Ledger/PPUp.lagda
+++ b/src/Ledger/PPUp.lagda
@@ -19,10 +19,10 @@ open import Algebra.Literals
 open import Data.Nat.Properties using (m+1+n≢m)
 open import Data.Product.Properties
 open import Ledger.PParams Epoch
-open import Relation.Nullary.Product
 
 open import Agda.Builtin.FromNat
 open import Data.Nat.Literals
+import Data.Unit.Polymorphic
 open Semiring-Lit Slotʳ
 
 private variable m n : ℕ

--- a/src/Ledger/PPUp/Properties.agda
+++ b/src/Ledger/PPUp/Properties.agda
@@ -1,7 +1,6 @@
 {-# OPTIONS --safe #-}
 
 open import Ledger.Transaction
-open import Ledger.Epoch
 
 module Ledger.PPUp.Properties (txs : TransactionStructure) where
 
@@ -9,9 +8,6 @@ open TransactionStructure txs
 open import Ledger.Prelude hiding (_≥_; _+_; _*_; Dec₁)
 
 open import Ledger.PPUp txs
-
-open import Tactic.ReduceDec
-open import MyDebugOptions
 
 open import Algebra
 open Semiring Slotʳ hiding (refl; sym)

--- a/src/Ledger/PPUp/Properties.agda
+++ b/src/Ledger/PPUp/Properties.agda
@@ -20,7 +20,6 @@ import Data.Unit.Polymorphic
 open import Data.Product.Properties
 open import Interface.Decidable.Instance
 open import Relation.Nullary.Decidable
-open import Relation.Nullary.Product
 
 -- Ring literals
 open import Agda.Builtin.FromNat

--- a/src/Prelude.agda
+++ b/src/Prelude.agda
@@ -10,7 +10,7 @@ open import Function public
 open import Data.Bool hiding (_≟_; _≤_; _≤?_; _<_; _<?_) public
 open import Data.Empty public
 open import Data.List hiding (align; alignWith; fromMaybe; map; zip; zipWith) public
-open import Data.Maybe hiding (_>>=_; align; alignWith; fromMaybe; map; zip; zipWith) public
+open import Data.Maybe hiding (_>>=_; align; alignWith; ap; fromMaybe; map; zip; zipWith) public
 open import Data.Unit hiding (_≟_) public
 open import Data.Sum hiding (assocʳ; assocˡ; map; map₁; map₂; reduce; swap) public
 open import Data.Product hiding (assocʳ; assocˡ; map; map₁; map₂; swap) public

--- a/stdlib-meta-update-imports.patch
+++ b/stdlib-meta-update-imports.patch
@@ -144,10 +144,10 @@ index a1e3600..6695287 100644
 +          ; isBooleanAlgebra = isBooleanAlgebra
 +          }
 diff --git a/Class/Applicative/Instances.agda b/Class/Applicative/Instances.agda
-index 3a93f03..a0c81b2 100644
+index 3a93f03..2cb9c30 100644
 --- a/Class/Applicative/Instances.agda
 +++ b/Class/Applicative/Instances.agda
-@@ -62,8 +62,8 @@ instance
+@@ -62,8 +62,9 @@ instance
  
    Alternative-TC : Alternative TC
    Alternative-TC = record {M}
@@ -155,9 +155,11 @@ index 3a93f03..a0c81b2 100644
 +    where import Reflection.TCM.Syntax as M
  
    Applicative-TC : Applicative TC
-   Applicative-TC = record {M}
+-  Applicative-TC = record {M}
 -    where import Reflection.TypeChecking.Monad.Syntax as M
-+    where import Reflection.TCM.Syntax as M
++  Applicative-TC = record {M; M'}
++    where import Reflection.TCM as M
++          import Reflection.TCM.Syntax as M'
 diff --git a/Class/DecEq/Instances.agda b/Class/DecEq/Instances.agda
 index 225a7ea..fb71699 100644
 --- a/Class/DecEq/Instances.agda
@@ -209,6 +211,21 @@ index c4d836a..a5fecb1 100644
  
    Functor-∃Vec : Functor (∃ ∘ Vec)
    Functor-∃Vec ._<$>_ f (_ , xs) = -, (f <$> xs)
+diff --git a/Class/Monad/Instances.agda b/Class/Monad/Instances.agda
+index d550866..08270d8 100644
+--- a/Class/Monad/Instances.agda
++++ b/Class/Monad/Instances.agda
+@@ -40,8 +40,9 @@ instance
+     ._>>=_ → flip concatMap
+ 
+   Monad-TC : Monad TC
+-  Monad-TC = record {M}
++  Monad-TC = record {M; return = M'.pure}
+     where import Reflection as M
++          import Reflection.TCM as M'
+ 
+ {- ** Id monad: provides us with forward composition as _>=>_,
+                 but breaks instance-resolution/typeclass-inference
 diff --git a/Class/Show/Instances.agda b/Class/Show/Instances.agda
 index fb9b514..12e43e8 100644
 --- a/Class/Show/Instances.agda
@@ -257,7 +274,7 @@ index 8f30cae..1374218 100644
  -- ** Smart constructors
  
 diff --git a/Generics/Debug.agda b/Generics/Debug.agda
-index 08ccae8..5055ff6 100644
+index 08ccae8..f6d5ef9 100644
 --- a/Generics/Debug.agda
 +++ b/Generics/Debug.agda
 @@ -15,8 +15,8 @@ open import Data.Nat using (ℕ)
@@ -271,11 +288,20 @@ index 08ccae8..5055ff6 100644
  
  open import Class.Show.Core
  open import Class.Show.Instances
+@@ -77,7 +77,7 @@ module Debug (v : String × ℕ) where
+       go (i , ty) = print $ "\t" Str.++ show i Str.++ " : " Str.++ show ty
+ 
+   printCurrentContext : TC ⊤
+-  printCurrentContext = printContext =<< getContext
++  printCurrentContext = (λ l → printContext (Data.List.map proj₂ l)) =<< getContext
+ 
+   -- ** definitions
+   genSimpleDef : Name → Type → Term → TC ⊤
 diff --git a/Generics/Utils.agda b/Generics/Utils.agda
-index 0d24ee4..fc7bcea 100644
+index 0d24ee4..007499c 100644
 --- a/Generics/Utils.agda
 +++ b/Generics/Utils.agda
-@@ -5,14 +5,14 @@ open import Level using (Level)
+@@ -5,14 +5,15 @@ open import Level using (Level)
  open import Function
  
  open import Reflection hiding (visibility)
@@ -295,6 +321,7 @@ index 0d24ee4..fc7bcea 100644
 +open import Reflection.AST.Argument.Information
 +open import Reflection.AST.Argument.Visibility as Vis
 +open import Reflection.TCM.Syntax
++open import Reflection.TCM using () renaming (pure to return)
  
  open import Data.Unit
  open import Data.Product hiding (map; zip)
@@ -350,7 +377,7 @@ index 12f4c3e..e4e1ffc 100644
  open import Interface.Monad
  open import Interface.MonadError
 diff --git a/Interface/MonadTC.agda b/Interface/MonadTC.agda
-index 677963f..812bd58 100644
+index 677963f..fa072a6 100644
 --- a/Interface/MonadTC.agda
 +++ b/Interface/MonadTC.agda
 @@ -2,7 +2,7 @@
@@ -362,6 +389,24 @@ index 677963f..812bd58 100644
  
  open import Data.List using (map)
  
+@@ -23,7 +23,7 @@ private
+ 
+ instance
+   Monad-TC : Monad R.TC
+-  Monad-TC = record { R }
++  Monad-TC = record { R ; return = R.pure }
+ 
+ data ReductionOptions : Set where
+   onlyReduce : List Name → ReductionOptions
+@@ -49,7 +49,7 @@ initTCEnvWithGoal goal = R.getContext <&> λ ctx → record
+   ; reconstruction = false
+   ; noConstraints  = false
+   ; reduction      = reduceAll
+-  ; globalContext  = ctx
++  ; globalContext  = Data.List.map proj₂ ctx
+   ; localContext   = []
+   ; goal           = inj₁ goal
+   ; debug          = defaultDebugOptions
 diff --git a/Lenses/Derive.agda b/Lenses/Derive.agda
 index 933dee4..31d563c 100644
 --- a/Lenses/Derive.agda
@@ -423,10 +468,10 @@ index 1fe207e..65adab8 100644
  instance
    iMonad-TC = Monad-TC
 diff --git a/Prelude.agda b/MetaPrelude.agda
-similarity index 91%
+similarity index 82%
 rename from Prelude.agda
 rename to MetaPrelude.agda
-index 3ac9016..257a981 100644
+index 3ac9016..01c55ad 100644
 --- a/Prelude.agda
 +++ b/MetaPrelude.agda
 @@ -1,6 +1,6 @@
@@ -437,11 +482,13 @@ index 3ac9016..257a981 100644
  
  open import Level renaming (_⊔_ to _⊔ˡ_; suc to sucˡ; zero to zeroˡ) public
  open import Function public
-@@ -9,7 +9,7 @@ open import Data.Bool hiding (_≟_; _≤_; _≤?_; _<_; _<?_) public
+@@ -8,8 +8,8 @@ open import Function public
+ open import Data.Bool hiding (_≟_; _≤_; _≤?_; _<_; _<?_) public
  open import Data.Empty public
  open import Data.List hiding (align; alignWith; fromMaybe; map; zip; zipWith) public
- open import Data.Maybe hiding (_>>=_; align; alignWith; fromMaybe; map; zip; zipWith) public
+-open import Data.Maybe hiding (_>>=_; align; alignWith; fromMaybe; map; zip; zipWith) public
 -open import Data.Unit hiding (_≟_; decSetoid) public
++open import Data.Maybe hiding (_>>=_; ap; align; alignWith; fromMaybe; map; zip; zipWith) public
 +open import Data.Unit hiding (_≟_) public
  open import Data.Sum hiding (assocʳ; assocˡ; map; map₁; map₂; reduce; swap) public
  open import Data.Product hiding (assocʳ; assocˡ; map; map₁; map₂; swap) public
@@ -510,7 +557,7 @@ index 4266c50..830aa19 100644
  
  open import Generics using (absName; getVisibility; findMetas; isMeta; UnquoteDecl; Tactic) public
 diff --git a/Reflection/TCI.agda b/Reflection/TCI.agda
-index 79c2ffe..53b6197 100644
+index 79c2ffe..c0d4a2c 100644
 --- a/Reflection/TCI.agda
 +++ b/Reflection/TCI.agda
 @@ -5,7 +5,7 @@
@@ -522,6 +569,15 @@ index 79c2ffe..53b6197 100644
  
  open import Data.List using (map)
  
+@@ -52,7 +52,7 @@ applyNoConstraints x r@record { noConstraints = true  } = R'.noConstraints (x r)
+ 
+ applyExtContext : List (Arg Term) → R.TC A → R.TC A
+ applyExtContext [] x       = x
+-applyExtContext (t ∷ ts) x = applyExtContext ts $ R.extendContext t x
++applyExtContext (t ∷ ts) x = applyExtContext ts $ R.extendContext "_" t x
+ 
+ private
+   liftTC : R.TC A → TC A
 diff --git a/Tactic/AnyOf.agda b/Tactic/AnyOf.agda
 index 6dc5a85..0aa849c 100644
 --- a/Tactic/AnyOf.agda
@@ -601,7 +657,7 @@ index 39fcab6..88dd6b9 100644
  
  open import Generics
 diff --git a/Tactic/Derive/DecEq.agda b/Tactic/Derive/DecEq.agda
-index 41a3f98..b59ab6e 100644
+index 41a3f98..07b0bd4 100644
 --- a/Tactic/Derive/DecEq.agda
 +++ b/Tactic/Derive/DecEq.agda
 @@ -12,9 +12,9 @@ open import Meta
@@ -616,27 +672,25 @@ index 41a3f98..b59ab6e 100644
  
  open import Generics
  
-@@ -43,9 +43,6 @@ open ClauseExprM
- `yes x = quote _because_ ◆⟦ quote true  ◆ ∣ quote ofʸ ◆⟦ x ⟧ ⟧
+@@ -23,7 +23,6 @@ import Data.List.NonEmpty as NE
+ 
+ open import Relation.Nullary
+ open import Relation.Nullary.Decidable
+-open import Relation.Nullary.Product
+ 
+ module _ where
+   open import Interface.DecEq hiding (DecEq-List; DecEq-ℕ; DecEq-ℤ; DecEq-⊤; DecEq-Maybe) public
+@@ -44,7 +43,7 @@ open ClauseExprM
  `no  x = quote _because_ ◆⟦ quote false ◆ ∣ quote ofⁿ ◆⟦ x ⟧ ⟧
  
--map' : ∀ {p q} {P : Set p} {Q : Set q} → P ⇔ Q → Dec P → Dec Q
+ map' : ∀ {p q} {P : Set p} {Q : Set q} → P ⇔ Q → Dec P → Dec Q
 -map' record { f = f ; g = g } = map′ f g
--
++map' record { to = to ; from = from } = map′ to from
+ 
  module _ (transName : Name → Maybe Name) where
  
-   eqFromTerm : Term → Term → Term → Term
-@@ -63,7 +60,7 @@ module _ (transName : Name → Maybe Name) where
-   mapDiag nothing          = return $ `no `λ⦅ [ ("" , vArg?) ] ⦆∅
-   mapDiag (just p@(l , _)) = let k = length l in do
-     typeList ← traverseList inferType (applyDownFrom ♯ (length l))
--    return $ quote map' ∙⟦ genEquiv k ∣ genPf k (L.map eqFromTerm typeList) ⟧
-+    return $ quote map ∙⟦ genEquiv k ∣ genPf k (L.map eqFromTerm typeList) ⟧
-     where
-       genPf : ℕ → List (Term → Term → Term) → Term
-       genPf k []      = `yes (quote tt ◆)
 diff --git a/Tactic/Derive/Show.agda b/Tactic/Derive/Show.agda
-index c8e157a..4b88959 100644
+index c8e157a..e8adc92 100644
 --- a/Tactic/Derive/Show.agda
 +++ b/Tactic/Derive/Show.agda
 @@ -6,7 +6,7 @@ open import Meta
@@ -648,6 +702,15 @@ index c8e157a..4b88959 100644
  open import Agda.Builtin.Reflection using (primShowQName)
  
  open import Generics
+@@ -17,7 +17,7 @@ open import Data.String using (fromList; toList) renaming (_++_ to _++S_)
+ import Data.Char as C
+ import Reflection
+ 
+-open import Relation.Nullary.Negation
++open import Relation.Nullary.Decidable
+ 
+ open import Interface.Show
+ 
 diff --git a/Tactic/Derive/TestTypes.agda b/Tactic/Derive/TestTypes.agda
 index 85144b1..d5b50ed 100644
 --- a/Tactic/Derive/TestTypes.agda
@@ -675,10 +738,10 @@ index 54bb57d..7993c33 100644
  import Relation.Binary.PropositionalEquality as ≡
  open import Agda.Builtin.Reflection
 diff --git a/Tactic/Helpers.agda b/Tactic/Helpers.agda
-index 2802245..8aa8415 100644
+index 2802245..aa32b23 100644
 --- a/Tactic/Helpers.agda
 +++ b/Tactic/Helpers.agda
-@@ -1,7 +1,7 @@
+@@ -1,18 +1,18 @@
  {-# OPTIONS --safe --without-K #-}
  module Tactic.Helpers where
  
@@ -687,7 +750,11 @@ index 2802245..8aa8415 100644
  open import Meta
  
  open import Data.Nat using () renaming (_≟_ to _≟ℕ_)
-@@ -12,7 +12,7 @@ open import Generics
+ open import Data.List using (map; zipWith)
+ import Data.Sum
+ 
+-open import Generics
++open import Generics hiding (error)
  
  open import Relation.Nullary.Decidable hiding (map)
  open import Reflection.Syntax
@@ -696,6 +763,33 @@ index 2802245..8aa8415 100644
  
  import Reflection
  open import Interface.Monad.Instance
+@@ -102,7 +102,7 @@ module _ {M : ∀ {a} → Set a → Set a} ⦃ _ : Monad M ⦄ ⦃ me : MonadErr
+   getDataDef n = inDebugPath "getDataDef" do
+     debugLog ("Find details for datatype: " ∷ᵈ n ∷ᵈ [])
+     (data-type pars cs) ← getDefinition n
+-      where _ → error1 "Not a data definition!"
++      where _ → error (n ∷ᵈ " is not a 'data' type!" ∷ᵈ [])
+     debugLogᵐ ("Constructor names: " ∷ᵈᵐ cs ᵛ ∷ᵈᵐ []ᵐ)
+     cs' ← traverseList (λ n → (n ,_) <$> getType' n) cs
+     debugLogᵐ ("Result: " ∷ᵈᵐ cs' ᵛⁿ ∷ᵈᵐ []ᵐ)
+@@ -112,7 +112,7 @@ module _ {M : ∀ {a} → Set a → Set a} ⦃ _ : Monad M ⦄ ⦃ me : MonadErr
+   getRecordDef : Name → M RecordDef
+   getRecordDef n = do
+     (record-type c fs) ← getDefinition n
+-      where _ → error1 "Not a record definition!"
++      where _ → error (n ∷ᵈ " is not a 'record' type!" ∷ᵈ [])
+     args ← proj₁ <$> getType' n
+     return (record { name = c ; fields = fs ; params = args })
+ 
+@@ -120,7 +120,7 @@ module _ {M : ∀ {a} → Set a → Set a} ⦃ _ : Monad M ⦄ ⦃ me : MonadErr
+   getDataOrRecordDef n =
+     catch (inj₁ <$> getDataDef n)
+       λ _ → catch (inj₂ <$> getRecordDef n)
+-      λ _ → error1 "Neither a data not a record definition!"
++      λ _ → error (n ∷ᵈ " is neither a 'data' not a 'record' type!" ∷ᵈ [])
+ 
+   getParams : Name → M (List (Abs (Arg Type)))
+   getParams n = Data.Sum.[ DataDef.params , RecordDef.params ] <$> getDataOrRecordDef n
 diff --git a/Tactic/ReduceDec.agda b/Tactic/ReduceDec.agda
 index 1fea416..879d8be 100644
 --- a/Tactic/ReduceDec.agda
@@ -850,3 +944,14 @@ index 290cbb9..0951344 100644
  
  open import Generics
  open Debug ("try" , 100)
+diff --git a/stdlib-meta.agda-lib b/stdlib-meta.agda-lib
+index 846d353..088d562 100644
+--- a/stdlib-meta.agda-lib
++++ b/stdlib-meta.agda-lib
+@@ -1,3 +1,5 @@
+ name: stdlib-meta
+ depend: standard-library
+ include: .
++flags:
++  -WnoUnsupportedIndexedMatch
+\ No newline at end of file


### PR DESCRIPTION
Update ledger & the dependencies to Agda 2.6.3. This gives us a few nice things, in particular some improvements to metaprogramming and potentially quotients via erased cubical. It also means we don't have to rely on a custom patched version of Agda anymore.