### PR TITLE
Delegations and deposits

### DIFF
--- a/src/Axiom/Set.agda
+++ b/src/Axiom/Set.agda
@@ -198,7 +198,7 @@ record Theory {ℓ} : Type (sucˡ ℓ) where
       from' (x , x∈X , refl) | just x₁ | [ eq ] = to ∈-unions
         ( maybe ❴_❵ ∅ (f x)
         , to ∈-map (x , refl , x∈X)
-        , subst (λ z → x₁ ∈ maybe ❴_❵ ∅ z) (sym eq) (from ∈-singleton refl))
+        , subst (λ z → x₁ ∈ maybe ❴_❵ ∅ z) (sym eq) (to ∈-singleton refl))
 
   binary-unions : ∃[ Y ] ∀ {a} → (a ∈ X ⊎ a ∈ X') ⇔ a ∈ Y
   binary-unions {X = X} {X'} with unions (fromList (X ∷ [ X' ]))

--- a/src/Axiom/Set/Map.agda
+++ b/src/Axiom/Set/Map.agda
@@ -216,6 +216,10 @@ module Restrictionᵐ (sp-∈ : spec-∈ A) where
   infix 30 _⦅_,-⦆
   _⦅_,-⦆ = curryᵐ
 
+  update : A → Maybe B → Map A B → Map A B
+  update x (just y) m = insert m x y
+  update x nothing  m = m ∣ ❴ x ❵ ᶜ
+
 module Lookupᵐ (sp-∈ : spec-∈ A) where
   open import Relation.Nullary.Decidable
   private module R = Restriction sp-∈

--- a/src/Axiom/Set/Map/Dec.agda
+++ b/src/Axiom/Set/Map/Dec.agda
@@ -3,6 +3,7 @@ open import Axiom.Set
 
 module Axiom.Set.Map.Dec (thᵈ : Theoryᵈ) where
 
+open import Algebra
 open import Agda.Primitive renaming (Set to Type)
 open import Data.These
 open import Interface.DecEq
@@ -18,6 +19,7 @@ open import Axiom.Set.Rel th hiding (_∣'_; _∣^'_)
 open import Axiom.Set.Map th
 open import Data.List.Relation.Unary.Any
 open import Relation.Binary.PropositionalEquality
+import Relation.Binary.Reasoning.Setoid as SetoidReasoning
 
 private variable A A' B B' C D : Type
                  R R' : Rel A B
