### PR TITLE
Make deposit contribute towards DRep votes

### DIFF
--- a/src/Axiom/Set.agda
+++ b/src/Axiom/Set.agda
@@ -134,6 +134,9 @@ record Theory {ℓ} : Type (sucˡ ℓ) where
   ∈-map : ∀ {f : A → B} {b} → (∃[ a ] b ≡ f a × a ∈ X) ⇔ b ∈ map f X
   ∈-map = proj₂ $ replacement _ _
 
+  ∈-map′ : ∀ {f : A → B} {a} → a ∈ X → f a ∈ map f X
+  ∈-map′ {a = a} a∈X = to ∈-map (a , refl , a∈X)
+
   -- don't know that there's a set containing all members of a type, which this is equivalent to
   -- _⁻¹_ : (A → B) → Set B → Set A
   -- f ⁻¹ X = {!!}
@@ -202,6 +205,11 @@ record Theory {ℓ} : Type (sucˡ ℓ) where
     (∃[ T ] T ∈ map (partialToSet f) X × y ∈ T)             ∼⟨ ∈-unions ⟩
     y ∈ mapPartial f X ∎
     where open R.EquationalReasoning
+
+  ⊆-mapPartial : ∀ {f : A → Maybe B} → map just (mapPartial f X) ⊆ map f X
+  ⊆-mapPartial {f = f} a∈m with from ∈-map a∈m
+  ... | x , refl , a∈mp with from (∈-mapPartial {f = f}) a∈mp
+  ... | x' , x'∈X , jx≡fx = to ∈-map (x' , sym jx≡fx , x'∈X)
 
   binary-unions : ∃[ Y ] ∀ {a} → (a ∈ X ⊎ a ∈ X') ⇔ a ∈ Y
   binary-unions {X = X} {X'} with unions (fromList (X ∷ [ X' ]))

--- a/src/Axiom/Set/Map/Dec.agda
+++ b/src/Axiom/Set/Map/Dec.agda
@@ -24,6 +24,7 @@ private variable A B C D : Type
 
 module Lookupᵐᵈ (sp-∈ : spec-∈ A) where
   open Lookupᵐ sp-∈
+  infixr 6 _∪⁺_
 
   unionThese : ⦃ DecEq A ⦄ → (m : Map A B) → (m' : Map A C) → (x : A) → x ∈ dom (m ˢ) ∪ dom (m' ˢ) → These B C
   unionThese m m' x dp with x ∈? dom (m ˢ) | x ∈? dom (m' ˢ)

--- a/src/Ledger/Deleg.lagda
+++ b/src/Ledger/Deleg.lagda
@@ -31,7 +31,6 @@ open EpochStructure epochStructure
 \begin{code}
 record PoolParams : Set where
   field rewardAddr  : Credential
-        deposit     : Coin
 
 data DCert : Set where
   delegate   : Credential → Maybe VDeleg → Maybe Credential → Coin → DCert
@@ -117,8 +116,7 @@ data _⊢_⇀⦇_,DELEG⦈_ : DelegEnv → DState → DCert → DState → Set w
 
 data _⊢_⇀⦇_,POOL⦈_ : PoolEnv → PState → DCert → PState → Set where
   POOL-regpool : let open PParams pp ; open PoolParams poolParams in
-    deposit ≡ poolDeposit
-    → c ∉ dom (pools ˢ)
+    c ∉ dom (pools ˢ)
     ────────────────────────────────
     pp ⊢ ⟦ pools , retiring ⟧ᵖ ⇀⦇ regpool c poolParams ,POOL⦈ ⟦ ❴ c , poolParams ❵ᵐ ∪ᵐˡ pools , retiring ⟧ᵖ
 

--- a/src/Ledger/Ratify.lagda
+++ b/src/Ledger/Ratify.lagda
@@ -124,7 +124,7 @@ module _ (ce : Epoch) (ccHotKeys : KeyHash ↛ Maybe KeyHash)
 
   actualCCVotes : Credential ↛ Vote
   actualCCVotes = case cc of λ where
-    (just (cc , _)) → mapKeys inj₁ (λ where refl → refl) $ mapWithKey actualCCVote cc
+    (just (cc , _)) → mapKeys inj₁ (mapWithKey actualCCVote cc) (λ where _ _ refl → refl)
     nothing         → ∅ᵐ
 
   actualPDRepVotes : VDeleg ↛ Vote
