### PR TITLE
Treasury donations

### DIFF
--- a/src/Ledger/Foreign/HSLedger.agda
+++ b/src/Ledger/Foreign/HSLedger.agda
@@ -166,20 +166,21 @@ instance
 
       from' : F.TxBody → TxBody
       from' txb = let open F.TxBody txb in record
-        { txins    = from ⦃ Convertible-FinSet ⦃ Coercible⇒Convertible ⦄ ⦄ txins
-        ; txouts   = from txouts
-        ; txcerts  = []
-        ; mint     = ε -- since simpleTokenAlgebra only contains ada mint will always be empty
-        ; txfee    = txfee
-        ; txvldt   = coerce txvldt
-        ; txwdrls  = ∅ᵐ
-        ; txup     = nothing
-        ; txADhash = nothing
-        ; netwrk   = nothing
-        ; txsize   = txsize
-        ; txid     = txid
-        ; txvote   = []
-        ; txprop   = []
+        { txins      = from ⦃ Convertible-FinSet ⦃ Coercible⇒Convertible ⦄ ⦄ txins
+        ; txouts     = from txouts
+        ; txcerts    = []
+        ; mint       = ε -- since simpleTokenAlgebra only contains ada mint will always be empty
+        ; txfee      = txfee
+        ; txvldt     = coerce txvldt
+        ; txwdrls    = ∅ᵐ
+        ; txup       = nothing
+        ; txADhash   = nothing
+        ; netwrk     = nothing
+        ; txsize     = txsize
+        ; txid       = txid
+        ; txvote     = []
+        ; txprop     = []
+        ; txdonation = ε
         }
 
   Convertible-TxWitnesses : Convertible TxWitnesses F.TxWitnesses
@@ -276,9 +277,10 @@ instance
 
       from' : F.UTxOState → UTxOState
       from' s = record
-        { utxo     = from ⦃ Convertible-Map ⦃ DecEq-Product ⦄ ⦃ Coercible⇒Convertible ⦄ ⦄ (F.UTxOState.utxo s)
-        ; fees     = F.UTxOState.fees s
-        ; deposits = ∅ᵐ
+        { utxo      = from ⦃ Convertible-Map ⦃ DecEq-Product ⦄ ⦃ Coercible⇒Convertible ⦄ ⦄ (F.UTxOState.utxo s)
+        ; fees      = F.UTxOState.fees s
+        ; deposits  = ∅ᵐ
+        ; donations = ε
         }
 
 utxo-step : F.UTxOEnv → F.UTxOState → F.TxBody → Maybe F.UTxOState

--- a/src/Ledger/Introduction.lagda
+++ b/src/Ledger/Introduction.lagda
@@ -68,9 +68,7 @@ Agda functions.
 
 \begin{figure*}[h]
 \begin{code}[hide]
-module _ (ℙ_ : Set → Set)
-         (_↛_ : Set → Set → Set)
-         (_∈_ : ∀ {A : Set} → A → ℙ A → Set) where
+module _ (ℙ_ : Set → Set) (_∈_ : ∀ {A : Set} → A → ℙ A → Set) where
 \end{code}
 \begin{code}
   _⊆_ : {A : Set} → ℙ A → ℙ A → Set
@@ -85,7 +83,7 @@ module _ (ℙ_ : Set → Set)
   left-unique : {A B : Set} → Rel A B → Set
   left-unique R = ∀ {a b b'} → (a , b) ∈ R → (a , b') ∈ R → b ≡ b'
 
-  Map : Set → Set → Set
-  Map A B = Σ (Rel A B) left-unique
+  _⇀_ : Set → Set → Set
+  A ⇀ B = Σ (Rel A B) left-unique
 \end{code}
 \end{figure*}

--- a/src/Ledger/Transaction.lagda
+++ b/src/Ledger/Transaction.lagda
@@ -92,20 +92,21 @@ the transaction body are:
 \begin{AgdaSuppressSpace}
 \begin{code}
   record TxBody : Set where
-    field txins      : ℙ TxIn
-          txouts     : Ix ⇀ TxOut
-          txfee      : Coin
-          mint       : Value
-          txvldt     : Maybe Slot × Maybe Slot
-          txcerts    : List DCert
-          txwdrls    : Wdrl
-          txvote     : List GovVote
-          txprop     : List GovProposal
-          txup       : Maybe Update
-          txADhash   : Maybe ADHash
-          netwrk     : Maybe Network
-          txsize     : ℕ
-          txid       : TxId
+    field txins       : ℙ TxIn
+          txouts      : Ix ⇀ TxOut
+          txfee       : Coin
+          mint        : Value
+          txvldt      : Maybe Slot × Maybe Slot
+          txcerts     : List DCert
+          txwdrls     : Wdrl
+          txvote      : List GovVote
+          txprop      : List GovProposal
+          txdonation  : ℕ
+          txup        : Maybe Update
+          txADhash    : Maybe ADHash
+          netwrk      : Maybe Network
+          txsize      : ℕ
+          txid        : TxId
 
   record TxWitnesses : Set where
     field vkSigs   : VKey ⇀ Sig


### PR DESCRIPTION
This PR adds the donations field to TxBody and updates the `pov` proof to account for that. I also extracted some lemmas from the pov proof and moved them to the `DepositHelpers` module.

resolves #109