### PR TITLE
Added autovoters

### DIFF
--- a/src/Ledger/GovernanceActions.lagda
+++ b/src/Ledger/GovernanceActions.lagda
@@ -43,6 +43,11 @@ data GovRole : Set where
   DRep  : GovRole
   SPO   : GovRole
 
+data VDeleg : Set where
+  credVoter        : GovRole → Credential → VDeleg
+  abstainRep       : VDeleg
+  noConfidenceRep  : VDeleg
+
 record Anchor : Set where
   field  url   : String
          hash  : DocHash
@@ -80,6 +85,7 @@ instance
   _ = +-0-commutativeMonoid
   unquoteDecl DecEq-GovRole = derive-DecEq ((quote GovRole , DecEq-GovRole) ∷ [])
   unquoteDecl DecEq-Vote    = derive-DecEq ((quote Vote    , DecEq-Vote)    ∷ [])
+  unquoteDecl DecEq-VDeleg  = derive-DecEq ((quote VDeleg  , DecEq-VDeleg)  ∷ [])
 \end{code}
 \caption{Governance actions and votes}
 \label{defs:governance}

--- a/src/Ledger/Prelude.agda
+++ b/src/Ledger/Prelude.agda
@@ -26,8 +26,12 @@ open Computational public
 -- TODO: move this into Interface.DecEq
 open import Data.Rational
 import Data.Rational.Properties as ℚ
+import Data.Bool.Properties as 𝔹
 
 instance
+  DecEq-Bool : DecEq Bool
+  DecEq-Bool = record { _≟_ = 𝔹._≟_ }
+
   DecEq-ℚ : DecEq ℚ
   DecEq-ℚ = record { _≟_ = ℚ._≟_ }
 

--- a/src/Ledger/Transaction.lagda
+++ b/src/Ledger/Transaction.lagda
@@ -76,7 +76,7 @@ This function must produce a unique id for each unique transaction body.
   open Ledger.GovernanceActions TxId Network ADHash epochStructure ppUpd ppHashingScheme crypto hiding (yes; no) public
 
   open import Ledger.Address Network KeyHash ScriptHash public
-  open import Ledger.Deleg crypto Network epochStructure public
+  open import Ledger.Deleg crypto TxId Network ADHash epochStructure ppUpd ppHashingScheme public
 \end{code}
 \emph{Derived types}
 \AgdaTarget{TxIn, TxOut, UTxO, Wdrl}


### PR DESCRIPTION
This PR adds the `Voter` datatype. A voter can be either a credential voter that votes using a credential (such as DReps), an abstainer that always abstains, or a no confidence voter that always votes no to everything except the NoConfidence action. The autovoter votes are added as soon as a new action is proposed and these autovoters can be delegated to just like you would delegate to DReps.

resolves #91 