### PR TITLE
Add an executableSpecSrc attribute to the nix builds

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -117,6 +117,7 @@ rec {
       };
     in
     {
+      executableSpecSrc = hsSrc;
       executableSpec = haskellPackages.callCabal2nix "Agda-ledger-executable-spec" "${hsSrc}" { };
       docs = docs;
     };


### PR DESCRIPTION
This is the source of the Haskell package, which can be useful for diagnosing issues with building it.