@@ -134,9 +134,9 @@ module _ (ce : Epoch) (ccHotKeys : KeyHash ↛ Maybe KeyHash)
                                            _            → Vote.no) ❵ᵐ
 
   actualVotes : VDeleg ↛ Vote
-  actualVotes = mapKeys (credVoter CC) (λ where refl → refl) actualCCVotes
+  actualVotes = mapKeys (credVoter CC) actualCCVotes (λ where _ _ refl → refl)
               ∪ᵐˡ (actualPDRepVotes
-              ∪ᵐˡ mapKeys (uncurry credVoter) (λ where refl → refl) votes) -- TODO: make `actualVotes` for DRep, SPO
+              ∪ᵐˡ mapKeys (uncurry credVoter) votes (λ where _ _ refl → refl)) -- TODO: make `actualVotes` for DRep, SPO
 
 votedHashes : Vote → (VDeleg ↛ Vote) → GovRole → ℙ VDeleg
 votedHashes v votes r = votes ⁻¹ v

--- a/src/Ledger/Utxo/Properties.lagda
+++ b/src/Ledger/Utxo/Properties.lagda
@@ -82,56 +82,56 @@ newTxid⇒disj id∉utxo = disjoint⇒disjoint' λ h h' → id∉utxo $ to ∈-m
 
 consumedCoinEquality : ∀ {pp} → coin (mint tx) ≡ 0
                      → coin (consumed pp utxoState tx)
-                     ≡ cbalance ((UTxOState.utxo utxoState) ∣ txins tx) + depositRefunds utxoState tx
-consumedCoinEquality {tx} {utxoState} h = let utxo = UTxOState.utxo utxoState in begin
-  coin (balance (utxo ∣ txins tx) +ᵛ mint tx +ᵛ inject (depositRefunds utxoState tx))
+                     ≡ cbalance ((UTxOState.utxo utxoState) ∣ txins tx) + depositRefunds pp utxoState tx
+consumedCoinEquality {tx} {utxoState} {pp} h = let utxo = UTxOState.utxo utxoState in begin
+  coin (balance (utxo ∣ txins tx) +ᵛ mint tx +ᵛ inject (depositRefunds pp utxoState tx))
     ≡⟨ ∙-homo-Coin coinIsMonoidMorphism _ _ ⟩
-  coin (balance (utxo ∣ txins tx) +ᵛ mint tx) + coin (inject $ depositRefunds utxoState tx)
+  coin (balance (utxo ∣ txins tx) +ᵛ mint tx) + coin (inject $ depositRefunds pp utxoState tx)
     ≡⟨ cong (coin (balance (utxo ∣ txins tx) +ᵛ mint tx) +_) (property _) ⟩
-  coin (balance (utxo ∣ txins tx) +ᵛ mint tx) + depositRefunds utxoState tx
+  coin (balance (utxo ∣ txins tx) +ᵛ mint tx) + depositRefunds pp utxoState tx
     ≡⟨ cong! (∙-homo-Coin coinIsMonoidMorphism _ _) ⟩
-  coin (balance (utxo ∣ txins tx)) + coin (mint tx) + depositRefunds utxoState tx
-    ≡⟨ cong (λ x → cbalance (utxo ∣ txins tx) + x + depositRefunds utxoState tx) h ⟩
-  cbalance (utxo ∣ txins tx) + 0 + depositRefunds utxoState tx
+  coin (balance (utxo ∣ txins tx)) + coin (mint tx) + depositRefunds pp utxoState tx
+    ≡⟨ cong (λ x → cbalance (utxo ∣ txins tx) + x + depositRefunds pp utxoState tx) h ⟩
+  cbalance (utxo ∣ txins tx) + 0 + depositRefunds pp utxoState tx
     ≡⟨ cong! (+-identityʳ (cbalance (utxo ∣ txins tx))) ⟩
-  cbalance (utxo ∣ txins tx) + depositRefunds utxoState tx                        ∎
+  cbalance (utxo ∣ txins tx) + depositRefunds pp utxoState tx                        ∎
 
 producedCoinEquality : ∀ {pp} → coin (produced pp utxoState tx)
