### PR TITLE
Example of a token algebra

### DIFF
--- a/src/Axiom/Set.agda
+++ b/src/Axiom/Set.agda
@@ -187,22 +187,35 @@ record Theory {ℓ} : Type (sucˡ ℓ) where
       (just x) → λ h → cong just (sym $ from ∈-singleton h)
       nothing  → λ h → case from ∈-fromList h of λ ())
 
+  concatMapˢ : (A → Set B) → Set A → Set B
+  concatMapˢ f a = proj₁ $ unions (map f a)
+
+  ∈-concatMapˢ : {y : B} {f : A → Set B} → (∃[ x ] x ∈ X × y ∈ f x) ⇔ y ∈ concatMapˢ f X 
+  ∈-concatMapˢ {X = X} {y} {f} =
+    (∃[ x ] x ∈ X × y ∈ f x)
+      ∼⟨ ∃-cong′ (λ {x} → ∃-≡ (λ T → x ∈ X × y ∈ T)) ⟩
+    (∃[ x ] ∃[ T ] T ≡ f x × x ∈ X × y ∈ T)
+      ↔⟨ ∃∃↔∃∃ (λ x T → T ≡ f x × x ∈ X × y ∈ T) ⟩
+    (∃[ T ] ∃[ x ] T ≡ f x × x ∈ X × y ∈ T)
+      ∼⟨ ∃-cong′ $ mk⇔
+        (λ where (x , p₁ , p₂ , p₃) → (x , p₁ , p₂) , p₃)
+        (λ where ((x , p₁ , p₂) , p₃) → x , p₁ , p₂ , p₃) ⟩
+    (∃[ T ] (∃[ x ] T ≡ f x × x ∈ X) × y ∈ T)
+      ∼⟨ ∃-cong′ (∈-map ×-cong R.K-refl) ⟩
+    (∃[ T ] T ∈ map f X × y ∈ T)
+      ∼⟨ ∈-unions ⟩
+    y ∈ concatMapˢ f X ∎
+    where open R.EquationalReasoning
+
   mapPartial : (A → Maybe B) → Set A → Set B
-  mapPartial f X = proj₁ $ unions (map (partialToSet f) X)
+  mapPartial f = concatMapˢ (partialToSet f)
 
   ∈-mapPartial : {y : B} {f : A → Maybe B} → (∃[ x ] x ∈ X × f x ≡ just y) ⇔ y ∈ mapPartial f X
   ∈-mapPartial {X = X} {y} {f} =
     (∃[ x ] x ∈ X × f x ≡ just y)
       ∼⟨ ∃-cong′ (R.K-refl ×-cong (∈-partialToSet {f = f})) ⟩
     (∃[ x ] x ∈ X × y ∈ partialToSet f x)
-      ∼⟨ ∃-cong′ (λ {x} → ∃-≡ (λ T → x ∈ X × y ∈ T)) ⟩
-    (∃[ x ] ∃[ T ] T ≡ partialToSet f x × x ∈ X × y ∈ T)
-      ↔⟨ ∃∃↔∃∃ (λ x T → T ≡ partialToSet f x × x ∈ X × y ∈ T) ⟩
-    (∃[ T ] ∃[ x ] T ≡ partialToSet f x × x ∈ X × y ∈ T)    ∼⟨ ∃-cong′ $ mk⇔
-      (λ where (x , p₁ , p₂ , p₃) → ((x , p₁ , p₂) , p₃))
-      (λ where ((x , p₁ , p₂) , p₃) → (x , p₁ , p₂ , p₃)) ⟩
-    (∃[ T ] (∃[ x ] T ≡ partialToSet f x × x ∈ X) × y ∈ T)  ∼⟨ ∃-cong′ (∈-map ×-cong R.K-refl) ⟩
-    (∃[ T ] T ∈ map (partialToSet f) X × y ∈ T)             ∼⟨ ∈-unions ⟩
+      ∼⟨ ∈-concatMapˢ ⟩
     y ∈ mapPartial f X ∎
     where open R.EquationalReasoning
 

--- a/src/Axiom/Set/Map.agda
+++ b/src/Axiom/Set/Map.agda
@@ -19,6 +19,7 @@ open import Data.List.Ext.Properties
 open import Data.Product.Properties
 open import Data.Maybe.Base using () renaming (map to map?)
 open import Interface.DecEq
+open import Relation.Binary using (REL)
 open import Relation.Unary using () renaming (Decidable to Dec₁)
 
 open Equivalence
@@ -45,6 +46,9 @@ private variable A A' B B' C D : Type
 left-unique : Rel A B → Type
 left-unique R = ∀ {a b b'} → (a , b) ∈ R → (a , b') ∈ R → b ≡ b'
 
+left-unique-rel : {A B : Type} → REL A B 0ℓ → Type 0ℓ
+left-unique-rel R = ∀ {a b b'} → R a b → R a b' → b ≡ b'
+
 record IsLeftUnique (R : Rel A B) : Type where
   field isLeftUnique : left-unique R
 
@@ -61,6 +65,9 @@ left-unique-mapˢ _ p q with from ∈-map p | from ∈-map q
 
 Map : Type → Type → Type
 Map A B = Σ (Rel A B) left-unique
+
+PartialMap : Type → Type → Type₁
+PartialMap A B = Σ (REL A B 0ℓ) left-unique-rel
 
 _≡ᵐ_ : Map A B → Map A B → Type
 (x , _) ≡ᵐ (y , _) = x ≡ᵉ y

--- a/src/Axiom/Set/Map/Dec.agda
+++ b/src/Axiom/Set/Map/Dec.agda
@@ -24,7 +24,6 @@ private variable A B C D : Type
 
 module Lookupᵐᵈ (sp-∈ : spec-∈ A) where
   open Lookupᵐ sp-∈
-  infixr 6 _∪⁺_
 
   unionThese : ⦃ DecEq A ⦄ → (m : Map A B) → (m' : Map A C) → (x : A) → x ∈ dom (m ˢ) ∪ dom (m' ˢ) → These B C
   unionThese m m' x dp with x ∈? dom (m ˢ) | x ∈? dom (m' ˢ)
