### PR TITLE
Publish specs on github pages

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,9 @@
 name: Formal Ledger Specs
 on: [push]
 
+permissions:
+  contents: write
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -123,3 +126,18 @@ jobs:
               </html>
               EOF
 
+      - name: Add files
+        run: |
+            git config --local user.name ${{ github.actor }}
+            git add index.html
+            git add pdfs
+            git commit -m "Updated"
+
+
+      - name: Push to gh-pages
+        uses: ad-m/github-push-action@v0.6.0
+        with:
+            github_token: ${{ secrets.GITHUB_TOKEN }}
+            branch: gh-pages
+            force: true
+            directory: .

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -101,6 +101,7 @@ jobs:
           key: cache-store-${{ runner.os }}-${{github.run_id}}
 
       - name: Prepare pdf files to be deployed to site
+        if: github.ref == 'refs/heads/master'
         run: |
           mkdir -p pdfs
           for f in $(find -L outputs -name '*.pdf'); do
@@ -108,6 +109,7 @@ jobs:
           done
 
       - name: Build static file
+        if: github.ref == 'refs/heads/master'
         run: |
               touch index.html
               cat > index.html << EOF
@@ -127,6 +129,8 @@ jobs:
               EOF
 
       - name: Add files
+        if: github.ref == 'refs/heads/master'
+
         run: |
             git config --local user.name ${{ github.actor }}
             git add index.html
@@ -135,6 +139,7 @@ jobs:
 
 
       - name: Push to gh-pages
+        if: github.ref == 'refs/heads/master'
         uses: ad-m/github-push-action@v0.6.0
         with:
             github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,7 +53,8 @@ jobs:
       - name: Build ledger
         id: ledger
         run: |
-          v=$(nix-build -A ledger -j1 | tr '\n' ' ')
+          mkdir -p outputs
+          v=$(nix-build -A ledger -j1 -o outputs/ledger| tr '\n' ' ')
           closure=$(nix-store --query --requisites --include-outputs $v | tr '\n' ' ')
           echo "derivation=$v" >> $GITHUB_OUTPUT
           echo "closure=$closure" >> $GITHUB_OUTPUT
@@ -61,7 +62,7 @@ jobs:
       - name: Build midnight
         id: midnight
         run: |
-          v=$(nix-build -A midnight -j1 | tr '\n' ' ')
+          v=$(nix-build -A midnight -j1 -o outputs/midnight | tr '\n' ' ')
           closure=$(nix-store --query --requisites --include-outputs $v | tr '\n' ' ')
           echo "derivation=$v" >> $GITHUB_OUTPUT
           echo "closure=$closure" >> $GITHUB_OUTPUT

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -96,3 +96,30 @@ jobs:
             store
             derivations
           key: cache-store-${{ runner.os }}-${{github.run_id}}
+
+      - name: Prepare pdf files to be deployed to site
+        run: |
+          mkdir -p pdfs
+          for f in $(find -L outputs -name '*.pdf'); do
+            cp -L --force $f pdfs
+          done
+
+      - name: Build static file
+        run: |
+              touch index.html
+              cat > index.html << EOF
+              <!DOCTYPE html>
+              <html>
+              <body>
+                  <h3>Formal ledger specs</h3>
+                  <ul>
+              EOF
+              for f in pdfs/*.pdf; do
+                echo "<li><a href="$f">$(basename $f)</a></li>" >> index.html
+              done
+              cat >> index.html << EOF
+              </ul>
+              </body>
+              </html>
+              EOF
+


### PR DESCRIPTION
This PR will create a static html file listing the pdf files generated in the build.

A current limitation is that the pdfs need to have unique names, otherwise only one of them is kept. 
At the moment,  in master, this is what is happening, because both ledger and midnight pdfs are called PDF.pdf , however [this PR ](https://github.com/input-output-hk/formal-ledger-specifications/pull/80) addresses this, so, after it is merged,  the page will show to different pdfs called "cardano-ledger.pdf" and "midnight-example.pdf". 

An example of how this page looks like: https://bienpulenta.github.io/formal-ledger-specifications

In order for the github page to be created, we need to change the Settings in this repo, and set the deploy-source to branch "gh-pages", like in this example screenshot: 

![2023-04-03_14-26](https://user-images.githubusercontent.com/2070003/229523470-efa564a2-6d09-4144-80c0-122cf41e48a0.png)