@@ -47,4 +49,8 @@ module Lookupᵐᵈ (sp-∈ : spec-∈ A) where
        helper _ _ | _ | _ | _ , _ , refl | _ , _ , refl
            | yes _ | [ eq ] | yes _ | [ eq' ] with trans (sym eq) eq'
        ... | refl = refl
+
+  _∪⁺_ : ⦃ M : Monoid 0ℓ 0ℓ ⦄ → (open Monoid M renaming (Carrier to V)) → ⦃ DecEq A ⦄ → Map A V → Map A V → Map A V
+  _∪⁺_ ⦃ M = M ⦄ = unionWith (fold id id _∙_)
+    where open Monoid M
 

--- a/src/Ledger/Deleg.lagda
+++ b/src/Ledger/Deleg.lagda
@@ -4,64 +4,158 @@
 {-# OPTIONS --safe #-}
 
 open import Ledger.Prelude
+open import Ledger.Epoch
+open import Ledger.Crypto
 
-module Ledger.Deleg (Network KeyHash ScriptHash : Set)
-                    ⦃ _ : DecEq Network ⦄ ⦃ _ : DecEq KeyHash ⦄ ⦃ _ : DecEq ScriptHash ⦄ where
+module Ledger.Deleg
+  (crypto : Crypto)
+  (Network : Set)
+  (epochStructure : EpochStructure)
+  ⦃ _ : DecEq Network ⦄
+  where
+
+open Crypto crypto
 
 open import Ledger.Address Network KeyHash ScriptHash
+open import Ledger.PParams epochStructure using (PParams)
+
+open EpochStructure epochStructure
+
 \end{code}
 \begin{figure*}[h]
 \begin{code}
+record PoolParams : Set where
+  field rewardAddr : Credential
+        deposit    : Coin
+
 data DCert : Set where
-  -- regkey    : Credential → DCert
-  -- delegate  : Credential → KeyHash → DCert
-  -- deregkey
-  -- regpool
-  -- retirepool
-  regdrep    : Credential → DCert
+  delegate   : Credential → Maybe Credential → Maybe Credential → Coin → DCert
+  regpool    : Credential → PoolParams → DCert
+  retirepool : Credential → Epoch → DCert
+  regdrep    : Credential → Coin → DCert
   deregdrep  : Credential → DCert
-  delegdrep  : Credential → Credential → DCert -- TODO: merge with 'delegate' certificate?
   ccreghot   : Credential → KeyHash → DCert
 
-VDelEnv = ⊤
+VDelEnv = PParams
 
-record VDelState : Set where
-  constructor ⟦_,_,_⟧ᵈ
-  field dreps            : ℙ Credential
-        drepDelegations  : Credential ↛ Credential
-        ccHotKeys        : KeyHash ↛ KeyHash -- TODO: maybe replace with credential
+CertEnv = PParams
+
+DelegEnv = PParams
+
+PoolEnv = PParams
+
+record DState : Set where
+  constructor ⟦_,_⟧ᵈ
+  field voteDelegs      : Credential ↛ Credential
+  --    ^ stake credential to DRep credential
+        stakeDelegs     : Credential ↛ Credential
+  --    ^ stake credential to pool credential
+
+record PState : Set where
+  constructor ⟦_,_⟧ᵖ
+  field pools    : Credential ↛ PoolParams
+        retiring : Credential ↛ Epoch
+
+record VState : Set where
+  constructor ⟦_,_⟧ᵛ
+  field dreps     : Credential ↛ Coin
+        ccHotKeys : KeyHash ↛ KeyHash -- TODO: maybe replace with credential
+
+record CertState : Set where
+  field dState : DState
+        pState : PState
+        vState : VState
 \end{code}
 
 \begin{code}[hide]
 private variable
-  dreps : ℙ Credential
-  delegs : Credential ↛ Credential
+  dReps dReps' : Credential ↛ Coin
+  pools : Credential ↛ PoolParams
+  vDelegs sDelegs : Credential ↛ Credential
+  retiring retiring' : Credential ↛ Epoch
   ccKeys : KeyHash ↛ KeyHash
+  dCert : DCert
   c c' : Credential
+  mc mc' : Maybe Credential
+  d : Coin
+  e : Epoch
   kh kh' : KeyHash
+  st st' : CertState
+  stᵛ stᵛ' : VState
+  stᵈ stᵈ' : DState
+  stᵖ stᵖ' : PState
+  pp : PParams
+  poolParams : PoolParams
 \end{code}
 
 \begin{code}
-data _⊢_⇀⦇_,VDEL⦈_ : VDelEnv → VDelState → DCert → VDelState → Set where
-  VDEL-regdrep :
-    -- TODO: deposit
-    _ ⊢ ⟦ dreps , delegs , ccKeys ⟧ᵈ ⇀⦇ regdrep c ,VDEL⦈ ⟦ dreps ∪ singleton c , delegs , ccKeys ⟧ᵈ
+
+requiredDeposit : PParams → Maybe Credential → Coin
+requiredDeposit pp (just x) = PParams.poolDeposit pp
+requiredDeposit pp nothing = 0
+
+data _⊢_⇀⦇_,DELEG⦈_ : DelegEnv → DState → DCert → DState → Set where
+  DELEG-delegate :
+    d ≡ requiredDeposit pp mc ⊔ requiredDeposit pp mc'
+    ────────────────────────────────
+    pp ⊢ ⟦ vDelegs , sDelegs ⟧ᵈ ⇀⦇ delegate c mc mc' d ,DELEG⦈
+         ⟦ update c mc vDelegs , update c mc' sDelegs ⟧ᵈ
+
+data _⊢_⇀⦇_,POOL⦈_ : PoolEnv → PState → DCert → PState → Set where
+  POOL-regpool : let open PParams pp ; open PoolParams poolParams in
+    deposit ≡ poolDeposit
+    → c ∉ dom (pools ˢ)
+    ────────────────────────────────
+    pp ⊢ ⟦ pools , retiring ⟧ᵖ ⇀⦇ regpool c poolParams ,POOL⦈ ⟦ ❴ c , poolParams ❵ᵐ ∪ᵐˡ pools , retiring ⟧ᵖ
+
+  POOL-retirepool : let open PoolParams poolParams in
+    pp ⊢ ⟦ pools , retiring ⟧ᵖ ⇀⦇ retirepool c e ,POOL⦈
+         ⟦ pools , ❴ c , e ❵ᵐ ∪ᵐˡ retiring ⟧ᵖ
+
+data _⊢_⇀⦇_,VDEL⦈_ : VDelEnv → VState → DCert → VState → Set where
+  VDEL-regdrep : let open PParams pp in
+    d ≡ poolDeposit -- TODO use drepDeposit instead
+    → c ∉ dom (dReps ˢ)
+    ────────────────────────────────
+    pp ⊢ ⟦ dReps , ccKeys ⟧ᵛ ⇀⦇ regdrep c d ,VDEL⦈
+         ⟦ ❴ c , d ❵ᵐ ∪ᵐˡ dReps , ccKeys ⟧ᵛ
 
   VDEL-deregdrep :
-    c ∉ dreps
+    c ∉ dom (dReps ˢ)
+    → dReps' ≡ ❴ c , d ❵ᵐ ∪ᵐˡ dReps
     ────────────────────────────────
-    _ ⊢ ⟦ dreps ∪ singleton c , delegs , ccKeys ⟧ᵈ ⇀⦇ deregdrep c ,VDEL⦈ ⟦ dreps , delegs , ccKeys ⟧ᵈ
-
-  VDEL-delegdrep :
-    -- TODO: deposit? easy if merged with 'delegate'
-    _ ⊢ ⟦ dreps , delegs , ccKeys ⟧ᵈ ⇀⦇ delegdrep c c' ,VDEL⦈
-        ⟦ dreps , singletonᵐ c c' ∪ᵐˡ delegs , ccKeys ⟧ᵈ
+    pp ⊢ ⟦ dReps , ccKeys ⟧ᵛ ⇀⦇ deregdrep c ,VDEL⦈
+         ⟦ dReps' , ccKeys ⟧ᵛ
 
   VDEL-ccreghot :
     c ≡ inj₁ kh'
     ────────────────────────────────
-    _ ⊢ ⟦ dreps , delegs , ccKeys ⟧ᵈ ⇀⦇ ccreghot c kh ,VDEL⦈
-        ⟦ dreps , delegs , singletonᵐ kh' kh ∪ᵐˡ ccKeys ⟧ᵈ
+    pp ⊢ ⟦ dReps , ccKeys ⟧ᵛ ⇀⦇ ccreghot c kh ,VDEL⦈
+         ⟦ dReps , singletonᵐ kh' kh ∪ᵐˡ ccKeys ⟧ᵛ
+
+data _⊢_⇀⦇_,CERT⦈_ : CertEnv → CertState → DCert → CertState → Set where
+  CERT-deleg :
+    pp ⊢ stᵈ ⇀⦇ dCert ,DELEG⦈ stᵈ'
+    ────────────────────────────────
+    pp ⊢ st ⇀⦇ dCert ,CERT⦈ record st { dState = stᵈ' }
+
+  CERT-vdel :
+    pp ⊢ stᵛ ⇀⦇ dCert ,VDEL⦈ stᵛ'
+    ────────────────────────────────
+    pp ⊢ st ⇀⦇ dCert ,CERT⦈ record st { vState = stᵛ' }
+
+  CERT-pool :
+    pp ⊢ stᵖ ⇀⦇ dCert ,POOL⦈ stᵖ'
+    ────────────────────────────────
+    pp ⊢ st ⇀⦇ dCert ,CERT⦈ record st { pState = stᵖ' }
+
+_⊢_⇀⦇_,CERTS⦈_ : CertEnv → CertState → List DCert → CertState → Set
+_⊢_⇀⦇_,CERTS⦈_ = SS⇒BS λ (Γ , _) → Γ ⊢_⇀⦇_,CERT⦈_
+
+--Computational-CERTS : Computational _⊢_⇀⦇_,CERTS⦈_
+--Computational-CERTS = MkComputational
+--  (λ Γ st cs → {!!})
+--  {!!}
 \end{code}
 \caption{VDel rules \& definitions}
 \end{figure*}

--- a/src/Ledger/GovernanceActions.lagda
+++ b/src/Ledger/GovernanceActions.lagda
@@ -11,7 +11,7 @@ import Ledger.PParams as PP
 
 open import Data.Rational using (ℚ)
 open import Data.Nat using (_≤_)
-open import Data.Nat.Properties using (+-0-commutativeMonoid)
+open import Data.Nat.Properties using (+-0-commutativeMonoid ; +-0-monoid)
 open import Data.These
 
 module Ledger.GovernanceActions (TxId Network DocHash : Set)
@@ -102,13 +102,8 @@ private variable
   wdrl : Credential ↛ Coin
   newTreasury : Coin
 
-addCoin : These Coin Coin → Coin
-addCoin (this x)    = x
-addCoin (that x)    = x
-addCoin (these x y) = x + y
-
-_∪⁺_ : ∀ {A} → ⦃ DecEq A ⦄ → A ↛ Coin → A ↛ Coin → A ↛ Coin
-_∪⁺_ = unionWith addCoin
+instance
+  _ = +-0-monoid
 
 data
 \end{code}

--- a/src/Ledger/Ledger.lagda
+++ b/src/Ledger/Ledger.lagda
@@ -32,11 +32,11 @@ record LEnv : Set where
         roles : KeyHash ↛ GovRole -- replaces genDelegs
 
 record LState : Set where
-  constructor ⟦_,_⟧ˡ
+  constructor ⟦_,_,_⟧ˡ
   field utxoSt : UTxOState
         tally  : TallyState
         --ppup   : PPUpdateState
-        --dpstate : DPState
+        certState : CertState
 \end{code}
 \caption{Types for the LEDGER transition system}
 \end{figure*}
@@ -46,6 +46,7 @@ private variable
   s s' s'' : LState
   utxoSt' : UTxOState
   tally' : TallyState
+  certState' : CertState
   tx : Tx
 
 data _⊢_⇀⦇_,LEDGER⦈_ : LEnv → LState → Tx → LState → Set where
@@ -53,11 +54,11 @@ data _⊢_⇀⦇_,LEDGER⦈_ : LEnv → LState → Tx → LState → Set where
 \begin{figure*}[h]
 \begin{code}
   LEDGER : let open LState s; txb = body tx; open LEnv Γ in
-    record { LEnv Γ } ⊢ utxoSt ⇀⦇ tx ,UTXOW⦈ utxoSt'
+    pparams ⊢ certState ⇀⦇ txcerts txb ,CERTS⦈ certState'
+    → record { LEnv Γ } ⊢ utxoSt ⇀⦇ tx ,UTXOW⦈ utxoSt'
     → record { epoch = epoch slot ; LEnv Γ ; TxBody txb } ⊢ tally ⇀⦇ txgov txb ,TALLY⦈ tally'
-    -- DELEGS
     ────────────────────────────────
-    Γ ⊢ s ⇀⦇ tx ,LEDGER⦈ ⟦ utxoSt' , tally' ⟧ˡ
+    Γ ⊢ s ⇀⦇ tx ,LEDGER⦈ ⟦ utxoSt' , tally' , certState' ⟧ˡ
 \end{code}
 \caption{LEDGER transition system}
 \end{figure*}

--- a/src/Ledger/Prelude.agda
+++ b/src/Ledger/Prelude.agda
@@ -81,6 +81,7 @@ module _ {A : Set} ⦃ _ : DecEq A ⦄ where
   open Corestrictionᵐ {A} ∈-sp public
   open Unionᵐ {A} ∈-sp public
   open Intersection {A} ∈-sp public
+  open Lookupᵐ {A} ∈-sp public
   open Lookupᵐᵈ {A} ∈-sp public
 
 module _ {A B : Set} ⦃ _ : DecEq A ⦄ ⦃ _ : DecEq B ⦄ where

--- a/src/Ledger/TokenAlgebra.lagda
+++ b/src/Ledger/TokenAlgebra.lagda
@@ -29,4 +29,7 @@ record TokenAlgebra : Set₁ where
         coinIsMonoidMorphism : coin Is Value-CommutativeMonoid -CommutativeMonoid⟶ +-0-commutativeMonoid
 
         instance DecEq-Value : DecEq Value
+
+  sumᵛ : List Value → Value
+  sumᵛ = foldr _+ᵛ_ (inject 0)
 \end{code}

--- a/src/Ledger/Transaction.lagda
+++ b/src/Ledger/Transaction.lagda
@@ -77,6 +77,7 @@ This function must produce a unique id for each unique transaction body.
   open Ledger.GovernanceActions TxId Network ADHash epochStructure ppUpd ppHashingScheme crypto hiding (yes; no) public
 
   open import Ledger.Address Network KeyHash ScriptHash public
+  open import Ledger.Deleg crypto Network epochStructure public
 \end{code}
 \emph{Derived types}
 \AgdaTarget{TxIn, TxOut, UTxO, Wdrl}
@@ -95,7 +96,7 @@ This function must produce a unique id for each unique transaction body.
   record TxBody : Set where
     field txins      : ℙ TxIn
           txouts     : Ix ↛ TxOut
-          --txcerts  : List DCert
+          txcerts    : List DCert
           mint       : Value
           txfee      : Coin
           txvldt     : Maybe Slot × Maybe Slot

--- a/src/Ledger/Utxo.lagda
+++ b/src/Ledger/Utxo.lagda
@@ -17,7 +17,7 @@ open import Algebra using (CommutativeMonoid)
 open import Algebra.Structures
 open import Data.List as List
 open import Data.Nat using (_≤?_; _≤_)
-open import Data.Nat.Properties using (+-0-monoid)
+open import Data.Nat.Properties using (+-0-monoid ; +-0-commutativeMonoid)
 open import Interface.Decidable.Instance
 
 open TransactionStructure txs
@@ -38,6 +38,7 @@ instance
   _ = Decidable²⇒Dec _≤?_
   _ = TokenAlgebra.Value-CommutativeMonoid tokenAlgebra
   _ = +-0-monoid
+  _ = +-0-commutativeMonoid
 
 -- utxoEntrySizeWithoutVal = 27 words (8 bytes)
 utxoEntrySizeWithoutVal : MemoryEstimate
@@ -206,8 +207,11 @@ instance
   ... | yes p = yes (upper p)
   Dec-inInterval {slot} {nothing , nothing} = yes none
 
+  HasCoin-Deposits : HasCoin (Credential ↛ Coin)
+  HasCoin-Deposits .getCoin s = Σᵐᵛ[ x ← s ᶠᵐ ] x
+
   HasCoin-UTxOState : HasCoin UTxOState
-  HasCoin-UTxOState .getCoin s = getCoin (UTxOState.utxo s) + (UTxOState.fees s)
+  HasCoin-UTxOState .getCoin s = getCoin (UTxOState.utxo s) + (UTxOState.fees s) + getCoin (UTxOState.deposits s)
 data
 \end{code}
 \begin{code}
@@ -261,7 +265,7 @@ data _⊢_⇀⦇_,UTXO⦈_ where
 \begin{code}[hide]
 -- TODO: This can't be moved into Properties because it breaks. Move
 -- this once this is fixed.
---unquoteDecl Computational-UTXO = deriveComputational (quote _⊢_⇀⦇_,UTXO⦈_) Computational-UTXO
+unquoteDecl Computational-UTXO = deriveComputational (quote _⊢_⇀⦇_,UTXO⦈_) Computational-UTXO
 \end{code}
 \caption{UTXO inference rules}
 \label{fig:rules:utxo-shelley}

--- a/src/Ledger/Utxo/Properties.lagda
+++ b/src/Ledger/Utxo/Properties.lagda
@@ -12,7 +12,7 @@ open import Prelude
 open import Ledger.Prelude
 
 open import Algebra.Morphism
-open import Data.Nat.Properties using (+-0-commutativeMonoid; +-0-monoid; +-comm; +-identityʳ)
+open import Data.Nat.Properties using (+-0-commutativeMonoid; +-0-monoid; +-comm; +-identityʳ; +-assoc)
 open import Interface.ComputationalRelation
 open import Relation.Binary
 open import Tactic.Cong
@@ -43,6 +43,7 @@ private variable
   utxo utxo' utxo1 utxo2 : UTxO
   fee fee' fees fees' : Coin
   utxoState utxoState' utxoState1 utxoState2 : UTxOState
+  deposits deposits' : Credential ↛ Coin
   Γ : UTxOEnv
   s s' : UTxOState
 
@@ -70,11 +71,22 @@ newTxid⇒disj : txid tx ∉ map proj₁ (dom (utxo ˢ)) → disjoint' (dom (utx
 newTxid⇒disj id∉utxo = disjoint⇒disjoint' λ h h' → id∉utxo $ to ∈-map
   (-, (case from ∈-map h' of λ where (_ , refl , h'') → case from ∈-map h'' of λ where (_ , refl , _) → refl) , h)
 
-consumedCoinEquality :  ∀ {pp} → coin (mint tx) ≡ 0 → coin (consumed pp utxo tx) ≡ cbalance (utxo ∣ txins tx)
-consumedCoinEquality {tx} {utxo} h = begin
-  coin (balance (utxo ∣ txins tx) +ᵛ mint tx) ≡⟨ ∙-homo-Coin coinIsMonoidMorphism _ _ ⟩
-  cbalance (utxo ∣ txins tx) + coin (mint tx) ≡tʳ⟨ cong (cbalance (utxo ∣ txins tx) +_) h ⟩
-  cbalance (utxo ∣ txins tx) ∎
+consumedCoinEquality :  ∀ {pp} → coin (mint tx) ≡ 0 → coin (consumed pp utxoState utxo tx) ≡ cbalance (utxo ∣ txins tx) + coin (refunded utxoState tx)
+consumedCoinEquality {tx} {utxoState} {utxo} h = begin
+  coin (balance (utxo ∣ txins tx) +ᵛ mint tx +ᵛ refunded utxoState tx)             ≡⟨ ∙-homo-Coin coinIsMonoidMorphism _ _ ⟩
+  coin (balance (utxo ∣ txins tx) +ᵛ mint tx) + coin (refunded utxoState tx)       ≡⟨ cong
+                                                                                       (_+ coin (refunded utxoState tx))
+                                                                                       (∙-homo-Coin coinIsMonoidMorphism _ _)
+                                                                                   ⟩
+  coin (balance (utxo ∣ txins tx)) + coin (mint tx) + coin (refunded utxoState tx) ≡⟨ cong
+                                                                                       (_+ coin (refunded utxoState tx))
+                                                                                       (cong (cbalance (utxo ∣ txins tx) +_) h)
+                                                                                   ⟩
+  cbalance (utxo ∣ txins tx) + 0 + coin (refunded utxoState tx)                    ≡⟨ cong
+                                                                                       (_+ coin (refunded utxoState tx))
+                                                                                       (+-identityʳ (cbalance (utxo ∣ txins tx)))
+                                                                                   ⟩
+  cbalance (utxo ∣ txins tx) + coin (refunded utxoState tx)                        ∎
 
 producedCoinEquality : ∀ {pp} → coin (produced pp utxo tx) ≡ cbalance (outs tx) + (txfee tx) + coin (totalDeposits tx)
 producedCoinEquality {utxo} {tx} = begin
@@ -86,15 +98,15 @@ producedCoinEquality {utxo} {tx} = begin
                                                                                 ⟩
   cbalance (outs tx) + (txfee tx) + coin (totalDeposits tx)                     ∎
 
-balCoinValueToCbalance : ∀ {pp} → coin (mint tx) ≡ 0 → (coin (consumed pp utxo tx) ≡ coin (produced pp utxo tx))
-                                                       ≡ (cbalance (utxo ∣ txins tx) ≡ cbalance (outs tx) + (txfee tx) + coin (totalDeposits tx))
-balCoinValueToCbalance {tx} {utxo} {pp} h rewrite (consumedCoinEquality {tx} {utxo} {pp} h)
+balCoinValueToCbalance : ∀ {pp} → coin (mint tx) ≡ 0 → (coin (consumed pp utxoState utxo tx) ≡ coin (produced pp utxo tx))
+                                                       ≡ (cbalance (utxo ∣ txins tx) + coin (refunded utxoState tx) ≡ cbalance (outs tx) + (txfee tx) + coin (totalDeposits tx))
+balCoinValueToCbalance {tx} {utxoState} {utxo} {pp} h rewrite (consumedCoinEquality {tx} {utxoState} {utxo} {pp} h)
                                                   | producedCoinEquality {utxo} {tx} {pp} = refl
 
-balValueToCoin : ∀ {pp} → coin (mint tx) ≡ 0 → consumed pp utxo tx ≡ produced pp utxo tx
-                                             → cbalance (utxo ∣ txins tx) ≡ cbalance (outs tx) + (txfee tx) + coin (totalDeposits tx)
-balValueToCoin {utxo} {tx} {pp} h h' with cong coin h'
-... | ans rewrite balCoinValueToCbalance {utxo} {tx} {pp} h = ans
+balValueToCoin : ∀ {pp} → coin (mint tx) ≡ 0 → consumed pp utxoState utxo tx ≡ produced pp utxo tx
+                                             → cbalance (utxo ∣ txins tx) + coin (refunded utxoState tx) ≡ cbalance (outs tx) + (txfee tx) + coin (totalDeposits tx)
+balValueToCoin {utxoState} {utxo} {tx} {pp} h h' with cong coin h'
+... | ans rewrite balCoinValueToCbalance {utxoState} {utxo} {tx} {pp} h = ans
 
 \end{code}
 
@@ -126,20 +138,53 @@ and
   →
 \end{code}
 \begin{code}[inline*]
-      Γ ⊢ ⟦ utxo , fee ⟧ᵘ ⇀⦇ tx ,UTXO⦈ ⟦ utxo' , fee' ⟧ᵘ
+      Γ ⊢ ⟦ utxo , fee , deposits ⟧ᵘ ⇀⦇ tx ,UTXO⦈ ⟦ utxo' , fee' , deposits' ⟧ᵘ
 \end{code}
 then
 \begin{code}[hide]
   →
 \end{code}
 \begin{code}
-      getCoin ⟦ utxo , fee ⟧ᵘ ≡ getCoin ⟦ utxo' , fee' ⟧ᵘ
+      getCoin ⟦ utxo , fee , deposits ⟧ᵘ ≡ getCoin ⟦ utxo' , fee' , deposits' ⟧ᵘ
 \end{code}
 \begin{code}[hide]
-pov {tx} {utxo} {_} {fee} h' (UTXO-inductive {Γ} _ _ _ _ newBal noMintAda _) =
+pov {tx} {utxo} {_} {fee} {deposits} {utxo'} {fee'} {deposits'} h' (UTXO-inductive {Γ} _ _ _ _ newBal noMintAda _) =
   let h : disjoint (dom ((utxo ∣ txins tx ᶜ) ˢ)) (dom (outs tx ˢ))
       h = λ h₁ h₂ → ∉-∅ $ proj₁ (newTxid⇒disj {tx = tx} {utxo} h') $ to ∈-∩ (cores-domᵐ h₁ , h₂)
+      utxoState = ⟦ utxo , fee , deposits ⟧ᵘ
+      utxoState' = ⟦ utxo' , fee' , deposits' ⟧ᵘ
   in begin
+    cbalance utxo + fee + getCoin deposits ≡⟨ cong (_+ getCoin deposits) {!!} ⟩
+    cbalance ((utxo ∣ txins tx ᶜ) ∪ᵐˡ (utxo ∣ txins tx)) + getCoin deposits ≡⟨ {!!} ⟩
+    cbalance utxo + getCoin deposits + fee ≡⟨
+      cong
+        (_+ fee)
+        (begin
+          cbalance utxo + getCoin deposits
+            ≡˘⟨ cong (_+ getCoin deposits) (balance-cong-coin {utxo = (utxo ∣ txins tx ᶜ) ∪ᵐˡ (utxo ∣ txins tx)} {utxo' = utxo}
+                  let open IsEquivalence ≡ᵉ-isEquivalence renaming (trans to _≡ᵉ-∘_)
+                  in (disjoint-∪ᵐˡ-∪ (disjoint-sym res-ex-disjoint) ≡ᵉ-∘ ∪-sym) ≡ᵉ-∘ res-ex-∪ (_∈? txins tx)) ⟩
+          cbalance ((utxo ∣ txins tx ᶜ) ∪ᵐˡ (utxo ∣ txins tx)) + getCoin deposits
+            ≡⟨ cong (_+ getCoin deposits) (balance-∪ {utxo ∣ txins tx ᶜ} {utxo ∣ txins tx} (flip res-ex-disjoint)) ⟩
+          cbalance (utxo ∣ txins tx ᶜ) + cbalance (utxo ∣ txins tx) + getCoin deposits
+            ≡⟨ +-assoc (cbalance (utxo ∣ txins tx ᶜ)) (cbalance (utxo ∣ txins tx)) (getCoin deposits) ⟩
+          cbalance (utxo ∣ txins tx ᶜ) + (cbalance (utxo ∣ txins tx) + getCoin deposits)
+            ≡⟨ cong (cbalance (utxo ∣ txins tx ᶜ) +_) {!!} ⟩
+          cbalance (utxo ∣ txins tx ᶜ) + (cbalance (outs tx) + txfee tx + getCoin deposits) ≡⟨ {!!} ⟩
+          cbalance (utxo ∣ txins tx ᶜ) + cbalance (outs tx) + txfee tx + getCoin deposits
+            ≡⟨ cong
+                 (_+ getCoin deposits)
+                 (begin 
+                    cbalance (utxo ∣ txins tx ᶜ) + cbalance (outs tx) + txfee tx
+                        ≡˘⟨ cong! (balance-∪ {utxo ∣ txins tx ᶜ} {outs tx} h) ⟩
+                    cbalance ((utxo ∣ txins tx ᶜ) ∪ᵐˡ outs tx) + txfee tx ∎)
+             ⟩
+          (cbalance ((utxo ∣ txins tx ᶜ) ∪ᵐˡ outs tx) + txfee tx) + getCoin deposits ∎
+        )
+    ⟩
+    (cbalance ((utxo ∣ txins tx ᶜ) ∪ᵐˡ outs tx) + txfee tx) + getCoin deposits + fee ≡⟨ {!!} ⟩
+    cbalance ((utxo ∣ txins tx ᶜ) ∪ᵐˡ outs tx) + (fee + txfee tx) + getCoin deposits' ∎
+{- begin
   cbalance utxo + fee
     ≡tʳ⟨ cong (_+ fee) $ begin
       cbalance utxo
@@ -149,15 +194,15 @@ pov {tx} {utxo} {_} {fee} h' (UTXO-inductive {Γ} _ _ _ _ newBal noMintAda _) =
       cbalance ((utxo ∣ txins tx ᶜ) ∪ᵐˡ (utxo ∣ txins tx))
         ≡⟨ balance-∪ {utxo ∣ txins tx ᶜ} {utxo ∣ txins tx} (flip (res-ex-disjoint)) ⟩
       {!!}
-      --cbalance (utxo ∣ txins tx ᶜ) + cbalance (utxo ∣ txins tx)
-      --  ≡tʳ⟨ cong (cbalance (utxo ∣ txins tx ᶜ) +_) (balValueToCoin {tx} {utxo} {UTxOEnv.pparams Γ} noMintAda newBal) ⟩
-      --cbalance (utxo ∣ txins tx ᶜ) + cbalance (outs tx) + txfee tx
-      --  ≡˘⟨ cong! (balance-∪ {utxo ∣ txins tx ᶜ} {outs tx} h) ⟩
-      --cbalance ((utxo ∣ txins tx ᶜ) ∪ᵐˡ outs tx) + txfee tx ∎
+      cbalance (utxo ∣ txins tx ᶜ) + cbalance (utxo ∣ txins tx)
+        ≡tʳ⟨ cong (cbalance (utxo ∣ txins tx ᶜ) +_) (balValueToCoin {tx} {utxo} {UTxOEnv.pparams Γ} noMintAda newBal) ⟩
+      cbalance (utxo ∣ txins tx ᶜ) + cbalance (outs tx) + txfee tx
+        ≡˘⟨ cong! (balance-∪ {utxo ∣ txins tx ᶜ} {outs tx} h) ⟩
+      cbalance ((utxo ∣ txins tx ᶜ) ∪ᵐˡ outs tx) + txfee tx ∎
     ⟩
   cbalance ((utxo ∣ txins tx ᶜ) ∪ᵐˡ outs tx) + (txfee tx + fee)
     ≡˘⟨ cong (cbalance ((utxo ∣ txins tx ᶜ) ∪ᵐˡ outs tx) +_) (+-comm fee (txfee tx)) ⟩
-  cbalance ((utxo ∣ txins tx ᶜ) ∪ᵐˡ outs tx) + (fee + txfee tx) ∎
+  cbalance ((utxo ∣ txins tx ᶜ) ∪ᵐˡ outs tx) + (fee + txfee tx) ∎ -}
 
 \end{code}
 


### PR DESCRIPTION
This PR adds certificates for delegation and DRep / staking pool (de)registration. The DELPL rule is renamed to CERT and a new VDEL rule was added to handle DRep certificates.

The deposits are being kept track of in the `deposits` map of `UTxOState`.

Also added a `unionWith` for monoids.

The computational and PoV proofs are incomplete and will have to be finished in a future PR.