-                              ≡ cbalance (outs tx) + (txfee tx) + newDeposits utxoState tx
-producedCoinEquality {utxoState} {tx} = begin
-  coin (balance (outs tx) +ᵛ inject (txfee tx) +ᵛ inject (newDeposits utxoState tx))
+                              ≡ cbalance (outs tx) + (txfee tx) + newDeposits pp utxoState tx
+producedCoinEquality {utxoState} {tx} {pp} = begin
+  coin (balance (outs tx) +ᵛ inject (txfee tx) +ᵛ inject (newDeposits pp utxoState tx))
     ≡⟨ ∙-homo-Coin coinIsMonoidMorphism _ _ ⟩
-  coin (balance (outs tx) +ᵛ inject (txfee tx)) + coin (inject (newDeposits utxoState tx))
+  coin (balance (outs tx) +ᵛ inject (txfee tx)) + coin (inject (newDeposits pp utxoState tx))
     ≡⟨ cong! (property _) ⟩
-  coin (balance (outs tx) +ᵛ inject (txfee tx)) + newDeposits utxoState tx
+  coin (balance (outs tx) +ᵛ inject (txfee tx)) + newDeposits pp utxoState tx
     ≡⟨ cong! (∙-homo-Coin coinIsMonoidMorphism _ _) ⟩
-  coin (balance (outs tx)) + coin (inject (txfee tx)) + newDeposits utxoState tx
-    ≡⟨ cong (λ x → cbalance (outs tx) + x + newDeposits utxoState tx) (property (txfee tx)) ⟩
-  cbalance (outs tx) + (txfee tx) + newDeposits utxoState tx                     ∎
+  coin (balance (outs tx)) + coin (inject (txfee tx)) + newDeposits pp utxoState tx
+    ≡⟨ cong (λ x → cbalance (outs tx) + x + newDeposits pp utxoState tx) (property (txfee tx)) ⟩
+  cbalance (outs tx) + (txfee tx) + newDeposits pp utxoState tx                     ∎
 
 balValueToCoin : ∀ {pp} → coin (mint tx) ≡ 0 → consumed pp utxoState tx ≡ produced pp utxoState tx
-               → cbalance ((UTxOState.utxo utxoState) ∣ txins tx) + depositRefunds utxoState tx
-               ≡ cbalance (outs tx) + (txfee tx) + newDeposits utxoState tx
+               → cbalance ((UTxOState.utxo utxoState) ∣ txins tx) + depositRefunds pp utxoState tx
+               ≡ cbalance (outs tx) + (txfee tx) + newDeposits pp utxoState tx
 balValueToCoin {tx} {utxoState} {pp} h h' = begin
-  cbalance ((UTxOState.utxo utxoState) ∣ txins tx) + depositRefunds utxoState tx
+  cbalance ((UTxOState.utxo utxoState) ∣ txins tx) + depositRefunds pp utxoState tx
     ≡˘⟨ consumedCoinEquality {tx} {utxoState} {pp} h ⟩
   coin (consumed pp utxoState tx) ≡⟨ cong! h' ⟩
   coin (produced pp utxoState tx) ≡⟨ producedCoinEquality {utxoState} {tx} {pp} ⟩
-  cbalance (outs tx) + (txfee tx) + newDeposits utxoState tx ∎
+  cbalance (outs tx) + (txfee tx) + newDeposits pp utxoState tx ∎
 
 posPart-negPart≡x : ∀ {x} → posPart x ⊖ negPart x ≡ x
 posPart-negPart≡x {ℤ.+_ n}     = refl
 posPart-negPart≡x {ℤ.negsuc n} = refl
 
 module DepositHelpers
-  (utxo : UTxO) (fees : Coin) (deposits : (DepositPurpose × Credential) ↛ Coin) (tx : TxBody) where
+  (utxo : UTxO) (fees : Coin) (deposits : (DepositPurpose × Credential) ↛ Coin) (tx : TxBody) (pp : PParams) where
 
   private
     dep = getCoin deposits
-    uDep = getCoin (updateDeposits (txcerts tx) deposits)
-    Δdep = depositsChange (txcerts tx) deposits
-    ref = depositRefunds ⟦ utxo , fees , deposits ⟧ᵘ tx
-    tot = newDeposits    ⟦ utxo , fees , deposits ⟧ᵘ tx
+    uDep = getCoin (updateDeposits pp (txcerts tx) deposits)
+    Δdep = depositsChange pp (txcerts tx) deposits
+    ref = depositRefunds pp ⟦ utxo , fees , deposits ⟧ᵘ tx
+    tot = newDeposits    pp ⟦ utxo , fees , deposits ⟧ᵘ tx
 
   deposits-change' : Δdep ≡ tot ⊖ ref
   deposits-change' = sym posPart-negPart≡x