@@ -48,7 +47,12 @@ module Lookupᵐᵈ (sp-∈ : spec-∈ A) where
            | yes _ | [ eq ] | yes _ | [ eq' ] with trans (sym eq) eq'
        ... | refl = refl
 
-  _∪⁺_ : ⦃ M : Monoid 0ℓ 0ℓ ⦄ → (open Monoid M renaming (Carrier to V)) → ⦃ DecEq A ⦄ → Map A V → Map A V → Map A V
-  _∪⁺_ ⦃ M = M ⦄ = unionWith (fold id id _∙_)
-    where open Monoid M
-
+  module _ ⦃ M : Monoid 0ℓ 0ℓ ⦄ ⦃ _ : DecEq A ⦄ where
+    infixr 6 _∪⁺_
+    open Monoid M renaming (Carrier to V)
+    
+    _∪⁺_ : Map A V → Map A V → Map A V
+    _∪⁺_ = unionWith (fold id id _∙_)
+    
+    aggregate₊ : FinSet (A × V) → Map A V
+    aggregate₊ (_ , l , _) = foldl (λ m x → m ∪⁺ ❴ x ❵ᵐ) ∅ᵐ l

--- a/src/Everything.agda
+++ b/src/Everything.agda
@@ -2,6 +2,7 @@ module Everything where
 
 import Ledger.PDF
 import Ledger.Foreign.HSLedger
+import Ledger.TokenAlgebra.ValueRelation
 
 import MidnightExample.PDF
 import MidnightExample.HSLedger

--- a/src/Ledger/Chain.lagda
+++ b/src/Ledger/Chain.lagda
@@ -9,6 +9,8 @@ module Ledger.Chain (txs : TransactionStructure) where
 
 open import Ledger.Prelude
 
+open import Algebra
+
 open TransactionStructure txs
 open import Ledger.PParams epochStructure
 open import Ledger.NewPP txs
@@ -19,7 +21,7 @@ open import Ledger.Ratify txs
 open import Ledger.Tally TxId Network ADHash epochStructure ppUpd ppHashingScheme crypto
 open Equivalence
 open import Data.Nat.Properties using (+-0-monoid)
-open import Data.Maybe.Base using () renaming (map to map?)
+open import Data.Maybe.Base using (_>>=_) renaming (map to map?)
 
 \end{code}
 \begin{figure*}[h]
@@ -41,6 +43,9 @@ record ChainState : Set where
 record Block : Set where
   field ts   : List Tx
         slot : Slot
+
+instance
+  _ = +-0-monoid
 \end{code}
 \caption{Definitions for the NEWEPOCH and CHAIN transition systems}
 \end{figure*}
@@ -55,6 +60,7 @@ private variable
   e : Epoch
   es' : EnactState
   newTally : TallyState
+  removed : List (GovActionID × GovActionState)
 
 -- The NEWEPOCH rule is actually multiple rules in one for the sake of simplicity:
 -- it also does what EPOCH used to do in previous eras
@@ -68,16 +74,32 @@ data _⊢_⇀⦇_,NEWEPOCH⦈_ : NewEpochEnv → NewEpochState → Epoch → New
       -- TODO Wire CertState together with treasury and withdrawals
       open CertState certState
       open PState pState
+      removedGovActions = map GovActionDeposit (map proj₁ (fromList removed))
       pup = PPUpdateState.pup ppup
+      deposits = UTxOState.deposits utxoSt
       acnt' = record acnt { treasury = Acnt.treasury acnt + UTxOState.fees utxoSt }
       retired = retiring ⁻¹ e
-      certState' = record certState { pState = record pState { pools = pools ∣ retired ᶜ ; retiring = retiring ∣ retired ᶜ } }
-      ls' = record ls { tally = newTally ; utxoSt = record utxoSt { fees = 0 } ; certState = certState' }
+      govActionRewards' = concatMapˢ
+        (λ where
+          (gaid , gaSt) → map
+            (GovActionState.returnAddr gaSt ,_)
+            ((deposits ˢ) ⟪$⟫ ❴ GovActionDeposit gaid ❵)
+        )
+        (fromList removed)
+      govActionRewards = aggregate₊ (govActionRewards' , finiteness govActionRewards')
+      certState' = record certState {
+        pState = record pState { pools = pools ∣ retired ᶜ ; retiring = retiring ∣ retired ᶜ };
+        dState = record dState { rewards = DState.rewards dState ∪⁺ govActionRewards } }
+      utxoSt' = record utxoSt
+        { fees = 0
+        ; deposits = deposits ∣ removedGovActions ᶜ
+        }
+      ls' = record ls { tally = newTally ; utxoSt = utxoSt' ; certState = certState' }
     in
     e ≡ sucᵉ lastEpoch
     → record { currentEpoch = e ; ccHotKeys = VState.ccHotKeys vState ; NewEpochEnv Γ }
-                    ⊢                               ⟦ es  , [] ⟧ʳ
-                    ⇀⦇ setToList (tally ˢ) ,RATIFY⦈ ⟦ es' , setToList (newTally ˢ) ⟧ʳ
+                    ⊢                               ⟦ es  , [] , [] ⟧ʳ
+                    ⇀⦇ setToList (tally ˢ) ,RATIFY⦈ ⟦ es' , setToList (newTally ˢ) , removed ⟧ʳ
     -- TODO: remove keys that aren't in the CC from the hot key map
     ────────────────────────────────
     Γ ⊢ nes ⇀⦇ e ,NEWEPOCH⦈ ⟦ e , acnt' , ls' , es' ⟧ⁿᵉ
