### PR TITLE
Cache nix store in github actions caches

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,13 +4,94 @@ on: [push]
 jobs:
   build:
     runs-on: ubuntu-latest
+
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
+
       - uses: cachix/install-nix-action@v15
         with:
           nix_path: nixpkgs=channel:nixos-unstable
           extra_nix_config: |
             trusted-public-keys = hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ= cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
             substituters = https://cache.nixos.org/
-      - name: Build all derivations 
-        run: nix-build -A ledger -A midnight -j1
+
+      - name: Restore store
+        id: cache-store-restore
+        uses: actions/cache/restore@v3
+        with:
+          path: |
+              store
+              derivations
+          key: cache-store-${{ runner.os }}-${{github.run_id}}
+          restore-keys: |
+            cache-store-${{ runner.os }}
+
+      - name: Import cached nix store
+        continue-on-error: true
+        run: |
+          du -sh store || true
+          nix-store --import < store
+
+       # We have to build this explicitly, in order to cache it,
+       # since it's not part of the static binary agdaLedger closure
+      - name: Build agda
+        id: agda
+        run: |
+          v=$(nix-build -A agda)
+          closure=$(nix-store --query --requisites --include-outputs $v | tr '\n' ' ')
+          echo "derivation=$v" >> $GITHUB_OUTPUT
+          echo "closure=$closure" >> $GITHUB_OUTPUT
+
+      - name: Build agdaLedger
+        id: agdaLedger
+        run: |
+          v=$(nix-build -A agdaLedger)
+          closure=$(nix-store --query --requisites --include-outputs $v | tr '\n' ' ')
+          echo "derivation=$v" >> $GITHUB_OUTPUT
+          echo "closure=$closure" >> $GITHUB_OUTPUT
+
+      - name: Build ledger
+        id: ledger
+        run: |
+          v=$(nix-build -A ledger -j1 | tr '\n' ' ')
+          closure=$(nix-store --query --requisites --include-outputs $v | tr '\n' ' ')
+          echo "derivation=$v" >> $GITHUB_OUTPUT
+          echo "closure=$closure" >> $GITHUB_OUTPUT
+
+      - name: Build midnight
+        id: midnight
+        run: |
+          v=$(nix-build -A midnight -j1 | tr '\n' ' ')
+          closure=$(nix-store --query --requisites --include-outputs $v | tr '\n' ' ')
+          echo "derivation=$v" >> $GITHUB_OUTPUT
+          echo "closure=$closure" >> $GITHUB_OUTPUT
+
+      - name: Export all derivations
+        id: export-derivations
+        run: |
+          hashes="${{steps.agda.outputs.derivation}}-${{steps.agdaLedger.outputs.derivation}}-${{steps.ledger.outputs.derivation}}-${{steps.midnight.outputs.derivation}}"
+          closures="${{steps.agda.outputs.closure}} ${{steps.agdaLedger.outputs.closure}} ${{ steps.ledger.outputs.closure}} ${{steps.midnight.outputs.closure}}"
+          touch derivations
+          updated=false
+          # export only if the hashes changed or the store does not exist for some reason
+          if grep -qe "^$hashes" derivations && [[ -f store ]]
+              then
+                echo "No need to re-export the store"
+              else
+                nix-store --export $closures > store
+                echo "Exported store of size: $(du -sh store)"
+                echo "$hashes" > derivations
+                echo "Wrote new derivations hashes: $(cat derivations)"
+                updated=true
+          fi
+          echo "updated=$updated" >> $GITHUB_OUTPUT
+
+      - name: Upload nix store
+        id: cache-derivations-save
+        uses: actions/cache/save@v3
+        if: steps.export-derivations.outputs.updated == 'true'
+        with:
+          path: |
+            store
+            derivations
+          key: cache-store-${{ runner.os }}-${{github.run_id}}


### PR DESCRIPTION
to reduce the number of unnecessary rebuilds. 

Implementation notes:
The Github action build job is updated to :

- store in a cache:
             * the result of nix-store --export  and
              * a string formed of the names of the derivations that are being built
- import the cached store every time
- export the store only if the string containing the hashes changed

I added this extra thing with the hashes because exporting the store every time was taking a lot of time for the cases in which it didn't need to be re-exported.
The size of the exported cache is about 8GB but in the github UI it shows like 1.1GB, I guess because of the compression.
Because the cache can't be updated, I keep creating new ones when necessary (i.e. when the derivations changed). Apparently Github clears the old ones as you reach the 10GB quota, so I expect this to work fine for this case.

Something that is a bit annoying (though likely necessary) is that the cache is scoped by branch, so if say you open a PR then you won't have any caching, only subsequent pushes will. I think there is some relationship with the caching on the main branch (have to look more into it), so if the branches can use the cache from the main branch that would be useful - but only if the latter was used in the past 7 days, otherwise github will have deleted it.