@@ -221,14 +221,15 @@ pov {tx} {utxo} {_} {fees} {deposits} {utxo'} {fees'} {deposits'} h' (UTXO-induc
   let h : disjoint (dom ((utxo ∣ txins tx ᶜ) ˢ)) (dom (outs tx ˢ))
       h = λ h₁ h₂ → ∉-∅ $ proj₁ (newTxid⇒disj {tx = tx} {utxo} h') $ to ∈-∩ (res-comp-domᵐ h₁ , h₂)
       utxoSt = ⟦ utxo , fees , deposits ⟧ᵘ
-      ref = depositRefunds utxoSt tx
-      totDep = newDeposits utxoSt tx
+      pp = UTxOEnv.pparams Γ
+      ref = depositRefunds pp utxoSt tx
+      totDep = newDeposits pp utxoSt tx
       remDepTot = getCoin deposits ∸ ref
       dep = getCoin deposits
       open DepositHelpers utxo fees deposits tx
   in begin
     cbalance utxo + fees + dep   ≡tˡ⟨ cong (cbalance utxo +_) (+-comm fees _) ⟩
-    cbalance utxo + (dep + fees) ≡˘⟨ cong (λ x → cbalance utxo + (x + fees)) (m+[n∸m]≡n ref≤dep) ⟩
+    cbalance utxo + (dep + fees) ≡˘⟨ cong (λ x → cbalance utxo + (x + fees)) (m+[n∸m]≡n (ref≤dep pp)) ⟩
     cbalance utxo + ((ref + remDepTot) + fees) ≡t⟨⟩
     cbalance utxo + ref + (remDepTot + fees) ≡⟨
       cong (_+ (remDepTot + fees))
@@ -263,11 +264,11 @@ pov {tx} {utxo} {_} {fees} {deposits} {utxo'} {fees'} {deposits'} h' (UTXO-induc
       ≡˘⟨ +-assoc (cbalance ((utxo ∣ txins tx ᶜ) ∪ᵐˡ outs tx)) (fees + txfee tx) (totDep + remDepTot) ⟩
     cbalance ((utxo ∣ txins tx ᶜ) ∪ᵐˡ outs tx) + (fees + txfee tx) + (totDep + remDepTot)
       ≡⟨ cong (cbalance ((utxo ∣ txins tx ᶜ) ∪ᵐˡ outs tx) + (fees + txfee tx) +_) $ begin
-           totDep + (dep ∸ ref) ≡˘⟨ +-∸-assoc totDep ref≤dep ⟩
+           totDep + (dep ∸ ref) ≡˘⟨ +-∸-assoc totDep (ref≤dep pp) ⟩
            (totDep + dep) ∸ ref ≡⟨ cong (_∸ ref) (+-comm totDep dep) ⟩
            (dep + totDep) ∸ ref ∎ ⟩
     cbalance ((utxo ∣ txins tx ᶜ) ∪ᵐˡ outs tx) + (fees + txfee tx) + ((dep + totDep) ∸ ref)
-      ≡˘⟨ cong (cbalance ((utxo ∣ txins tx ᶜ) ∪ᵐˡ outs tx) + (fees + txfee tx) +_) deposits-change ⟩
+      ≡˘⟨ cong (cbalance ((utxo ∣ txins tx ᶜ) ∪ᵐˡ outs tx) + (fees + txfee tx) +_) (deposits-change pp) ⟩
     cbalance ((utxo ∣ txins tx ᶜ) ∪ᵐˡ outs tx) + (fees + txfee tx) + getCoin deposits' ∎
 
 \end{code}


### PR DESCRIPTION
This PR adds DRep deposits to the stake distribution map. I also added `mapMaybeWithKeyᵐ` to make it easier to filter out credentials from the deposit map based on the `DepositPurpose`. The stakeDistrs are no longer passed to CHAIN as state, but rather calculated in the CHAIN rule from LState. Currently it only puts the DRep deposits into the map, the other stake distributions can be added in later PRs.

resolves #92