### PR TITLE
Fixed a mistake in the VDEL rule

### DIFF
--- a/src/Ledger/Deleg.lagda
+++ b/src/Ledger/Deleg.lagda
@@ -137,8 +137,8 @@ data _⊢_⇀⦇_,VDEL⦈_ : VDelEnv → VState → DCert → VState → Set whe
          ⟦ ❴ c ❵ ∪ dReps , ccKeys ⟧ᵛ
 
   VDEL-deregdrep :
-    c ∉ dReps
-    → dReps' ≡ ❴ c ❵ ∪ dReps
+    c ∉ dReps'
+    → ❴ c ❵ ∪ dReps' ≡ dReps
     ────────────────────────────────
     pp ⊢ ⟦ dReps , ccKeys ⟧ᵛ ⇀⦇ deregdrep c ,VDEL⦈
          ⟦ dReps' , ccKeys ⟧ᵛ


### PR DESCRIPTION
The VDEL-deregdrep transition seemed to be adding the credential, not removing it.