@@ -113,18 +135,25 @@ filterPurpose prps m = mapKeys proj₂ (mapMaybeWithKeyᵐ (maybePurpose prps) m
 instance
   _ = +-0-monoid
 
+govActionDeposits : LState → VDeleg ↛ Coin
+govActionDeposits ls =
+  let open LState ls; open CertState certState; open PState pState; open UTxOState utxoSt; open DState dState
+   in foldl _∪⁺_ ∅ᵐ $ setToList $
+    mapPartial
+      (λ where (gaid , record { returnAddr = record {stake = c} }) → do
+        vd ← lookupᵐ? voteDelegs c ⦃ _ ∈? _ ⦄
+        dep ← lookupᵐ? deposits (GovActionDeposit gaid) ⦃ _ ∈? _ ⦄
+        just ❴ vd , dep ❵ᵐ )
+      (tally ˢ)
+
 calculateStakeDistrs : LState → StakeDistrs
 calculateStakeDistrs ls =
   let open LState ls; open CertState certState; open PState pState; open UTxOState utxoSt; open DState dState
       spoDelegs = ∅ᵐ -- TODO
       drepDelegs = ∅ᵐ -- TODO
-      govActionDeposits = foldl _∪⁺_ ∅ᵐ $ setToList $
-        mapPartial
-          (λ where record { returnAddr = record {stake = c} ; deposit = v } → map? (λ vd → ❴ vd , v ❵ᵐ) (lookupᵐ? voteDelegs c ⦃ _ ∈? _ ⦄))
-          (range (tally ˢ))
   in
   record
-    { stakeDistr = govActionDeposits
+    { stakeDistr = govActionDeposits ls
     }
 
 data _⊢_⇀⦇_,CHAIN⦈_ : ⊤ → ChainState → Block → ChainState → Set where

--- a/src/Ledger/GovernanceActions.lagda
+++ b/src/Ledger/GovernanceActions.lagda
@@ -74,8 +74,7 @@ record GovVote : Set where
         anchor      : Maybe Anchor
 
 record GovProposal : Set where
-  field deposit     : Coin
-        returnAddr  : RwdAddr
+  field returnAddr  : RwdAddr
         action      : GovAction
         anchor      : Anchor
 \end{code}

--- a/src/Ledger/Prelude.agda
+++ b/src/Ledger/Prelude.agda
@@ -80,14 +80,15 @@ abstract
   ≟-∅ = Decˡ.≟-∅
 
 open import Axiom.Set.Rel th hiding (_∣'_; _∣^'_) public
-open import Axiom.Set.Map th renaming (Map to _↛_) public
+open import Axiom.Set.Map th renaming (Map to _↛_ ; PartialMap to _⇀_) public
 open import Axiom.Set.TotalMap th public
 open L.Decˡ hiding (_∈?_; ≟-∅) public
 open import Axiom.Set.Sum th public
 open import Axiom.Set.Map.Dec List-Modelᵈ public
+open import Axiom.Set.Factor List-Model public
 
 module _ {A : Set} ⦃ _ : DecEq A ⦄ where
-  open Restriction {A} ∈-sp hiding (_∣_; _∣_ᶜ) public
+  open Restriction {A} ∈-sp renaming (_∣_ to _∣ʳ_; _∣_ᶜ to _∣ʳ_ᶜ) public
   open Corestriction {A} ∈-sp hiding (_∣^_; _∣^_ᶜ) public
   open Restrictionᵐ {A} ∈-sp public
   open Corestrictionᵐ {A} ∈-sp public

--- a/src/Ledger/Prelude/Base.agda
+++ b/src/Ledger/Prelude/Base.agda
@@ -2,6 +2,11 @@
 
 module Ledger.Prelude.Base where
 
-open import Data.Nat
+open import Data.Nat using (ℕ)
+open import Level
 
 Coin = ℕ
+
+1ℓ 2ℓ : Level
+1ℓ = suc 0ℓ
+2ℓ = suc 1ℓ

--- a/src/Ledger/Ratify.lagda
+++ b/src/Ledger/Ratify.lagda
@@ -27,6 +27,7 @@ _∧_ = _×_
 
 instance
   _ = +-0-commutativeMonoid
+  _ = +-0-monoid
 \end{code}
 \begin{figure*}[h]
 \begin{code}
@@ -39,9 +40,10 @@ record RatifyEnv : Set where
         ccHotKeys     : KeyHash ↛ Maybe KeyHash
 
 record RatifyState : Set where
-  constructor ⟦_,_⟧ʳ
-  field es      : EnactState
-        future  : List (GovActionID × GovActionState)
+  constructor ⟦_,_,_⟧ʳ
+  field es              : EnactState
+        future          : List (GovActionID × GovActionState)
+        expired         : List (GovActionID × GovActionState)
 \end{code}
 \caption{Types and functions for the RATIFY transition system}
 \end{figure*}
@@ -214,32 +216,32 @@ private variable
   es es' : EnactState
   upd : PParamsUpdate
   a : GovActionID × GovActionState
-  f f' l : List (GovActionID × GovActionState)
+  f f' l removed : List (GovActionID × GovActionState)
 
 data _⊢_⇀⦇_,RATIFY'⦈_ : RatifyEnv → RatifyState → GovActionID × GovActionState → RatifyState → Set where
 \end{code}
 \begin{figure*}[h]
 \begin{code}
-  RATIFY-Accept : let open RatifyEnv Γ in
+  RATIFY-Accept : let open RatifyEnv Γ; open GovActionState (proj₂ a) in
     accepted Γ es (proj₂ a)
     → _ ⊢ es ⇀⦇ GovActionState.action (proj₂ a) ,ENACT⦈ es'
     ────────────────────────────────
-    Γ ⊢ ⟦ es , f ⟧ʳ ⇀⦇ a ,RATIFY'⦈ ⟦ es' , f ⟧ʳ
+    Γ ⊢ ⟦ es , f , removed ⟧ʳ ⇀⦇ a ,RATIFY'⦈ ⟦ es' , f , a ∷ removed ⟧ʳ
 
   -- remove expired actions
   -- NOTE: don't have to remove actions that can never be accpted because of sufficient no votes
-  RATIFY-Reject : let open RatifyEnv Γ in
+  RATIFY-Reject : let open RatifyEnv Γ; open GovActionState (proj₂ a) in
     ¬ accepted Γ es (proj₂ a)
     → expired currentEpoch (proj₂ a)
     ────────────────────────────────
-    Γ ⊢ ⟦ es , f ⟧ʳ ⇀⦇ a ,RATIFY'⦈ ⟦ es , f ⟧ʳ
+    Γ ⊢ ⟦ es , f , removed ⟧ʳ ⇀⦇ a ,RATIFY'⦈ ⟦ es , f , a ∷ removed ⟧ʳ
 
   -- continue voting in the next epoch
   RATIFY-Continue : let open RatifyEnv Γ in
     ¬ accepted Γ es (proj₂ a)
     → ¬ expired currentEpoch (proj₂ a)
     ────────────────────────────────
-    Γ ⊢ ⟦ es , f ⟧ʳ ⇀⦇ a ,RATIFY'⦈ ⟦ es , a ∷ f ⟧ʳ
+    Γ ⊢ ⟦ es , f , removed ⟧ʳ ⇀⦇ a ,RATIFY'⦈ ⟦ es , a ∷ f , removed ⟧ʳ
 
 _⊢_⇀⦇_,RATIFY⦈_ : RatifyEnv → RatifyState → List (GovActionID × GovActionState) → RatifyState → Set
 _⊢_⇀⦇_,RATIFY⦈_ = SS⇒BS (λ where (Γ , _) → Γ ⊢_⇀⦇_,RATIFY'⦈_)

--- a/src/Ledger/TokenAlgebra.lagda
+++ b/src/Ledger/TokenAlgebra.lagda
@@ -1,19 +1,25 @@
 \section{Token Algebra}
+\label{sec:token-algebra}
+
 \begin{code}[hide]
 {-# OPTIONS --safe #-}
-module Ledger.TokenAlgebra where
 
-open import Ledger.Prelude
+open import Agda.Primitive  using() renaming (Set to Type)
 
-open import Algebra using (CommutativeMonoid)
-open import Algebra.Morphism
-open import Data.Integer
-open import Data.Nat.Properties using (+-0-commutativeMonoid)
+module Ledger.TokenAlgebra (PolicyId : Type) where
 
-record TokenAlgebra : Set₁ where
-  field PolicyId : Set
-        Value-CommutativeMonoid : CommutativeMonoid 0ℓ 0ℓ
+open import Ledger.Prelude hiding (Rel)
 
+open import Algebra              using (CommutativeMonoid)
+open import Algebra.Morphism     using (IsCommutativeMonoidMorphism-syntax)
+open import Data.Nat.Properties  using (+-0-commutativeMonoid)
+open import Relation.Binary      using (Rel)
+open import Relation.Unary       using (Pred)
+
+record TokenAlgebra : Type₁ where
+  field Value-CommutativeMonoid : CommutativeMonoid 0ℓ 0ℓ
+
+  MemoryEstimate : Type
   MemoryEstimate = ℕ
 
   open CommutativeMonoid Value-CommutativeMonoid using (_≈_; ε)
@@ -23,7 +29,39 @@ record TokenAlgebra : Set₁ where
         inject   : Coin → Value
         policies : Value → ℙ PolicyId
         size     : Value → MemoryEstimate
-        _≥ᵗ_      : Value → Value → Set
+        _≤ᵗ_      : Rel Value 0ℓ
+
+        property             : coin ∘ inject ≗ id
+        coinIsMonoidMorphism : coin Is Value-CommutativeMonoid -CommutativeMonoid⟶ +-0-commutativeMonoid
+
+        instance DecEq-Value : DecEq Value
+
+  sumᵛ : List Value → Value
+  sumᵛ = foldr _+ᵛ_ (inject 0)
+
+\end{code}
+
+\subsection{An alternative representation}
+\label{sec:token-algebra}
+
+Here is an altearntive manifestation of the token algebra which uses the \AgdaBound{REL}
+type from the Agda Standard Library instead of the \AgdaBound{Set} type.
+
+\begin{code}
+record TokenAlgebraPoly {ℓ ℓ' : Level} : Type ((sucˡ ℓ) ⊔ˡ (sucˡ ℓ')) where
+  field Value-CommutativeMonoid : CommutativeMonoid ℓ ℓ'
+
+  MemoryEstimate : Type
+  MemoryEstimate = ℕ
+
+  open CommutativeMonoid Value-CommutativeMonoid using (_≈_; ε)
+       renaming (Carrier to Value; refl to reflᵛ; _∙_ to _+ᵛ_) public
+
+  field coin     : Value → Coin
+        inject   : Coin → Value
+        policies : Value → Pred PolicyId 0ℓ
+        size     : Value → MemoryEstimate
+        _≤ᵗ_      : Rel Value 0ℓ
 
         property             : coin ∘ inject ≗ id
         coinIsMonoidMorphism : coin Is Value-CommutativeMonoid -CommutativeMonoid⟶ +-0-commutativeMonoid
@@ -33,3 +71,5 @@ record TokenAlgebra : Set₁ where
   sumᵛ : List Value → Value
   sumᵛ = foldr _+ᵛ_ (inject 0)
 \end{code}
+
+

--- a/src/Ledger/TokenAlgebra/ValueRelation.lagda
+++ b/src/Ledger/TokenAlgebra/ValueRelation.lagda
@@ -1,0 +1,345 @@
+\subsection{Value Relation}
+\label{sec:value-relation}
+
+\begin{code}[hide]
+{-# OPTIONS --safe #-}
+
+open import Agda.Primitive  using () renaming (Set to Type)
+
+module Ledger.TokenAlgebra.ValueRelation
+  (ByteString  : Type)
+  (PolicyId    : Type)
+  (AdaName     : ByteString)
+  where
+
+open import Algebra                      using (CommutativeMonoid ; Commutative ; Op₂)
+open import Algebra.Morphism             using (IsMonoidMorphism ; IsSemigroupMorphism)
+open import Data.Nat.Properties                        hiding (_≟_) --        using (+-identityˡ ; +-identityʳ ; +-comm ; +-assoc ; +-0-commutativeMonoid)
+open import Data.Nat using (_≤_)
+
+open import Data.Product.Base            using (swap)
+open import Data.Sum.Base                using ([_,_]′)
+open import Ledger.Prelude               hiding (Coin ; Rel ; _>_)
+open import Ledger.TokenAlgebra PolicyId using (TokenAlgebraPoly)
+open import Prelude
+open import Relation.Binary              using (REL ; Rel ; _⇒_ ; IsEquivalence ; Decidable) renaming (_⇔_ to _⇐⇒_ )
+open import Relation.Binary.Definitions  using (Decidable ; DecidableEquality)
+open import Relation.Binary.PropositionalEquality.Core using ( module ≡-Reasoning )
+
+private
+  variable
+    A B : Type
+    C : REL A B 0ℓ → Type 0ℓ
+
+\end{code}
+
+\subsection{Derived types}
+
+(See Fig 3 of the
+\href{https://github.com/input-output-hk/cardano-ledger/releases/latest/download/mary-ledger.pdf}%
+{Mary ledger specification}.)
+
+\begin{itemize}
+\item \AgdaBound{AssetName} is a byte string used to distinguish different assets with the same \AgdaBound{PolicyId}.
+\item \AgdaBound{AssetId} is a product type consisting of a \AgdaBound{PolicyId} and an \AgdaBound{AssetName}.
+\item \AgdaBound{AdaId} is the Id for the asset Ada.
+\item \AgdaBound{Quantity} is the type of amounts of assets.
+\end{itemize}
+
+In the formal ledger specification \AgdaBound{AssetId} is sometimes viewed as a direct sum type,
+the inhabitants of which belong to either \AgdaBound{AdaIdType} or the product
+\AgdaBound{PolicyId}~\AgdaBound{×}~\AgdaBound{AssetName}; if we were adhering to that point of view,
+then we would have defined
+\AgdaBound{AssetId}
+  = \AgdaBound{AdaIdType}~\AgdaBound{⊎}~(\AgdaBound{PolicyId}~\AgdaBound{×}~\AgdaBound{AssetName}).
+
+\begin{code}
+AssetName : Type
+AssetName = ByteString
+
+AssetId : Type
+AssetId = PolicyId × AssetName
+
+Quantity : Type
+Quantity = ℕ
+\end{code}
+
+Finally, we define a record type with a single inhabitant with which we may wish to
+represent the type of Ada (rather than viewing Ada as just another asset).
+
+\begin{code}
+record AdaIdType : Type where
+  instance constructor AdaId
+\end{code}
+
+
+\subsection{The identity of the value monoid}
+
+We'll use \AgdaBound{ι} to denote the identity for the Value monoid.
+
+\begin{code}
+ι : REL AssetId Quantity 0ℓ
+ι _ q = q ≡ 0
+
+I : AssetId ⇀ Quantity
+I = ι , λ 0b 0b' → trans 0b (sym 0b')
+
+_⊕₁_ : Op₂ (REL AssetId Quantity 0ℓ)
+Ru ⊕₁ Rv = λ aid q → ∃[ qu ] (∃[ qv ] (Ru aid qu × Rv aid qv × (q ≡ qu + qv)))
+
+open ≡-Reasoning
+
+ι-left⇒R : ∀{R} → ι ⊕₁ R ⇒ R
+ι-left⇒R {R} {aid} {q} (qι , qu , h) = subst (R aid) ι-left-lemma (proj₁ (proj₂ h))
+ where
+ ι-left-lemma : qu ≡ q
+ ι-left-lemma = begin
+    qu       ≡˘⟨ +-identityˡ qu ⟩
+    0 + qu   ≡˘⟨ cong (λ x → x + qu) (proj₁ h) ⟩
+    qι + qu  ≡˘⟨ proj₂ (proj₂ h) ⟩
+    q        ∎
+
+R⇒ι-left : ∀{R} → R ⇒ ι ⊕₁ R
+R⇒ι-left {R} Rh = 0 , _ , refl , Rh , sym (+-identityˡ _)
+
+ι-right⇒R : ∀{R} → R ⊕₁ ι ⇒ R
+ι-right⇒R {R} {aid} {q} (qu , qι , h) = subst (R aid) ι-right-lemma (proj₁ h)
+ where
+ ι-right-lemma : qu ≡ q
+ ι-right-lemma = begin
+    qu       ≡˘⟨ +-identityʳ qu ⟩
+    qu + 0   ≡˘⟨ cong (λ x → qu + x) (proj₁ (proj₂ h)) ⟩
+    qu + qι  ≡˘⟨ proj₂ (proj₂ h) ⟩
+    q        ∎
+
+R⇒ι-right : ∀{R} → R ⇒ R ⊕₁ ι
+R⇒ι-right {R} Rh = _ , 0 , Rh , refl , sym (+-identityʳ _)
+
+\end{code}
+
+\subsection{Equivalence on the value monoid}
+
+\begin{code}
+-- the following probably belongs somewhere else
+⇐⇒-isEquivalence : IsEquivalence {A = REL A B 0ℓ} _⇐⇒_
+IsEquivalence.refl ⇐⇒-isEquivalence = id , id
+IsEquivalence.sym ⇐⇒-isEquivalence = swap
+proj₁ (IsEquivalence.trans ⇐⇒-isEquivalence ij jk) ixy = (proj₁ jk) ((proj₁ ij) ixy)
+proj₂ (IsEquivalence.trans ⇐⇒-isEquivalence ij jk) kxy = (proj₂ ij) ((proj₂ jk) kxy)
+
+_≋_ : Rel (Σ (REL A B 0ℓ) C) 0ℓ
+u ≋ v = proj₁ u ⇐⇒ proj₁ v
+
+≋-isEquivalence : IsEquivalence {A = Σ (REL A B 0ℓ) C} _≋_
+IsEquivalence.refl ≋-isEquivalence = IsEquivalence.refl ⇐⇒-isEquivalence
+IsEquivalence.sym ≋-isEquivalence xy = IsEquivalence.sym ⇐⇒-isEquivalence xy
+IsEquivalence.trans ≋-isEquivalence ij jk = IsEquivalence.trans ⇐⇒-isEquivalence ij jk
+
+_≈_ : Rel (REL A B 0ℓ) 0ℓ
+u ≈ v = u ⇐⇒ v
+
+≈-isEquivalence : IsEquivalence {A = REL A B 0ℓ} _≈_
+IsEquivalence.refl ≈-isEquivalence = IsEquivalence.refl ⇐⇒-isEquivalence
+IsEquivalence.sym ≈-isEquivalence xy = IsEquivalence.sym ⇐⇒-isEquivalence xy
+IsEquivalence.trans ≈-isEquivalence ij jk = IsEquivalence.trans ⇐⇒-isEquivalence ij jk
+\end{code}
+
+\subsection{Summation of the value monoid and its properties}
+
+\begin{code}
+_⊕_ : Op₂ (AssetId ⇀ Quantity)
+proj₁ ((Ru , _) ⊕ (Rv , _)) = Ru ⊕₁ Rv
+proj₂ ((Ru , luu) ⊕ (Rv , luv)) {aid} {q} {q'} = Goal
+ where
+ Goal : (Ru ⊕₁ Rv) aid q → (Ru ⊕₁ Rv) aid q' → q ≡ q'
+ Goal (qu , qv , Ruqu , Rvqv , q≡quqv) (qu' , qv' , Ruqu' , Rvqv' , q'≡qu'qv') = begin
+   q           ≡⟨ q≡quqv ⟩
+   qu + qv    ≡⟨ cong₂ _+_ (luu Ruqu Ruqu') (luv Rvqv Rvqv') ⟩
+   qu' + qv'  ≡˘⟨ q'≡qu'qv' ⟩
+   q'          ∎
+
+ι-identity : Algebra.Identity _≋_ I _⊕_
+proj₁ ι-identity (R , _) = ι-left⇒R {R} , R⇒ι-left {R}
+proj₂ ι-identity (R , _) = ι-right⇒R {R} , R⇒ι-right {R}
+
+⊕-comm : Algebra.Commutative _≋_ _⊕_
+⊕-comm (Ru , _) (Rv , _) = i , ii
+ where
+ i : (Ru ⊕₁ Rv) ⇒ (Rv ⊕₁ Ru)
+ i (qu , qv , Rqu , Rqv , q≡quqv) = qv , qu , Rqv , Rqu , trans q≡quqv (+-comm qu qv)
+
+ ii : (Rv ⊕₁ Ru) ⇒ (Ru ⊕₁ Rv)
+ ii (qv , qu , Rqv , Rqu , q≡qvqu) = qu , qv , Rqu , Rqv , trans q≡qvqu (+-comm qv qu)
+
+
+⊕₁-assoc : Algebra.Associative _⇐⇒_ _⊕₁_
+⊕₁-assoc Ru Rv Rw = i , ii
+ where
+ i : ((Ru ⊕₁ Rv) ⊕₁ Rw) ⇒ (Ru ⊕₁ (Rv ⊕₁ Rw))
+ i {aid} {q} (quv , qw , (qu , qv , Ruqu , Rvqv , quv≡quqv) , Rwqw , q≡quvqw) = Goal
+  where
+  assc : q ≡ qu + (qv + qw)
+  assc = begin  q               ≡⟨ q≡quvqw ⟩
+                quv + qw        ≡⟨ cong (λ x → x + qw) quv≡quqv ⟩
+                qu + qv + qw    ≡⟨ +-assoc qu qv qw ⟩
+                qu + (qv + qw)  ∎
+
+  Goal : (Ru ⊕₁ (Rv ⊕₁ Rw)) aid q
+  Goal = qu , qv + qw , Ruqu , (qv , qw , Rvqv , Rwqw , refl) , assc
+
+ ii : (Ru ⊕₁ (Rv ⊕₁ Rw)) ⇒ ((Ru ⊕₁ Rv) ⊕₁ Rw)
+ ii {aid} {q} (qu , qvw , Ruqu , (qv , qw , Rvqv , Rwqw , qvw≡qvqw) , q≡quqvw) = Goal
+  where
+  assc : qu + qvw ≡ qu + qv + qw
+  assc = begin  qu + qvw        ≡⟨ cong (λ x → qu + x) qvw≡qvqw ⟩
+                qu + (qv + qw)  ≡˘⟨ +-assoc qu qv qw ⟩
+                qu + qv + qw    ∎
+
+  Goal : ((Ru ⊕₁ Rv) ⊕₁ Rw) aid q
+  Goal = qu + qv , qw , (qu , qv , Ruqu , Rvqv , refl) , Rwqw , trans q≡quqvw assc
+
+
+⊕-assoc : Algebra.Associative _≋_ _⊕_
+⊕-assoc (Ru , _) (Rv , _) (Rw , _)  = i , ii
+ where
+ i : (Ru ⊕₁ Rv) ⊕₁ Rw ⇒ Ru ⊕₁ (Rv ⊕₁ Rw)
+ i {aid} {q} (quv , qw , (qu , qv , Ruqu , Rvqv , quv≡quqv) , Rwqw , q≡quvqw) = Goal
+  where
+  assc : quv + qw ≡ qu + (qv + qw)
+  assc = begin  quv + qw        ≡⟨ cong (λ x → x + qw) quv≡quqv ⟩
+                qu + qv + qw    ≡⟨ +-assoc qu qv qw ⟩
+                qu + (qv + qw)  ∎
+
+  Goal : (Ru ⊕₁ (Rv ⊕₁ Rw)) aid q
+  Goal = qu , ((qv + qw) , (Ruqu , ((qv , qw , Rvqv , Rwqw , refl) , trans q≡quvqw assc )))
+
+
+ ii : Ru ⊕₁ (Rv ⊕₁ Rw) ⇒ (Ru ⊕₁ Rv) ⊕₁ Rw
+ ii {aid} {q} (qu , qvw , Ruqu , (qv , qw , Rvqv , Rwqw , qvw≡qvqw) , q≡quqvw) = Goal
+  where
+  tras : q ≡ qu + qv + qw
+  tras = begin  q               ≡⟨ q≡quqvw ⟩
+                qu + qvw        ≡⟨ cong (λ x → qu + x) qvw≡qvqw ⟩
+                qu + (qv + qw)  ≡˘⟨ +-assoc qu qv qw ⟩
+                qu + qv + qw    ∎
+
+  Goal : ((Ru ⊕₁ Rv) ⊕₁ Rw) aid q
+  Goal = (qu + qv) , (qw , ((qu , qv , Ruqu , Rvqv , refl) , (Rwqw , tras)))
+
+
+⊕-cong : Algebra.Congruent₂ _≋_ _⊕_
+⊕-cong {Ru , _} {Rv , _} {Ru' , _} {Rv' , _} (Ru⇒Rv , Rv⇒Ru) (Ru'⇒Rv' , Rv'⇒Ru') = i , ii
+ where
+ i : (Ru ⊕₁ Ru') ⇒ (Rv ⊕₁ Rv')
+ i (qu , qu' , Ruqu , Ru'qu' , q≡ququ') = qu , qu' , Ru⇒Rv Ruqu , Ru'⇒Rv' Ru'qu' , q≡ququ'
+
+ ii : (Rv ⊕₁ Rv') ⇒ (Ru ⊕₁ Ru')
+ ii (qv , qv' , Rvqv , Rv'qv' , q≡qvqv') = qv , qv' , Rv⇒Ru Rvqv , Rv'⇒Ru' Rv'qv' , q≡qvqv'
+\end{code}
+
+\subsection{Definition of the value monoid}
+
+An inhabitant of `Value` is a map denoting a finite collection of quantities of assets.
+
+\begin{code}
+open TokenAlgebraPoly
+open CommutativeMonoid renaming (_∙_ to _⋆_) hiding (trans ; sym)
+open Algebra
+
+module _
+  {AdaPolicy   : PolicyId}
+  {DecEqValue  : DecidableEquality (AssetId ⇀ Quantity) }
+  {Size        : AssetId ⇀ Quantity → ℕ}
+  {AdaForAll   : (R : AssetId ⇀ Quantity) → ∃[ q ] (proj₁ R) (AdaPolicy , AdaName) q}
+  where
+
+  contr : ⊥
+  contr = proj₂ $ AdaForAll ((λ _ _ → ⊥) , λ where () ())
+
+  VAda : Quantity → AssetId ⇀ Quantity
+  VAda x = ((λ a q' → a ≡ (AdaPolicy , AdaName) × x ≡ q') , λ x y → trans (sym (proj₂ x)) (proj₂ y))
+
+  _hasHowMuchAda : AssetId ⇀ Quantity → Quantity
+  R hasHowMuchAda = proj₁ (AdaForAll R)
+
+  VAdaHasAda : ∀{x} → ((VAda x) hasHowMuchAda) ≡ x
+  VAdaHasAda {x} = (proj₂ (VAda x){(AdaPolicy , AdaName)})(proj₂ (AdaForAll (VAda x)))(_≡_.refl , _≡_.refl)
+
+  Value-TokenAlgebra : TokenAlgebraPoly
+  Value-TokenAlgebra =
+    record
+      { Value-CommutativeMonoid = Vcm
+      ; coin = λ R → R hasHowMuchAda
+      ; inject = VAda
+      ; policies = λ (V , _) → λ pid → ∃[ a ] ∃[ q ] V (pid , a) q
+      ; size = Size
+      ; _≤ᵗ_ = λ (Ru , _) (Rv , _) → ∀ qu qv aid → (Ru aid qu × Rv aid qv) → qu ≤ qv
+      ; property = λ x → VAdaHasAda
+      ; coinIsMonoidMorphism = record { mn-homo = mh }
+      ; DecEq-Value = record { _≟_ = DecEqValue }
+      }
+    where
+
+    -- Vcm is a `CommutativeMonoid` whose elements are maps, where each map denotes a finite
+    -- collections of quantities of assets.
+    Vcm : CommutativeMonoid 1ℓ 0ℓ
+    Vcm = record
+        { Carrier = AssetId ⇀ Quantity
+        ; _≈_ = _≋_
+        ; _∙_ = _⊕_
+        ; ε = I
+        ; isCommutativeMonoid = record { isMonoid = Vm ; comm = ⊕-comm } }
+        where
+        isSemigrp : IsSemigroup _≋_ _⊕_
+        isSemigrp = record
+            { isMagma = record
+                { isEquivalence = ≋-isEquivalence
+                ; ∙-cong = λ{u}{v}{w}{x} y z → ⊕-cong {u}{v}{w}{x} y z }
+            ; assoc = ⊕-assoc }
+
+        Vm : IsMonoid _≋_ _⊕_ I
+        Vm = record { isSemigroup = isSemigrp ; identity = ι-identity }
+
+
+    mh : IsMonoidMorphism (monoid Vcm) (monoid +-0-commutativeMonoid) _hasHowMuchAda
+    IsSemigroupMorphism.⟦⟧-cong (IsMonoidMorphism.sm-homo mh) {R} {R'} (_ , R'⇒R) = begin
+      R hasHowMuchAda ≡⟨ proj₂ R Rq Rq' ⟩ R' hasHowMuchAda ∎
+      where
+      q = R hasHowMuchAda
+      q' = R' hasHowMuchAda
+
+      Rq : (proj₁ R) (AdaPolicy , AdaName) q
+      Rq = proj₂ (AdaForAll R)
+
+      Rq' : (proj₁ R) (AdaPolicy , AdaName) q'
+      Rq' = R'⇒R (proj₂ (AdaForAll R'))
+
+    IsSemigroupMorphism.∙-homo (IsMonoidMorphism.sm-homo mh) Ru Rv = begin
+          q                          ≡⟨ proj₂ (proj₂ (proj₂ (proj₂ ξ))) ⟩
+          proj₁ ξ + proj₁ (proj₂ ξ)  ≡˘⟨ cong (proj₁ ξ +_) qvξ ⟩
+          proj₁ ξ + qv               ≡˘⟨ cong (_+ qv )     quξ ⟩
+          qu + qv                    ∎
+     where
+     q qu qv : Quantity
+     q = (Ru ⊕ Rv) hasHowMuchAda
+     qu = Ru hasHowMuchAda
+     qv = Rv hasHowMuchAda
+
+     ξ : (proj₁ (Ru ⊕ Rv)) (AdaPolicy , AdaName) q
+     ξ = proj₂ (AdaForAll (Ru ⊕ Rv))
+
+     α : proj₁ Ru (AdaPolicy , AdaName) (proj₁ ξ)
+     α = proj₁ (proj₂ (proj₂ (proj₂ (AdaForAll (Ru ⊕ Rv)))))
+     β : proj₁ Rv (AdaPolicy , AdaName) (proj₁ (proj₂ ξ))
+     β = proj₁ (proj₂ (proj₂ (proj₂ (proj₂ (AdaForAll (Ru ⊕ Rv))))))
+
+     quξ : qu ≡ proj₁ ξ
+     quξ = proj₂ Ru (proj₂ (AdaForAll Ru)) α
+     qvξ : qv ≡ proj₁ (proj₂ ξ)
+     qvξ = proj₂ Rv (proj₂ (AdaForAll Rv)) β
+
+    IsMonoidMorphism.ε-homo mh = proj₂ (AdaForAll I)
+
+\end{code}
+
+[1] https://github.com/input-output-hk/cardano-ledger/releases/latest/download/mary-ledger.pdf

--- a/src/Ledger/Transaction.lagda
+++ b/src/Ledger/Transaction.lagda
@@ -12,10 +12,10 @@ open import Ledger.Prelude
 
 open import Ledger.Crypto
 open import Ledger.Epoch
-open import Ledger.TokenAlgebra
 import Ledger.PParams
 import Ledger.Script
 import Ledger.GovernanceActions
+import Ledger.TokenAlgebra as TA
 
 record TransactionStructure : Set₁ where
   field
@@ -39,9 +39,9 @@ This function must produce a unique id for each unique transaction body.
 
 \begin{figure*}[h]
 \emph{Abstract types}
-\AgdaTarget{Ix, TxId, Epoch, AuxiliaryData}
+\AgdaTarget{Ix, TxId, AuxiliaryData, PolicyId}
 \begin{code}
-        Ix TxId AuxiliaryData : Set
+        Ix TxId AuxiliaryData PolicyId : Set
 \end{code}
 \begin{code}[hide]
         epochStructure                      : EpochStructure
@@ -55,17 +55,19 @@ This function must produce a unique id for each unique transaction body.
         ppUpd                               : Ledger.PParams.PParamsDiff epochStructure
         txidBytes                           : TxId → Crypto.Ser crypto
         networkId                           : Network
-        tokenAlgebra                        : TokenAlgebra
         instance DecEq-TxId  : DecEq TxId
                  DecEq-Ix    : DecEq Ix
                  DecEq-Netw  : DecEq Network
                  DecEq-UpdT  : DecEq (Ledger.PParams.PParamsDiff.UpdateT ppUpd)
 
   open Crypto crypto public
-  open TokenAlgebra tokenAlgebra public
+  open TA PolicyId
   open isHashableSet adHashingScheme renaming (THash to ADHash) public
 
-  field ss : Ledger.Script.ScriptStructure KeyHash ScriptHash Slot
+  field  ss            : Ledger.Script.ScriptStructure KeyHash ScriptHash Slot
+         tokenAlgebra  : TokenAlgebra
+
+  open TokenAlgebra tokenAlgebra public
 
   open Ledger.Script.ScriptStructure ss public
 

--- a/src/Ledger/Utxo.lagda
+++ b/src/Ledger/Utxo.lagda
@@ -91,30 +91,35 @@ minfee pp tx = a * txsize tx + b
   where open PParams pp
 
 data DepositPurpose : Set where
-  CredentialDeposit  : DepositPurpose
-  PoolDeposit        : DepositPurpose
-  DRepDeposit        : DepositPurpose
+  CredentialDeposit  : Credential  → DepositPurpose
+  PoolDeposit        : Credential  → DepositPurpose
+  DRepDeposit        : Credential  → DepositPurpose
+  GovActionDeposit   : GovActionID → DepositPurpose
 
-certDeposit : PParams → DCert → Maybe (DepositPurpose × Credential × Coin)
-certDeposit _  (delegate c _ _ v)  = just (CredentialDeposit , c , v)
-certDeposit pp (regpool c _)       = just (PoolDeposit       , c , PParams.poolDeposit pp)
-certDeposit _  (regdrep c v _)     = just (DRepDeposit       , c , v)
+certDeposit : PParams → DCert → Maybe (DepositPurpose × Coin)
+certDeposit _  (delegate c _ _ v)  = just (CredentialDeposit c , v)
+certDeposit pp (regpool c _)       = just (PoolDeposit       c , PParams.poolDeposit pp)
+certDeposit _  (regdrep c v _)     = just (DRepDeposit       c , v)
 certDeposit _  _                   = nothing
 
-certDepositᵐ : PParams → DCert → (DepositPurpose × Credential) ↛ Coin
+certDepositᵐ : PParams → DCert → DepositPurpose ↛ Coin
 certDepositᵐ pp cert = case certDeposit pp cert of λ where
-  (just (p , c , v))  → ❴ (p , c) , v ❵ᵐ
-  nothing             → ∅ᵐ
+  (just (p , v))  → ❴ p , v ❵ᵐ
+  nothing         → ∅ᵐ
 
-certRefund : DCert → Maybe (DepositPurpose × Credential)
-certRefund (delegate c nothing nothing x)  = just (CredentialDeposit , c)
-certRefund (deregdrep c)                   = just (DRepDeposit       , c)
+certRefund : DCert → Maybe DepositPurpose
+certRefund (delegate c nothing nothing x)  = just (CredentialDeposit c)
+certRefund (deregdrep c)                   = just (DRepDeposit       c)
 certRefund _                               = nothing
 
-certRefundˢ : DCert → ℙ (DepositPurpose × Credential)
+certRefundˢ : DCert → ℙ DepositPurpose
 certRefundˢ = partialToSet certRefund
 
--- txDeposits : TxBody → (DepositPurpose × Credential) ↛ Coin
+propDepositᵐ : PParams → GovActionID → GovProposal → DepositPurpose ↛ Coin
+propDepositᵐ pp gaid record { returnAddr = record { stake = c } }
+  = ❴ GovActionDeposit gaid , PParams.govDeposit pp ❵ᵐ
+
+-- txDeposits : TxBody → DepositPurpose ↛ Coin
 -- txDeposits = foldr _∪⁺_ ∅ᵐ ∘ List.map certDepositᵐ ∘ txcerts
 
 -- this has to be a type definition for inference to work
@@ -151,26 +156,39 @@ record UTxOState : Set where
   constructor ⟦_,_,_⟧ᵘ
   field utxo      : UTxO
         fees      : Coin
-        deposits  : (DepositPurpose × Credential) ↛ Coin
+        deposits  : DepositPurpose ↛ Coin
 
-updateDeposits : PParams → List DCert → (DepositPurpose × Credential) ↛ Coin → (DepositPurpose × Credential) ↛ Coin
-updateDeposits _  []              deposits = deposits
-updateDeposits pp (cert ∷ certs)  deposits =
-  ((updateDeposits pp certs deposits) ∪⁺ certDepositᵐ pp cert) ∣ certRefundˢ cert ᶜ
+updateCertDeposits : PParams → List DCert → DepositPurpose ↛ Coin → DepositPurpose ↛ Coin
+updateCertDeposits _  []              deposits = deposits
+updateCertDeposits pp (cert ∷ certs)  deposits =
+  ((updateCertDeposits pp certs deposits) ∪⁺ certDepositᵐ pp cert) ∣ certRefundˢ cert ᶜ
 
-depositsChange : PParams → List DCert → (DepositPurpose × Credential) ↛ Coin → ℤ
-depositsChange pp certs deposits = getCoin (updateDeposits pp certs deposits) ⊖ getCoin deposits
+updateProposalDeposits : PParams → TxId → List GovProposal → DepositPurpose ↛ Coin → DepositPurpose ↛ Coin
+updateProposalDeposits pp _    []             deposits = deposits
+updateProposalDeposits pp txid (prop ∷ props) deposits
+  = updateProposalDeposits pp txid props deposits
+  ∪⁺ propDepositᵐ pp (txid , length props) prop
+
+updateDeposits : PParams → TxBody → DepositPurpose ↛ Coin → DepositPurpose ↛ Coin
+updateDeposits pp txb
+  = updateCertDeposits pp (txcerts txb)
+  ∘ updateProposalDeposits pp (txid txb) (txprop txb)
+
+depositsChange : PParams → TxBody → DepositPurpose ↛ Coin → ℤ
+depositsChange pp txb deposits = getCoin (updateDeposits pp txb deposits) ⊖ getCoin deposits
 
 -- refundedDeposits : TxBody → ℙ (DepositPurpose × Credential)
 -- refundedDeposits = mapPartial certRefund ∘ fromList ∘ txcerts
 
 depositRefunds : PParams → UTxOState → TxBody → Coin
-depositRefunds pp st txb = negPart $ depositsChange pp (txcerts txb) deposits
+depositRefunds pp st txb = negPart $ depositsChange pp txb deposits
   where open UTxOState st
 
 newDeposits : PParams → UTxOState → TxBody → Coin
-newDeposits pp st txb = posPart $ depositsChange pp (txcerts txb) deposits
-  where open UTxOState st
+newDeposits pp st txb = certDeposits
+  where
+    open UTxOState st
+    certDeposits = posPart $ depositsChange pp txb deposits
 
 consumed : PParams → UTxOState → TxBody → Value
 consumed pp st txb = balance (UTxOState.utxo st ∣ txins txb)
@@ -270,8 +288,7 @@ data _⊢_⇀⦇_,UTXO⦈_ where
     Γ ⊢ s ⇀⦇ tx ,UTXO⦈
         ⟦ (utxo ∣ txins tx ᶜ) ∪ᵐˡ outs tx
         , fees + f
-        , updateDeposits pp (txcerts tx) deposits
-        ⟧ᵘ
+        , updateDeposits pp tx deposits ⟧ᵘ
 \end{code}
 \begin{code}[hide]
 -- TODO: This can't be moved into Properties because it breaks. Move

--- a/src/Ledger/Utxo/Properties.lagda
+++ b/src/Ledger/Utxo/Properties.lagda
@@ -52,7 +52,7 @@ private variable
   utxo utxo' utxo1 utxo2 : UTxO
   fee fee' fees fees' : Coin
   utxoState utxoState' utxoState1 utxoState2 : UTxOState
-  deposits deposits' : (DepositPurpose × Credential) ↛ Coin
+  deposits deposits' : DepositPurpose ↛ Coin
   Γ : UTxOEnv
   s s' : UTxOState
 
@@ -124,12 +124,12 @@ posPart-negPart≡x {ℤ.+_ n}     = refl
 posPart-negPart≡x {ℤ.negsuc n} = refl
 
 module DepositHelpers
-  (utxo : UTxO) (fees : Coin) (deposits : (DepositPurpose × Credential) ↛ Coin) (tx : TxBody) (pp : PParams) where
+  (utxo : UTxO) (fees : Coin) (deposits : DepositPurpose ↛ Coin) (tx : TxBody) (pp : PParams) where
 
   private
     dep = getCoin deposits
-    uDep = getCoin (updateDeposits pp (txcerts tx) deposits)
-    Δdep = depositsChange pp (txcerts tx) deposits
+    uDep = getCoin (updateDeposits pp tx deposits)
+    Δdep = depositsChange pp tx deposits
     ref = depositRefunds pp ⟦ utxo , fees , deposits ⟧ᵘ tx
     tot = newDeposits    pp ⟦ utxo , fees , deposits ⟧ᵘ tx
 


### PR DESCRIPTION
-  A new directory called `TokenAlgebra` was added inside of which is the `ValueRelation.lagda` file with the `ValueRelation` module.  It's called `ValueRelation` because it's based on `REL`; we expect to add to this directory a `ValueSet.lagda` file/module with an example based on `Set`.

-  Here a partial function is constructed as an inhabitant of the `REL` type from the Agda Standard Library along with a proof of left-uniqueness (i.e., if `(a, b)` and `(a, b')` belong to the relation, then `b ≡ b'`).

-  A couple of modifications to the original `TokenAlgebra` module were necessary. Some of these were done in a separate new `TokenAlgebraPoly` type.

   - [X] `PolicyID` is now a parameter of the `TokenAlgebra` module instead of a field in the `TokenAlgebra` record type.
   - [X] `policies : Value → ℙ PolicyID` is changed to `policies : Value → Pred PolicyID 0ℓ`, but @WhatisRT says we need to change that back.

**ISSUES/TODO**

- [ ] It's not possible to keep the `TokenAlgebraPoly` type at level `Type₁` Therefore, the current implementation of `TransactionStructure`, which lives at level `Type₁`, must use the `TokenAlgebra` type based on `Set` (though we could simply change the universe level in the definition of `TransactionStructure` to make it compatible with `TokenAlgebraPoly` if desired).

- [ ] We need to figure out how to construct inhabitants of `Set` type so that we can make use of `policies : Value → ℙ PolicyID` instead of `policies : Value → Pred PolicyID 0ℓ` in the `TokenAlgebraPoly` type.