### PR TITLE
Nix cleanup & improvements

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - uses: cachix/install-nix-action@v15
+      - uses: cachix/install-nix-action@v20
         with:
           nix_path: nixpkgs=channel:nixos-unstable
           extra_nix_config: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Build agda
         id: agda
         run: |
-          v=$(nix-build -A agda)
+          v=$(nix-build -A agdaWithStdLibMeta)
           closure=$(nix-store --query --requisites --include-outputs $v | tr '\n' ' ')
           echo "derivation=$v" >> $GITHUB_OUTPUT
           echo "closure=$closure" >> $GITHUB_OUTPUT

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,8 +29,12 @@ jobs:
       - name: Import cached nix store
         continue-on-error: true
         run: |
-          du -sh store || true
-          nix-store --import < store
+          if [[ -f store ]]; then
+            du -sh store || true
+            nix-store --import < store
+          else
+            echo "No cached store found"
+          fi
 
        # We have to build this explicitly, in order to cache it,
        # since it's not part of the static binary formalLedger closure

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,7 +33,7 @@ jobs:
           nix-store --import < store
 
        # We have to build this explicitly, in order to cache it,
-       # since it's not part of the static binary agdaLedger closure
+       # since it's not part of the static binary formalLedger closure
       - name: Build agda
         id: agda
         run: |
@@ -42,10 +42,10 @@ jobs:
           echo "derivation=$v" >> $GITHUB_OUTPUT
           echo "closure=$closure" >> $GITHUB_OUTPUT
 
-      - name: Build agdaLedger
-        id: agdaLedger
+      - name: Build formalLedger
+        id: formalLedger
         run: |
-          v=$(nix-build -A agdaLedger)
+          v=$(nix-build -A formalLedger)
           closure=$(nix-store --query --requisites --include-outputs $v | tr '\n' ' ')
           echo "derivation=$v" >> $GITHUB_OUTPUT
           echo "closure=$closure" >> $GITHUB_OUTPUT
@@ -69,8 +69,8 @@ jobs:
       - name: Export all derivations
         id: export-derivations
         run: |
-          hashes="${{steps.agda.outputs.derivation}}-${{steps.agdaLedger.outputs.derivation}}-${{steps.ledger.outputs.derivation}}-${{steps.midnight.outputs.derivation}}"
-          closures="${{steps.agda.outputs.closure}} ${{steps.agdaLedger.outputs.closure}} ${{ steps.ledger.outputs.closure}} ${{steps.midnight.outputs.closure}}"
+          hashes="${{steps.agda.outputs.derivation}}-${{steps.formalLedger.outputs.derivation}}-${{steps.ledger.outputs.derivation}}-${{steps.midnight.outputs.derivation}}"
+          closures="${{steps.agda.outputs.closure}} ${{steps.formalLedger.outputs.closure}} ${{ steps.ledger.outputs.closure}} ${{steps.midnight.outputs.closure}}"
           touch derivations
           updated=false
           # export only if the hashes changed or the store does not exist for some reason

--- a/default.nix
+++ b/default.nix
@@ -98,12 +98,12 @@ rec {
         ];
         buildPhase = ''
           find ${dir} -name \*.lagda -exec agda --latex {} \;
-          cd latex && latexmk -xelatex ${dir}/${doc}.tex && cd ..
+          cd latex && latexmk -xelatex ${dir}/PDF.tex && cd ..
         '';
         installPhase = ''
           mkdir -p $out
-          agda --html --html-dir $out/html ${dir}/${doc}.lagda
-          cp latex/${doc}.pdf $out
+          agda --html --html-dir $out/html ${dir}/PDF.lagda
+          cp latex/PDF.pdf $out/${doc}.pdf
         '';
       };
     in
@@ -117,12 +117,12 @@ rec {
     dir = "Ledger";
     agdaLedgerFile = "Foreign/HSLedger.agda";
     hsMainFile = "HSLedgerTest.hs";
-    doc = "PDF";
+    doc = "cardano-ledger";
   };
   midnight = specsDerivations {
     dir = "MidnightExample";
     agdaLedgerFile = "HSLedger.agda";
     hsMainFile = "Main.hs";
-    doc = "PDF";
+    doc = "midnight-example";
   };
 }

--- a/default.nix
+++ b/default.nix
@@ -41,12 +41,10 @@ let
 in
 rec {
 
-  agda  = agdaWithPkgs deps;
-  agda2 = agdaWithPkgs [ agdaStdlib ];           # for working on stdlib-meta
-  agda3 = agdaWithPkgs (deps ++ [ agdaLedger ]); # for using ledger as a library
+  agda = agdaWithPkgs (deps ++ [ formalLedger ]);
 
-  agdaLedger = customAgda.agdaPackages.mkDerivation {
-    pname = "Agda-ledger";
+  formalLedger = customAgda.agdaPackages.mkDerivation {
+    pname = "formal-ledger";
     version = "0.1";
     src = ./src;
     meta = { };
@@ -63,9 +61,9 @@ rec {
     let
       hsSrc =
         stdenv.mkDerivation {
-          pname = "Agda-ledger-${dir}-hs-src";
+          pname = "formal-ledger-${dir}-hs-src";
           version = "0.1";
-          src = "${agdaLedger}";
+          src = "${formalLedger}";
           meta = { };
           buildInputs = [ (agdaWithPkgs deps) ];
           buildPhase = "";
@@ -81,7 +79,7 @@ rec {
       docs = stdenv.mkDerivation {
         pname = "${dir}-docs";
         version = "0.1";
-        src = "${agdaLedger}";
+        src = "${formalLedger}";
         meta = { };
         buildInputs = [
           (agdaWithPkgs deps)

--- a/default.nix
+++ b/default.nix
@@ -41,6 +41,7 @@ let
 in
 rec {
 
+  agdaWithStdLibMeta = agdaWithPkgs deps;
   agda = agdaWithPkgs (deps ++ [ formalLedger ]);
 
   formalLedger = customAgda.agdaPackages.mkDerivation {
@@ -65,7 +66,7 @@ rec {
           version = "0.1";
           src = "${formalLedger}";
           meta = { };
-          buildInputs = [ (agdaWithPkgs deps) ];
+          buildInputs = [ agdaWithStdLibMeta ];
           buildPhase = "";
           installPhase = ''
             mkdir -p $out
@@ -82,7 +83,7 @@ rec {
         src = "${formalLedger}";
         meta = { };
         buildInputs = [
-          (agdaWithPkgs deps)
+           agdaWithStdLibMeta
           (texlive.combine {
             inherit (texlive)
               scheme-small

--- a/src/formal-ledger.agda-lib
+++ b/src/formal-ledger.agda-lib
@@ -1,4 +1,4 @@
-name: Agda-ledger
+name: formal-ledger
 depend:
   standard-library
   stdlib-meta


### PR DESCRIPTION
This improves consistency of package names, provides a single `Agda` package that should work for all purposes we had separate packages for previously and renames the generated PDFs. The produced files were called `PDF.pdf`, this renames them to `cardano-ledger.pdf` and `midnight-example.pdf` respectively.