### PR TITLE
Move the definition of Coin into Ledger.Prelude.Base

### DIFF
--- a/src/Ledger/Interface/HasCoin.agda
+++ b/src/Ledger/Interface/HasCoin.agda
@@ -3,9 +3,7 @@
 module Ledger.Interface.HasCoin where
 
 open import Prelude
-
-private
-  Coin = ℕ
+open import Ledger.Prelude.Base
 
 record HasCoin {a} (A : Set a) : Set a where
   field getCoin : A → Coin

--- a/src/Ledger/PParams.lagda
+++ b/src/Ledger/PParams.lagda
@@ -8,7 +8,6 @@ open import Ledger.Prelude
 \end{code}
 \begin{figure*}[h]
 \begin{code}
-Coin = ℕ
 ProtVer = ℕ × ℕ
 
 record PParams : Set where

--- a/src/Ledger/Prelude.agda
+++ b/src/Ledger/Prelude.agda
@@ -1,15 +1,30 @@
 {-# OPTIONS --safe #-}
 
+--------------------------------------------------------------------------------
+-- Ledger prelude
+--
+-- Re-exports modules relating to STS, set theory and other
+-- miscellaneous things used to write the ledger rules. If something
+-- is used in more than two Ledger.* modules, it should probably go
+-- here.
+--------------------------------------------------------------------------------
+
 module Ledger.Prelude where
 
 open import Prelude public
+
+open import Ledger.Prelude.Base public
 
 open import Interface.ComputationalRelation public
 open import Interface.DecEq public
 open import Ledger.Interface.HasCoin public
 open import Relation.Nullary public
-open import Relation.Nullary.Negation
 open import Relation.Unary using () renaming (Decidable to Dec₁) public
+
+open Computational public
+
+--------------------------------------------------------------------------------
+-- Set theory
 
 open import Axiom.Set
 open import Axiom.Set.List as L renaming (List-Model to List-Model'; List-Modelᶠ to List-Model'ᶠ; List-Modelᵈ to List-Model'ᵈ)
@@ -45,7 +60,7 @@ abstract
 
 open import Axiom.Set.Rel th hiding (_∣'_; _∣^'_) public
 open import Axiom.Set.Map th renaming (Map to _↛_) public
-open import Axiom.Set.TotalMap th
+open import Axiom.Set.TotalMap th public
 open L.Decˡ hiding (_∈?_; ≟-∅) public
 open import Axiom.Set.Sum th public
 
@@ -69,8 +84,6 @@ module Properties where
   open import Axiom.Set.Properties th public
   module _ {A : Set} ⦃ _ : DecEq A ⦄ where
     open Intersectionᵖ {A} ∈-sp public
-
-open Computational public
 
 _ᶠᵐ : {A B : Set} → A ↛ B → FinMap A B
 (R , uniq) ᶠᵐ = (R , uniq , finiteness _)

--- a/src/Ledger/Prelude/Base.agda
+++ b/src/Ledger/Prelude/Base.agda
@@ -1,0 +1,7 @@
+{-# OPTIONS --safe #-}
+
+module Ledger.Prelude.Base where
+
+open import Data.Nat
+
+Coin = ℕ

--- a/src/Ledger/TokenAlgebra.lagda
+++ b/src/Ledger/TokenAlgebra.lagda
@@ -14,7 +14,6 @@ record TokenAlgebra : Set₁ where
   field PolicyId : Set
         Value-CommutativeMonoid : CommutativeMonoid 0ℓ 0ℓ
 
-  Coin = ℕ
   MemoryEstimate = ℕ
 
   open CommutativeMonoid Value-CommutativeMonoid using (_≈_; ε)

--- a/src/Ledger/Transaction.lagda
+++ b/src/Ledger/Transaction.lagda
@@ -61,7 +61,7 @@ This function must produce a unique id for each unique transaction body.
                  DecEq-UpdT  : DecEq (Ledger.PParams.PParamsDiff.UpdateT ppUpd)
 
   open Crypto crypto public
-  open TokenAlgebra tokenAlgebra hiding (Coin) public
+  open TokenAlgebra tokenAlgebra public
   open isHashableSet adHashingScheme renaming (THash to ADHash) public
 
   field ss : Ledger.Script.ScriptStructure KeyHash ScriptHash Slot


### PR DESCRIPTION
`Coin` was defined in multiple places before, leading to some issues with the Haskell build.