### PR TITLE
TokenAlgebra examples

### DIFF
--- a/src/Axiom/Set.agda
+++ b/src/Axiom/Set.agda
@@ -1,6 +1,6 @@
 {-# OPTIONS --safe --no-import-sorts #-}
 
-open import Agda.Primitive renaming (Set to Type)
+open import Agda.Primitive using () renaming (Set to Type)
 
 module Axiom.Set where
 

--- a/src/Axiom/Set/Factor.agda
+++ b/src/Axiom/Set/Factor.agda
@@ -1,6 +1,6 @@
 {-# OPTIONS --safe --no-import-sorts #-}
 
-open import Agda.Primitive renaming (Set to Type)
+open import Agda.Primitive using (lzero) renaming (Set to Type)
 open import Axiom.Set
 
 module Axiom.Set.Factor (th : Theory {lzero}) where

--- a/src/Axiom/Set/List.agda
+++ b/src/Axiom/Set/List.agda
@@ -1,12 +1,6 @@
 {-# OPTIONS --safe --no-import-sorts #-}
 
-open import Agda.Primitive renaming (Set to Type)
-
 module Axiom.Set.List where
-
-open import Prelude
-
-open import Axiom.Set
 
 import Data.List
 import Data.List.Relation.Unary.All as All
@@ -14,6 +8,9 @@ import Data.List.Relation.Unary.Any as Any
 import Function.Properties.Inverse as I
 import Function.Related.Propositional as R
 import Relation.Nullary.Decidable as Dec
+
+open import Agda.Primitive using () renaming (Set to Type)
+open import Axiom.Set
 open import Data.List.Membership.Propositional using (find; lose) renaming (_∈_ to _∈ˡ_)
 open import Data.List.Membership.Propositional.Properties
 open import Data.Product
@@ -21,6 +18,7 @@ open import Data.Product.Algebra
 open import Data.Product.Properties.Ext
 open import Function.Related hiding (⌊_⌋)
 open import Interface.DecEq
+open import Prelude
 open import Relation.Binary using () renaming (Decidable to Dec₂)
 open import Relation.Nullary.Decidable
 

--- a/src/Axiom/Set/Map/Dec.agda
+++ b/src/Axiom/Set/Map/Dec.agda
@@ -3,13 +3,12 @@ open import Axiom.Set
 
 module Axiom.Set.Map.Dec (thᵈ : Theoryᵈ) where
 
-open import Prelude
-
-open import Agda.Primitive renaming (Set to Type)
+open import Agda.Primitive using () renaming (Set to Type)
 open import Algebra
 open import Data.Sum as Sum
 open import Data.These
 open import Interface.DecEq
+open import Prelude
 open import Relation.Binary.PropositionalEquality
 open import Relation.Nullary.Decidable
 

--- a/src/Axiom/Set/Properties.agda
+++ b/src/Axiom/Set/Properties.agda
@@ -1,17 +1,15 @@
 {-# OPTIONS --safe --no-import-sorts #-}
 
-open import Agda.Primitive renaming (Set to Type)
 open import Axiom.Set
 
 module Axiom.Set.Properties {ℓ} (th : Theory {ℓ}) where
-
-open import Prelude hiding (isEquivalence; trans; filter)
-open Theory th
 
 import Data.List
 import Data.Sum
 import Function.Related.Propositional as R
 import Relation.Nullary.Decidable
+
+open import Agda.Primitive using () renaming (Set to Type)
 open import Data.List.Ext.Properties
 open import Data.List.Membership.DecPropositional using () renaming (_∈?_ to _∈ˡ?_)
 open import Data.List.Membership.Propositional using () renaming (_∈_ to _∈ˡ_)
@@ -22,11 +20,13 @@ open import Data.List.Relation.Unary.Unique.Propositional.Properties.WithK
 open import Data.Product using (map₂)
 open import Function.Related using (toRelated; fromRelated)
 open import Interface.DecEq
+open import Prelude hiding (isEquivalence; trans; filter)
 open import Relation.Binary
 open import Relation.Binary.Lattice
 open import Relation.Binary.Morphism
 open import Relation.Unary using () renaming (Decidable to Dec₁)
 
+open Theory th
 open Equivalence
 
 private variable A B C D : Type ℓ

--- a/src/Axiom/Set/Rel.agda
+++ b/src/Axiom/Set/Rel.agda
@@ -1,33 +1,33 @@
 {-# OPTIONS --safe --no-import-sorts #-}
 {-# OPTIONS -v allTactics:100 #-}
 
-open import Agda.Primitive renaming (Set to Type)
+open import Agda.Primitive using(lzero) renaming (Set to Type)
 open import Axiom.Set
-import Relation.Binary.Reasoning.Setoid as SetoidReasoning
-import Function.Related.Propositional as R
 
 module Axiom.Set.Rel (th : Theory {lzero}) where
-open Theory th
-open import Axiom.Set.Properties th
 
+open import Axiom.Set.Properties th
+open import Data.List.Ext.Properties
+open import Data.Maybe.Base using () renaming (map to map?)
+open import Data.Product.Properties
+open import Data.These hiding (map)
+open import Interface.DecEq
 open import Prelude hiding (filter)
+open import Relation.Binary hiding (Rel)
+open import Relation.Nullary
+open import Relation.Unary using () renaming (Decidable to Dec₁)
+open import Tactic.AnyOf
+open import Tactic.Defaults
 
 import Data.Product
 import Data.Sum
-open import Data.These hiding (map)
-open import Data.List.Ext.Properties
-open import Data.Product.Properties
-open import Data.Maybe.Base using () renaming (map to map?)
-open import Interface.DecEq
-open import Relation.Unary using () renaming (Decidable to Dec₁)
-open import Relation.Nullary
-open import Relation.Binary hiding (Rel)
+import Function.Related.Propositional as R
 import Relation.Binary.PropositionalEquality as I
+import Relation.Binary.Reasoning.Setoid as SetoidReasoning
 
+open Theory th
 open Equivalence
 
-open import Tactic.AnyOf
-open import Tactic.Defaults
 
 -- Because of missing macro hygiene, we have to copy&paste this. https://github.com/agda/agda/issues/3819
 private macro

--- a/src/Axiom/Set/Sum.agda
+++ b/src/Axiom/Set/Sum.agda
@@ -1,6 +1,6 @@
 {-# OPTIONS --safe --no-import-sorts #-}
 
-open import Agda.Primitive renaming (Set to Type)
+open import Agda.Primitive using (lzero) renaming (Set to Type)
 open import Axiom.Set
 open import Algebra using (CommutativeMonoid)
 

--- a/src/Axiom/Set/TotalMap.agda
+++ b/src/Axiom/Set/TotalMap.agda
@@ -1,19 +1,19 @@
 {-# OPTIONS --safe --no-import-sorts #-}
 {-# OPTIONS -v allTactics:100 #-}
 
-open import Agda.Primitive renaming (Set to Type)
 open import Axiom.Set
 
 module Axiom.Set.TotalMap (th : Theory) where
 
-open import Prelude
-
-open Theory th
+open import Agda.Primitive using () renaming (Set to Type)
 open import Axiom.Set.Map th
 open import Axiom.Set.Properties th
 open import Axiom.Set.Rel th
+open import Prelude
 open import Tactic.AnyOf
 open import Tactic.Defaults
+
+open Theory th
 
 private variable A B : Type
 

--- a/src/Ledger/Foreign/HSLedger.agda
+++ b/src/Ledger/Foreign/HSLedger.agda
@@ -1,9 +1,8 @@
 {-# OPTIONS --overlapping-instances #-}
 
-open import Agda.Primitive using () renaming (Set to Type)
-
 module Ledger.Foreign.HSLedger where
 
+open import Agda.Primitive          using () renaming (Set to Type)
 open import Algebra.Morphism        using ( IsCommutativeMonoidMorphism )
 open import Data.Nat                using ( _≤_ ; _≤ᵇ_)
 open import Data.Nat.Properties     using ( +-*-semiring ; <-isStrictTotalOrder )
@@ -94,7 +93,7 @@ HSScriptStructure = record { p1s = HSP1ScriptStructure ; ps = HSP2ScriptStructur
 
 open import Data.Nat
 open import Data.Nat.Properties using (+-0-commutativeMonoid; _≟_)
-open import Ledger.TokenAlgebra using (TokenAlgebra)
+open import Ledger.TokenAlgebra.Base using (TokenAlgebra)
 open import Ledger.Transaction
 
 

--- a/src/Ledger/Foreign/LedgerTypes.agda
+++ b/src/Ledger/Foreign/LedgerTypes.agda
@@ -81,7 +81,7 @@ record PParams : Set where
         maxTxSize        : ℕ
         maxHeaderSize    : ℕ
         maxValSize       : ℕ
-        minUTxOValue     : Coin
+        minUtxOValue     : Coin
         poolDeposit      : Coin
         Emax             : Epoch
         pv               : Pair ℕ ℕ
@@ -101,7 +101,7 @@ record PParams : Set where
     , maxTxSize        :: Integer
     , maxHeaderSize    :: Integer
     , maxValSize       :: Integer
-    , minUTxOValue     :: Integer
+    , minUtxOValue     :: Integer
     , poolDeposit      :: Integer
     , emax             :: Integer
     , pv               :: (Integer, Integer)

--- a/src/Ledger/PDF.lagda
+++ b/src/Ledger/PDF.lagda
@@ -88,6 +88,11 @@ open import Ledger.PPUp
 open import Ledger.PPUp.Properties
 
 open import Ledger.Ledger.Properties
+-- TODO: once holes are filled in `Ledger.TokenAlgebra.ValueSet`
+--       replace the next two lines with `open import Ledger.Tokenalgebra`
+open import Ledger.TokenAlgebra.Base
+open import Ledger.TokenAlgebra.ValueRelation
+
 \end{code}
 
 \include{Ledger/Introduction}

--- a/src/Ledger/PParams.lagda
+++ b/src/Ledger/PParams.lagda
@@ -32,20 +32,20 @@ data PParamGroup : Set where
 
 record PParams : Set where
   field -- Network group
-        maxBlockSize      : ℕ
-        maxTxSize         : ℕ
-        maxHeaderSize     : ℕ
-        maxValSize        : ℕ
-        pv                : ProtVer -- retired, keep for now
+        maxBlockSize     : ℕ
+        maxTxSize        : ℕ
+        maxHeaderSize    : ℕ
+        maxValSize       : ℕ
+        pv               : ProtVer -- retired, keep for now
 
         -- Economic group
-        a                 : ℕ
-        b                 : ℕ
-        minUTxOValue      : Coin
-        poolDeposit       : Coin
+        a                : ℕ
+        b                : ℕ
+        minUtxOValue     : Coin
+        poolDeposit      : Coin
 
         -- Technical group
-        Emax              : Epoch
+        Emax             : Epoch
 
         -- Governance group
         votingThresholds  : ℚ × ℚ

--- a/src/Ledger/TokenAlgebra.lagda
+++ b/src/Ledger/TokenAlgebra.lagda
@@ -1,22 +1,26 @@
-\section{Token algebras}
+\section{Token Algebra}
+\label{sec:token-algebra}
+
 \begin{code}[hide]
 {-# OPTIONS --safe #-}
+
 module Ledger.TokenAlgebra where
 
-open import Ledger.Prelude
-
-open import Algebra using (CommutativeMonoid)
-open import Algebra.Morphism
-open import Data.Integer
-open import Data.Nat.Properties using (+-0-commutativeMonoid)
+open import Agda.Primitive       using() renaming (Set to Type)
+open import Algebra              using (CommutativeMonoid)
+open import Algebra.Morphism     using (IsCommutativeMonoidMorphism-syntax)
+open import Data.Nat.Properties  using (+-0-commutativeMonoid)
+open import Ledger.Prelude       hiding (Rel)
+open import Relation.Binary      using (Rel)
+open import Relation.Unary       using (Pred)
 \end{code}
 
 \begin{figure*}
 \begin{code}
-record TokenAlgebra : Set₁ where
-  field PolicyId : Set
-        Value-CommutativeMonoid : CommutativeMonoid 0ℓ 0ℓ
+record TokenAlgebra : Type₁ where
+  field Value-CommutativeMonoid : CommutativeMonoid 0ℓ 0ℓ
 
+  MemoryEstimate : Type
   MemoryEstimate = ℕ
 \end{code}
 \begin{code}[hide]
@@ -24,19 +28,56 @@ record TokenAlgebra : Set₁ where
        renaming (Carrier to Value; refl to reflᵛ; _∙_ to _+ᵛ_) public
 \end{code}
 \begin{code}
-  field coin      : Value → Coin
-        inject    : Coin → Value
-        policies  : Value → ℙ PolicyId
-        size      : Value → MemoryEstimate
-        _≤ᵗ_      : Value → Value → Set
 
-        property             : coin ∘ inject ≗ id
-        coinIsMonoidMorphism : coin Is Value-CommutativeMonoid -CommutativeMonoid⟶ +-0-commutativeMonoid
+  field coin     : Value → Coin
+        inject   : Coin → Value
+        size                  : Value → MemoryEstimate
+        _≤ᵗ_                  : Rel Value 0ℓ
+        AssetNameType         : Type
+        property              : coin ∘ inject ≗ id
+        coinIsMonoidMorphism  : coin Is Value-CommutativeMonoid -CommutativeMonoid⟶ +-0-commutativeMonoid
+        instance DecEq-Value  : DecEq Value
 \end{code}
 \begin{code}[hide]
-        instance DecEq-Value : DecEq Value
+        -- policies : Value → ℙ PolicyId
+
+  sumᵛ : List Value → Value
+  sumᵛ = foldr _+ᵛ_ (inject 0)
+
 \end{code}
+\caption{Token algebras, used for multi-assets}
+\end{figure*}
+
+
+\subsection{An alternative representation}
+\label{sec:token-algebra}
+
+Here is an altearntive manifestation of the token algebra which uses the \AgdaBound{REL}
+type from the Agda Standard Library instead of the \AgdaBound{Set} type.
+
 \begin{code}
+record TokenAlgebraPoly {ℓ ℓ' : Level} : Type ((sucˡ ℓ) ⊔ˡ (sucˡ ℓ')) where
+  field Value-CommutativeMonoid : CommutativeMonoid ℓ ℓ'
+
+  MemoryEstimate : Type
+  MemoryEstimate = ℕ
+
+  open CommutativeMonoid Value-CommutativeMonoid using (_≈_; ε)
+       renaming (Carrier to Value; refl to reflᵛ; _∙_ to _+ᵛ_) public
+
+  field coin                  : Value → Coin
+        inject                : Coin → Value
+        -- policies              : Value → Pred PolicyId 0ℓ
+        -- (removing policies since here we take Value to be total)
+        size                  : Value → MemoryEstimate
+        _≤ᵗ_                  : Rel Value 0ℓ
+        AssetNameType         : Type
+        specialAsset          : AssetNameType
+        composeToIdentity     : coin ∘ inject ≗ id
+        coinIsMonoidMorphism  : coin Is Value-CommutativeMonoid -CommutativeMonoid⟶ +-0-commutativeMonoid
+
+        -- instance DecEq-AssetName  : DecEq AssetName
+
   sumᵛ : List Value → Value
   sumᵛ = foldr _+ᵛ_ (inject 0)
 \end{code}

--- a/src/Ledger/TokenAlgebra.lagda
+++ b/src/Ledger/TokenAlgebra.lagda
@@ -2,84 +2,10 @@
 \label{sec:token-algebra}
 
 \begin{code}[hide]
-{-# OPTIONS --safe #-}
 
 module Ledger.TokenAlgebra where
 
-open import Agda.Primitive       using() renaming (Set to Type)
-open import Algebra              using (CommutativeMonoid)
-open import Algebra.Morphism     using (IsCommutativeMonoidMorphism-syntax)
-open import Data.Nat.Properties  using (+-0-commutativeMonoid)
-open import Ledger.Prelude       hiding (Rel)
-open import Relation.Binary      using (Rel)
-open import Relation.Unary       using (Pred)
+open import Ledger.TokenAlgebra.Base           public
+open import Ledger.TokenAlgebra.ValueRelation  public
+open import Ledger.TokenAlgebra.ValueSet       public
 \end{code}
-
-\begin{figure*}
-\begin{code}
-record TokenAlgebra : Type₁ where
-  field Value-CommutativeMonoid : CommutativeMonoid 0ℓ 0ℓ
-
-  MemoryEstimate : Type
-  MemoryEstimate = ℕ
-\end{code}
-\begin{code}[hide]
-  open CommutativeMonoid Value-CommutativeMonoid using (_≈_; ε)
-       renaming (Carrier to Value; refl to reflᵛ; _∙_ to _+ᵛ_) public
-\end{code}
-\begin{code}
-
-  field coin     : Value → Coin
-        inject   : Coin → Value
-        size                  : Value → MemoryEstimate
-        _≤ᵗ_                  : Rel Value 0ℓ
-        AssetNameType         : Type
-        property              : coin ∘ inject ≗ id
-        coinIsMonoidMorphism  : coin Is Value-CommutativeMonoid -CommutativeMonoid⟶ +-0-commutativeMonoid
-        instance DecEq-Value  : DecEq Value
-\end{code}
-\begin{code}[hide]
-        -- policies : Value → ℙ PolicyId
-
-  sumᵛ : List Value → Value
-  sumᵛ = foldr _+ᵛ_ (inject 0)
-
-\end{code}
-\caption{Token algebras, used for multi-assets}
-\end{figure*}
-
-
-\subsection{An alternative representation}
-\label{sec:token-algebra}
-
-Here is an altearntive manifestation of the token algebra which uses the \AgdaBound{REL}
-type from the Agda Standard Library instead of the \AgdaBound{Set} type.
-
-\begin{code}
-record TokenAlgebraPoly {ℓ ℓ' : Level} : Type ((sucˡ ℓ) ⊔ˡ (sucˡ ℓ')) where
-  field Value-CommutativeMonoid : CommutativeMonoid ℓ ℓ'
-
-  MemoryEstimate : Type
-  MemoryEstimate = ℕ
-
-  open CommutativeMonoid Value-CommutativeMonoid using (_≈_; ε)
-       renaming (Carrier to Value; refl to reflᵛ; _∙_ to _+ᵛ_) public
-
-  field coin                  : Value → Coin
-        inject                : Coin → Value
-        -- policies              : Value → Pred PolicyId 0ℓ
-        -- (removing policies since here we take Value to be total)
-        size                  : Value → MemoryEstimate
-        _≤ᵗ_                  : Rel Value 0ℓ
-        AssetNameType         : Type
-        specialAsset          : AssetNameType
-        composeToIdentity     : coin ∘ inject ≗ id
-        coinIsMonoidMorphism  : coin Is Value-CommutativeMonoid -CommutativeMonoid⟶ +-0-commutativeMonoid
-
-        -- instance DecEq-AssetName  : DecEq AssetName
-
-  sumᵛ : List Value → Value
-  sumᵛ = foldr _+ᵛ_ (inject 0)
-\end{code}
-\caption{Token algebras, used for multi-assets}
-\end{figure*}

--- a/src/Ledger/TokenAlgebra/Base.lagda
+++ b/src/Ledger/TokenAlgebra/Base.lagda
@@ -1,0 +1,91 @@
+\section{Token Algebra}
+\label{sec:token-algebra}
+
+\begin{code}[hide]
+{-# OPTIONS --safe #-}
+
+module Ledger.TokenAlgebra.Base where
+
+open import Agda.Primitive       using() renaming (Set to Type)
+open import Algebra              using (CommutativeMonoid)
+open import Algebra.Morphism     using (IsCommutativeMonoidMorphism-syntax)
+open import Data.Nat.Properties  using (+-0-commutativeMonoid)
+open import Ledger.Prelude       hiding (Rel)
+open import Relation.Binary      using (Rel)
+open import Relation.Unary       using (Pred)
+\end{code}
+
+\begin{figure*}
+\begin{code}
+record TokenAlgebra : Type₁ where
+  field Value-CommutativeMonoid : CommutativeMonoid 0ℓ 0ℓ
+
+  MemoryEstimate : Type
+  MemoryEstimate = ℕ
+\end{code}
+\begin{code}[hide]
+  open CommutativeMonoid Value-CommutativeMonoid using (_≈_; ε)
+       renaming (Carrier to Value; refl to reflᵛ; _∙_ to _+ᵛ_) public
+\end{code}
+\begin{code}
+
+  field coin     : Value → Coin
+        inject   : Coin → Value
+        size                  : Value → MemoryEstimate
+        _≤ᵗ_                  : Rel Value 0ℓ
+        AssetNameType         : Type
+        property              : coin ∘ inject ≗ id
+        coinIsMonoidMorphism  : coin Is Value-CommutativeMonoid -CommutativeMonoid⟶ +-0-commutativeMonoid
+        instance DecEq-Value  : DecEq Value
+\end{code}
+\begin{code}[hide]
+        -- policies : Value → ℙ PolicyId
+
+  sumᵛ : List Value → Value
+  sumᵛ = foldr _+ᵛ_ (inject 0)
+
+\end{code}
+\caption{Token algebras, used for multi-assets}
+\end{figure*}
+
+
+\subsection{An alternative representation}
+\label{sec:token-algebra}
+
+Here is an altearntive manifestation of the token algebra which uses the \AgdaBound{REL}
+type from the Agda Standard Library instead of the \AgdaBound{Set} type.
+
+\begin{code}
+record TokenAlgebraPoly {ℓ ℓ' : Level} : Type ((sucˡ ℓ) ⊔ˡ (sucˡ ℓ')) where
+  field Value-CommutativeMonoid : CommutativeMonoid ℓ ℓ'
+
+  MemoryEstimate : Type
+  MemoryEstimate = ℕ
+
+  open CommutativeMonoid Value-CommutativeMonoid using (_≈_; ε)
+       renaming (Carrier to Value; refl to reflᵛ; _∙_ to _+ᵛ_) public
+
+  field coin                  : Value → Coin
+        inject                : Coin → Value
+        -- policies              : Value → Pred PolicyId 0ℓ
+        -- (removing policies since here we take Value to be total)
+        size                  : Value → MemoryEstimate
+        _≤ᵗ_                  : Rel Value 0ℓ
+        AssetNameType         : Type
+        specialAsset          : AssetNameType
+        composeToIdentity     : coin ∘ inject ≗ id
+        coinIsMonoidMorphism  : coin Is Value-CommutativeMonoid -CommutativeMonoid⟶ +-0-commutativeMonoid
+
+        -- instance DecEq-AssetName  : DecEq AssetName
+
+  sumᵛ : List Value → Value
+  sumᵛ = foldr _+ᵛ_ (inject 0)
+\end{code}
+\caption{Token algebras, used for multi-assets}
+\end{figure*}
+
+
+\begin{code}
+Quantity : Type
+Quantity = ℕ
+\end{code}

--- a/src/Ledger/TokenAlgebra/ValueRelation.lagda
+++ b/src/Ledger/TokenAlgebra/ValueRelation.lagda
@@ -1,0 +1,205 @@
+n\subsection{Value Relation}
+\label{sec:value-relation}
+
+\begin{code}[hide]
+{-# OPTIONS --safe #-}
+
+open import Agda.Primitive  using () renaming (Set to Type)
+
+module Ledger.TokenAlgebra.ValueRelation (PolicyId : Type) where
+
+open import Algebra                      using (CommutativeMonoid ; Commutative ; Op₂)
+open import Algebra.Morphism             using (IsMonoidMorphism ; IsSemigroupMorphism)
+open import Algebra.Morphism             using (IsCommutativeMonoidMorphism-syntax)
+open import Data.Nat.Properties          hiding (_≟_)
+open import Data.Nat using (_≤_)
+
+open import Data.Product.Base            using (swap)
+open import Data.Sum.Base                using ([_,_]′)
+open import Ledger.Prelude               hiding (Rel ; _>_ )
+open import Ledger.TokenAlgebra PolicyId using (TokenAlgebraPoly)
+open import Prelude
+open import Relation.Binary              using (REL ; Rel ; _⇒_ ; IsEquivalence ; Decidable) renaming (_⇔_ to _⇐⇒_ )
+open import Relation.Binary.Definitions  using (Decidable ; DecidableEquality)
+open import Relation.Binary.PropositionalEquality using (≡-≟-identity)
+open import Relation.Binary.PropositionalEquality.Core using ( module ≡-Reasoning )
+
+private
+  variable
+    A B : Type
+    C : REL A B 0ℓ → Type 0ℓ
+
+\end{code}
+
+\subsubsection{Derived types}
+
+(See Fig 3 of the
+\href{https://github.com/input-output-hk/cardano-ledger/releases/latest/download/mary-ledger.pdf}%
+{Mary ledger specification}.)
+
+\begin{itemize}
+\item \AgdaBound{AssetName} is a byte string used to distinguish different assets with the same \AgdaBound{PolicyId}.
+\item \AgdaBound{AssetId} is a product type consisting of a \AgdaBound{PolicyId} and an \AgdaBound{AssetName}.
+\item \AgdaBound{AdaId} is the Id for the asset Ada.
+\item \AgdaBound{Quantity} is the type of amounts of assets.
+\end{itemize}
+
+In the formal ledger specification \AgdaBound{AssetId} is sometimes viewed as a direct sum type,
+the inhabitants of which belong to either \AgdaBound{AdaIdType} or the product
+\AgdaBound{PolicyId}~\AgdaBound{×}~\AgdaBound{AssetName}; if we were adhering to that point of view,
+then we would have defined
+\AgdaBound{AssetId}
+  = \AgdaBound{AdaIdType}~\AgdaBound{⊎}~(\AgdaBound{PolicyId}~\AgdaBound{×}~\AgdaBound{AssetName}).
+
+\begin{code}
+Quantity : Type
+Quantity = ℕ
+\end{code}
+
+Finally, we define a record type with a single inhabitant with which we may wish to
+represent the type of Ada (rather than viewing Ada as just another asset).
+
+\begin{code}
+record AdaIdType : Type where
+  instance constructor AdaId
+\end{code}
+
+
+
+\begin{code}[hide]
+⇐⇒-isEquivalence : IsEquivalence {A = REL A B 0ℓ} _⇐⇒_
+IsEquivalence.refl ⇐⇒-isEquivalence = id , id
+IsEquivalence.sym ⇐⇒-isEquivalence = swap
+proj₁ (IsEquivalence.trans ⇐⇒-isEquivalence ij jk) ixy = (proj₁ jk) ((proj₁ ij) ixy)
+proj₂ (IsEquivalence.trans ⇐⇒-isEquivalence ij jk) kxy = (proj₂ ij) ((proj₂ jk) kxy)
+
+_≋_ : Rel (A → B) 0ℓ
+u ≋ v = ∀{a} → u a ≡ v a
+
+≋-isEquivalence : IsEquivalence {A = A → B} _≋_
+IsEquivalence.refl ≋-isEquivalence = refl
+IsEquivalence.sym ≋-isEquivalence x = sym x
+IsEquivalence.trans ≋-isEquivalence x y = trans x y
+
+_≈_ : Rel (REL A B 0ℓ) 0ℓ
+u ≈ v = u ⇐⇒ v
+
+≈-isEquivalence : IsEquivalence {A = REL A B 0ℓ} _≈_
+IsEquivalence.refl ≈-isEquivalence = IsEquivalence.refl ⇐⇒-isEquivalence
+IsEquivalence.sym ≈-isEquivalence xy = IsEquivalence.sym ⇐⇒-isEquivalence xy
+IsEquivalence.trans ≈-isEquivalence ij jk = IsEquivalence.trans ⇐⇒-isEquivalence ij jk
+\end{code}
+
+\subsection{Definition of the value monoid}
+
+An inhabitant of `Value` is a map denoting a finite collection of quantities of assets.
+
+\begin{code}
+open TokenAlgebraPoly
+open CommutativeMonoid renaming (_∙_ to _⋆_) hiding (refl ; sym ; trans)
+open Algebra
+
+
+Value-TokenAlgebra :  (specialPolicy  : PolicyId)
+                      (assetNameType  : Type)
+                      (specialAsset   : assetNameType)
+                      (sz             : ((PolicyId × assetNameType) → Quantity) → ℕ)
+                      (dec-eq         : DecEq assetNameType)
+                      ---------------------------------------------------
+ →                    TokenAlgebraPoly
+
+Value-TokenAlgebra specialPolicy assetNameType specialAsset₁ sz dec-eq =
+  record
+    { Value-CommutativeMonoid = Vcm
+    ; coin = λ u → u (specialPolicy , specialAsset₁)
+    ; inject = injectSpecial
+    ; size = sz
+    ; _≤ᵗ_ = λ u v → ∀ x → u x ≤ v x
+    ; AssetNameType = assetNameType
+    ; specialAsset = specialAsset₁
+    ; composeToIdentity = compose-to-id
+    ; coinIsMonoidMorphism = mcm
+    }
+
+  where
+
+  instance
+    DecEq-AssetName : DecEq assetNameType
+    DecEq-AssetName = dec-eq
+
+
+  AssetId : Type
+  AssetId = PolicyId × assetNameType
+
+  ι : AssetId → Quantity
+  ι = λ _ → 0
+
+  open ≡-Reasoning
+
+  _⊕_ : Op₂ (AssetId → Quantity)
+  Ru ⊕ Rv = λ x → (Ru x) + (Rv x)
+
+  ι-identity : Algebra.Identity _≋_ ι _⊕_
+  proj₁ ι-identity = λ x → refl
+  proj₂ ι-identity x {a} =  begin
+    x a + ι a  ≡⟨ cong (λ z → x a + z) refl ⟩
+    x a + 0    ≡⟨ +-comm (x a) 0 ⟩
+    x a        ∎
+
+  ⊕-comm : Algebra.Commutative _≋_ _⊕_
+  ⊕-comm x y {a} = +-comm (x a) (y a)
+
+  ⊕-assoc : Algebra.Associative _≋_ _⊕_
+  ⊕-assoc x y z {a} = +-assoc (x a) (y a) (z a)
+
+  ⊕-cong : Algebra.Congruent₂ _≋_ _⊕_
+  ⊕-cong xy uv = cong₂ _+_ xy uv
+
+  injectHelper : ∀ {q}{asset}{specialAsset₁} → Dec (asset ≡ specialAsset₁) → Quantity
+  injectHelper (false because _) = 0
+  injectHelper {q} (true because _) = q
+
+
+  injectSpecial : Quantity → AssetId → Quantity
+  injectSpecial q (pid , asset) = injectHelper {q} (asset ≟ specialAsset₁)
+
+
+  compose-to-id : ∀ q → injectSpecial q (specialPolicy , specialAsset₁) ≡ q
+  compose-to-id q = begin
+    injectSpecial q (specialPolicy , specialAsset₁)            ≡⟨ refl ⟩
+    injectHelper (specialAsset₁ ≟ specialAsset₁)               ≡⟨ cong (λ x → injectHelper x) (≡-≟-identity _≟_ refl) ⟩
+    injectHelper {q}{specialAsset₁}{specialAsset₁} (yes refl)  ≡⟨ refl ⟩
+    q                                                          ∎
+
+
+  -- Vcm is a `CommutativeMonoid` whose elements are maps, where each map denotes a finite
+  -- collections of quantities of assets.
+  Vcm : CommutativeMonoid 0ℓ 0ℓ
+  Vcm =
+    record
+      { Carrier = AssetId → Quantity
+      ; _≈_ = _≋_
+      ; _∙_ = _⊕_
+      ; ε = ι
+      ; isCommutativeMonoid = record { isMonoid = Vm ; comm = ⊕-comm } }
+      where
+      isSemigrp : IsSemigroup _≋_ _⊕_
+      isSemigrp = record
+          { isMagma = record
+              { isEquivalence = ≋-isEquivalence
+              ; ∙-cong = λ{u}{v}{w}{x} y z → ⊕-cong {u}{v}{w}{x} y z }
+          ; assoc = ⊕-assoc }
+
+      Vm : IsMonoid _≋_ _⊕_ ι
+      Vm = record { isSemigroup = isSemigrp ; identity = ι-identity }
+
+  open Algebra.Morphism
+
+  mcm : IsCommutativeMonoidMorphism Vcm +-0-commutativeMonoid (λ u → u (specialPolicy , specialAsset₁))
+  IsSemigroupMorphism.⟦⟧-cong (IsMonoidMorphism.sm-homo (IsCommutativeMonoidMorphism.mn-homo mcm)) = λ z → z
+  IsSemigroupMorphism.∙-homo (IsMonoidMorphism.sm-homo (IsCommutativeMonoidMorphism.mn-homo mcm)) = λ x y → refl
+  IsMonoidMorphism.ε-homo (IsCommutativeMonoidMorphism.mn-homo mcm) = refl
+
+
+\end{code}
+

--- a/src/Ledger/TokenAlgebra/ValueRelation.lagda
+++ b/src/Ledger/TokenAlgebra/ValueRelation.lagda
@@ -1,4 +1,4 @@
-n\subsection{Value Relation}
+\subsection{Value Relation}
 \label{sec:value-relation}
 
 \begin{code}[hide]
@@ -17,7 +17,7 @@ open import Data.Nat using (_≤_)
 open import Data.Product.Base            using (swap)
 open import Data.Sum.Base                using ([_,_]′)
 open import Ledger.Prelude               hiding (Rel ; _>_ )
-open import Ledger.TokenAlgebra PolicyId using (TokenAlgebraPoly)
+open import Ledger.TokenAlgebra.Base     using (TokenAlgebraPoly ; Quantity)
 open import Prelude
 open import Relation.Binary              using (REL ; Rel ; _⇒_ ; IsEquivalence ; Decidable) renaming (_⇔_ to _⇐⇒_ )
 open import Relation.Binary.Definitions  using (Decidable ; DecidableEquality)
@@ -50,19 +50,6 @@ the inhabitants of which belong to either \AgdaBound{AdaIdType} or the product
 then we would have defined
 \AgdaBound{AssetId}
   = \AgdaBound{AdaIdType}~\AgdaBound{⊎}~(\AgdaBound{PolicyId}~\AgdaBound{×}~\AgdaBound{AssetName}).
-
-\begin{code}
-Quantity : Type
-Quantity = ℕ
-\end{code}
-
-Finally, we define a record type with a single inhabitant with which we may wish to
-represent the type of Ada (rather than viewing Ada as just another asset).
-
-\begin{code}
-record AdaIdType : Type where
-  instance constructor AdaId
-\end{code}
 
 
 
@@ -100,7 +87,7 @@ open CommutativeMonoid renaming (_∙_ to _⋆_) hiding (refl ; sym ; trans)
 open Algebra
 
 
-Value-TokenAlgebra :  (specialPolicy  : PolicyId)
+Value-TokenAlgebraPoly :  (specialPolicy  : PolicyId)
                       (assetNameType  : Type)
                       (specialAsset   : assetNameType)
                       (sz             : ((PolicyId × assetNameType) → Quantity) → ℕ)
@@ -108,7 +95,7 @@ Value-TokenAlgebra :  (specialPolicy  : PolicyId)
                       ---------------------------------------------------
  →                    TokenAlgebraPoly
 
-Value-TokenAlgebra specialPolicy assetNameType specialAsset₁ sz dec-eq =
+Value-TokenAlgebraPoly specialPolicy assetNameType specialAsset₁ sz dec-eq =
   record
     { Value-CommutativeMonoid = Vcm
     ; coin = λ u → u (specialPolicy , specialAsset₁)

--- a/src/Ledger/TokenAlgebra/ValueSet.lagda
+++ b/src/Ledger/TokenAlgebra/ValueSet.lagda
@@ -1,7 +1,12 @@
 n\subsection{Value Set}
 \begin{code}[hide]
-{-# OPTIONS --safe --no-import-sorts #-}
-{-# OPTIONS -v allTactics:100 #-}
+
+-- !!!!!!! TODO: REMOVE THE NEXT LINE WHEN ALL HOLES ARE FILLED!!!!!!!!
+{-# OPTIONS --allow-unsolved-metas #-}
+
+-- !!!!!!! TODO: UNCOMMENT THE NEXT TWO LINES WHEN ALL HOLES ARE FILLED!!!!!!!!
+-- {-# OPTIONS --safe --no-import-sorts #-}
+-- {-# OPTIONS -v allTactics:100 #-}
 
 open import Agda.Primitive using (lzero) renaming (Set to Type)
 open import Axiom.Set using (Theory)
@@ -19,15 +24,15 @@ open import Data.Nat                      using (ℕ ; _≤_ ; _+_)
 open import Data.Nat.Properties           using (+-0-commutativeMonoid)
 
 open import Ledger.Prelude                using ( DecEq )
-open import Ledger.TokenAlgebra PolicyId  using ( TokenAlgebra )
+open import Ledger.TokenAlgebra.Base      using ( TokenAlgebra ; Quantity)
 
 open import Prelude                       using ( _,_ ; _×_ ; module Equivalence; _∘_ ; _≗_ ; id )
 open import Prelude                       using ( _≡_ ; refl ; 0ℓ; trans ; sym)
 
 open import Relation.Binary               using (IsEquivalence )
 
-open Theory th                            using (_∈_ ; spec-∈ ; Set ; singleton ; ∈-singleton)
-                                          renaming (map to mapˢ)
+open Theory th                            using (_∈_ ; spec-∈ ; singleton ; ∈-singleton)
+                                          renaming (map to mapˢ ; Set to Set' )
 open import Relation.Binary.PropositionalEquality.Core using ( module ≡-Reasoning )
 import Relation.Binary.Core  as stdlib
 
@@ -52,11 +57,6 @@ the inhabitants of which belong to either \AgdaBound{AdaIdType} or the product
 then we would have defined
 \AgdaBound{AssetId}
   = \AgdaBound{AdaIdType}~\AgdaBound{⊎}~(\AgdaBound{PolicyId}~\AgdaBound{×}~\AgdaBound{AssetName}).
-
-\begin{code}
-Quantity : Type
-Quantity = ℕ
-\end{code}
 
 Finally, we define a record type with a single inhabitant with which we may wish to
 represent the type of Ada (rather than viewing Ada as just another asset).
@@ -164,7 +164,7 @@ Value-TokenAlgebra assetNameType isTotal specialPolicy specialAsset decEqVal sz 
     u ⊕ v = m , lu
       where
 
-      m : Set(AssetId × Quantity)
+      m : Set'(AssetId × Quantity)
       m = {!!}
       -- PROBLEM/QUESTION.
       -- I want an `m` such that `lookupᵐ m a` is the function:
@@ -238,7 +238,7 @@ Value-TokenAlgebra assetNameType isTotal specialPolicy specialAsset decEqVal sz 
 
   ------------------------------------------------------------------------------------------------------
   -- odds and ends -------------------------------------------------------------------------------------
-  coinQzeroAsSet : Set(AssetId × Quantity)
+  coinQzeroAsSet : Set'(AssetId × Quantity)
   coinQzeroAsSet = singleton (specId , 0)
 
 

--- a/src/Ledger/TokenAlgebra/ValueSet.lagda
+++ b/src/Ledger/TokenAlgebra/ValueSet.lagda
@@ -1,0 +1,249 @@
+n\subsection{Value Set}
+\begin{code}[hide]
+{-# OPTIONS --safe --no-import-sorts #-}
+{-# OPTIONS -v allTactics:100 #-}
+
+open import Agda.Primitive using (lzero) renaming (Set to Type)
+open import Axiom.Set using (Theory)
+
+module Ledger.TokenAlgebra.ValueSet (PolicyId : Type)(th : Theory {lzero}) where
+
+open import Algebra                       using (CommutativeMonoid ; Commutative ; Op₂ ; Monoid)
+open import Algebra.Morphism              using ( IsMonoidMorphism ; IsSemigroupMorphism )
+
+open import Axiom.Set.Map th              using (_ˢ ; module Lookupᵐ ; singletonᵐ ; ❴_❵ᵐ)
+                                          renaming ( Map to _⇀_ )
+open import Axiom.Set.Rel th              using ( dom )
+
+open import Data.Nat                      using (ℕ ; _≤_ ; _+_)
+open import Data.Nat.Properties           using (+-0-commutativeMonoid)
+
+open import Ledger.Prelude                using ( DecEq )
+open import Ledger.TokenAlgebra PolicyId  using ( TokenAlgebra )
+
+open import Prelude                       using ( _,_ ; _×_ ; module Equivalence; _∘_ ; _≗_ ; id )
+open import Prelude                       using ( _≡_ ; refl ; 0ℓ; trans ; sym)
+
+open import Relation.Binary               using (IsEquivalence )
+
+open Theory th                            using (_∈_ ; spec-∈ ; Set ; singleton ; ∈-singleton)
+                                          renaming (map to mapˢ)
+open import Relation.Binary.PropositionalEquality.Core using ( module ≡-Reasoning )
+import Relation.Binary.Core  as stdlib
+
+\end{code}
+
+\subsubsection{Derived types}
+
+(See Fig 3 of the
+\href{https://github.com/input-output-hk/cardano-ledger/releases/latest/download/mary-ledger.pdf}%
+{Mary ledger specification}.)
+
+\begin{itemize}
+\item \AgdaBound{AssetName} is a byte string used to distinguish different assets with the same \AgdaBound{PolicyId}.
+\item \AgdaBound{AssetId} is a product type consisting of a \AgdaBound{PolicyId} and an \AgdaBound{AssetName}.
+\item \AgdaBound{AdaId} is the Id for the asset Ada.
+\item \AgdaBound{Quantity} is the type of amounts of assets.
+\end{itemize}
+
+In the formal ledger specification \AgdaBound{AssetId} is sometimes viewed as a direct sum type,
+the inhabitants of which belong to either \AgdaBound{AdaIdType} or the product
+\AgdaBound{PolicyId}~\AgdaBound{×}~\AgdaBound{AssetName}; if we were adhering to that point of view,
+then we would have defined
+\AgdaBound{AssetId}
+  = \AgdaBound{AdaIdType}~\AgdaBound{⊎}~(\AgdaBound{PolicyId}~\AgdaBound{×}~\AgdaBound{AssetName}).
+
+\begin{code}
+Quantity : Type
+Quantity = ℕ
+\end{code}
+
+Finally, we define a record type with a single inhabitant with which we may wish to
+represent the type of Ada (rather than viewing Ada as just another asset).
+
+\begin{code}
+record AdaIdType : Type where
+  instance constructor AdaId
+\end{code}
+
+
+\subsection{Definition of the value monoid}
+
+An inhabitant of `Value` is a map denoting a finite collection of quantities of assets.
+
+\begin{code}
+open TokenAlgebra
+open CommutativeMonoid renaming (_∙_ to _⋆_) hiding (refl ; sym ; trans)
+open Algebra
+
+
+Value-TokenAlgebra :  (assetNameType  : Type                                       )
+                      (isTotal        : ∀ x {m : (PolicyId × assetNameType) ⇀ Quantity} → x ∈ dom (m ˢ))
+                      (specialPolicy  : PolicyId                                   )
+                      (specialAsset   : assetNameType                              )
+                      (decEqVal       : DecEq ((PolicyId × assetNameType) ⇀ Quantity))
+                      (sz             : (PolicyId × assetNameType) ⇀ Quantity → ℕ  )
+                      -----------------------------------------------------------------------
+  →                   TokenAlgebra
+
+
+Value-TokenAlgebra assetNameType isTotal specialPolicy specialAsset decEqVal sz =
+  record
+    { Value-CommutativeMonoid = Vcm
+    ; coin = λ u → lookupᵐ u specId {isTotal specId {u} }
+    ; inject = λ c → ❴ specId , c ❵ᵐ
+    -- ; policies = {!!}
+    ; size = sz
+    ; _≤ᵗ_ = _≤'_
+    ; AssetNameType = assetNameType
+    ; property = compose-to-id
+    ; coinIsMonoidMorphism = CoinMM
+    ; DecEq-Value = decEqVal
+    }
+  where
+
+  AssetId : Type
+  AssetId = PolicyId × assetNameType
+
+  sp∈ : spec-∈ AssetId
+  sp∈ {X} = {!!}
+  -- QUESTION/PROBLEM.
+  -- I seem to need an inhabitant of `spec-∈ AssetId` but
+  -- I don't know why and I don't know how to get one.
+
+  open Lookupᵐ sp∈
+
+  specId : AssetId
+  specId = specialPolicy , specialAsset
+
+  open ≡-Reasoning
+  open Equivalence
+
+  compose-to-id : (λ u → lookupᵐ u specId {isTotal specId {u}} ) ∘ (singletonᵐ specId) ≗ id
+  compose-to-id = goal
+    where
+    goal : (λ u → lookupᵐ u specId {isTotal specId {u}} ) ∘ singletonᵐ specId ≗ id
+    goal q = begin
+      ((λ u → lookupᵐ u specId {isTotal specId {u}}) ∘ singletonᵐ specId) q  ≡⟨ refl ⟩
+      (λ u → lookupᵐ u specId {isTotal specId {u}}) (singletonᵐ specId q)  ≡⟨ {!!} ⟩
+      -- proj₁ (to {!!} {!!}) (singletonᵐ specId q) specId    ≡⟨ {!!} ⟩
+      q                                                 ∎
+
+
+
+  _≤'_ : (u v : AssetId ⇀ Quantity) → Type
+  u ≤' v = ∀ {x : AssetId} → uval x ≤ vval x
+   where
+   uval vval :  AssetId → Quantity
+   uval = λ aid → lookupᵐ u aid {isTotal aid {u} }
+   vval = λ aid → lookupᵐ v aid {isTotal aid {v} }
+
+
+  open CommutativeMonoid hiding (refl ; sym ; trans)
+  open Algebra
+
+  Vcm : CommutativeMonoid 0ℓ 0ℓ
+  Vcm =
+    record
+      { Carrier = AssetId ⇀ Quantity
+      ; _≈_ = _≋_
+      ; _∙_ = _⊕_
+      ; ε = ι
+      ; isCommutativeMonoid = record { isMonoid = Vm ; comm = ⊕-comm }
+      }
+    where
+    _≋_ : stdlib.Rel (AssetId ⇀ Quantity) 0ℓ
+    u ≋ v = ∀ {a} → lookupᵐ u a {isTotal a {u} } ≡ lookupᵐ v a {isTotal a {v} }
+
+    ≋-isEquivalence : IsEquivalence {0ℓ} _≋_
+    IsEquivalence.refl ≋-isEquivalence = refl
+    IsEquivalence.sym ≋-isEquivalence {x} {y} x≋y {a} = sym x≋y
+    IsEquivalence.trans ≋-isEquivalence x y = trans x y
+
+    _⊕_ : Op₂ (AssetId ⇀ Quantity)
+    u ⊕ v = m , lu
+      where
+
+      m : Set(AssetId × Quantity)
+      m = {!!}
+      -- PROBLEM/QUESTION.
+      -- I want an `m` such that `lookupᵐ m a` is the function:
+      --
+      --    λ u v → ∀ {a} → (lookupᵐ u a {isTotal a {u} }) + (lookupᵐ v a {isTotal a {v} })
+      --
+      -- How to acheive this?
+
+      lu : ∀{a}{b}{b'} → ((a , b) ∈ m → (a , b') ∈ m → b ≡ b')
+      lu {a}{b}{b'} h₀ h₁ = {!!}
+
+    ⊕-comm : Algebra.Commutative _≋_ _⊕_
+    ⊕-comm x y {a} = {!!}                   -- old proof: +-comm (x a) (y a)
+
+    ⊕-assoc : Algebra.Associative _≋_ _⊕_
+    ⊕-assoc x y z {a} = {!!}                -- old proof: +-assoc (x a) (y a) (z a)
+
+    ⊕-cong : Algebra.Congruent₂ _≋_ _⊕_
+    ⊕-cong xy uv = {!!}                     -- old proof: cong₂ _+_ xy uv
+
+
+    ι : AssetId ⇀ Quantity
+    ι = mapˢ f {!!} , {!!}
+      where
+      f : AssetId × Quantity → AssetId × Quantity
+      f (aid , q) = aid , 0
+
+
+    ι-identity : Algebra.Identity _≋_ ι _⊕_
+    ι-identity = lid , rid
+     where
+     lid : ∀ x {a} → (lookupᵐ (ι ⊕ x) a {isTotal a}) ≡ (lookupᵐ x a {isTotal a})
+     lid x {a} = {!!} -- cong (λ u → lookupᵐ u a {isTotal a}) {!!}
+     rid : ∀ x {a} → (lookupᵐ (x ⊕ ι) a {isTotal a}) ≡ (lookupᵐ x a {isTotal a})
+     rid x {a} = {!!}
+
+     -- OLD PROOF
+     -- ι-identity : Algebra.Identity _≋_ ι _⊕_
+     -- proj₁ ι-identity = λ x → refl
+     -- proj₂ ι-identity x {a} =  begin
+     --   x a + ι a  ≡⟨ cong (λ z → x a + z) refl ⟩
+     --   x a + 0    ≡⟨ +-comm (x a) 0 ⟩
+     --   x a        ∎
+
+
+    isSemigrp : IsSemigroup _≋_ _⊕_
+    isSemigrp = record
+        { isMagma = record
+            { isEquivalence = ≋-isEquivalence
+            ; ∙-cong = λ{u}{v}{w}{x} y z → ⊕-cong {u}{v}{w}{x} y z }
+        ; assoc = ⊕-assoc }
+
+    Vm : IsMonoid _≋_ _⊕_ ι
+    Vm = record { isSemigroup = isSemigrp ; identity = ι-identity }
+
+
+
+  open Algebra.Morphism
+  open IsSemigroupMorphism
+  open IsMonoidMorphism
+  open IsCommutativeMonoidMorphism
+
+  CoinMM :  IsCommutativeMonoidMorphism-syntax Vcm +-0-commutativeMonoid
+         λ u → lookupᵐ u specId {isTotal specId {u}}
+
+  ⟦⟧-cong  (sm-homo (mn-homo CoinMM)) = λ z → z
+  ∙-homo   (sm-homo (mn-homo CoinMM)) (x , xlu) (y , ylu) = {!!} -- old proof: λ _ _ → refl
+  ε-homo   (mn-homo CoinMM) = {!!}                               -- old proof: refl
+
+
+
+  ------------------------------------------------------------------------------------------------------
+  -- odds and ends -------------------------------------------------------------------------------------
+  coinQzeroAsSet : Set(AssetId × Quantity)
+  coinQzeroAsSet = singleton (specId , 0)
+
+
+  P : AssetId × Quantity → Type
+  P ( _ , q) = q ≡ 0
+
+\end{code}
+

--- a/src/Ledger/Transaction.lagda
+++ b/src/Ledger/Transaction.lagda
@@ -15,7 +15,7 @@ open import Ledger.Epoch
 import Ledger.PParams
 import Ledger.Script
 import Ledger.GovernanceActions
-import Ledger.TokenAlgebra as TA
+import Ledger.TokenAlgebra.Base as TA
 
 record TransactionStructure : Set₁ where
   field

--- a/src/Ledger/Transaction.lagda
+++ b/src/Ledger/Transaction.lagda
@@ -12,10 +12,10 @@ open import Ledger.Prelude
 
 open import Ledger.Crypto
 open import Ledger.Epoch
-open import Ledger.TokenAlgebra
 import Ledger.PParams
 import Ledger.Script
 import Ledger.GovernanceActions
+import Ledger.TokenAlgebra as TA
 
 record TransactionStructure : Set₁ where
   field
@@ -35,11 +35,15 @@ the transaction body are:
   \item The size and the hash of the serialized form of the transaction that was included in the block.
 \end{itemize}
 
+Finally, $\fun{txid}$ computes the transaction id of a given transaction.
+This function must produce a unique id for each unique transaction body.
+\textbf{We assume that} $\fun{txid}$ \textbf{is injective.}
+
 \begin{figure*}[h]
 \emph{Abstract types}
-\AgdaTarget{Ix, TxId, Epoch, AuxiliaryData}
+\AgdaTarget{Ix, TxId, Epoch, AuxiliaryData, PolicyIdType, AssetNameType}
 \begin{code}
-        Ix TxId AuxiliaryData : Set
+        Ix TxId AuxiliaryData PolicyIdType AssetNameType : Set
 \end{code}
 \begin{code}[hide]
         epochStructure                      : EpochStructure
@@ -53,17 +57,19 @@ the transaction body are:
         ppUpd                               : Ledger.PParams.PParamsDiff epochStructure
         txidBytes                           : TxId → Crypto.Ser crypto
         networkId                           : Network
-        tokenAlgebra                        : TokenAlgebra
         instance DecEq-TxId  : DecEq TxId
                  DecEq-Ix    : DecEq Ix
                  DecEq-Netw  : DecEq Network
                  DecEq-UpdT  : DecEq (Ledger.PParams.PParamsDiff.UpdateT ppUpd)
 
   open Crypto crypto public
-  open TokenAlgebra tokenAlgebra public
+  open TA
   open isHashableSet adHashingScheme renaming (THash to ADHash) public
 
-  field ss : Ledger.Script.ScriptStructure KeyHash ScriptHash Slot
+  field  ss            : Ledger.Script.ScriptStructure KeyHash ScriptHash Slot
+         tokenAlgebra  : TokenAlgebra
+
+  open TokenAlgebra tokenAlgebra public
 
   open Ledger.Script.ScriptStructure ss public
 

--- a/src/Ledger/Utxo.lagda
+++ b/src/Ledger/Utxo.lagda
@@ -30,7 +30,7 @@ open Tx
 
 open import Ledger.Crypto
 open import Ledger.PParams epochStructure
-open import Ledger.TokenAlgebra using (TokenAlgebra)
+open import Ledger.TokenAlgebra.Base using (TokenAlgebra)
 
 open import MyDebugOptions
 --open import Tactic.Defaults

--- a/src/Ledger/Utxo/Properties.lagda
+++ b/src/Ledger/Utxo/Properties.lagda
@@ -29,7 +29,7 @@ open import Tactic.MonoidSolver
 open TransactionStructure txs
 
 open import Ledger.PParams epochStructure
-open import Ledger.TokenAlgebra using (TokenAlgebra)
+open import Ledger.TokenAlgebra.Base using (TokenAlgebra)
 open import Ledger.Utxo txs renaming (Computational-UTXO to Computational-UTXO')
 
 open TxBody


### PR DESCRIPTION
-  Make new directory `src/Ledger/TokenAlgebra` containing two files so far:

   -  `ValueRelation.lagda` contains examples of token algebras which avoid the special set theory implemented in `src/Axiom/Set.lagda` and the submodules of `Axiom.Set`.

   -  `ValueSet.lagda` contains an (incompleted) example of a token algebra based on @WhatisRT's set theory formalization in `src/Axiom/Set.lagda` and submodules of `Axiom.Set`.

-  In `ValueRelation` a partial function is constructed as an inhabitant of the `REL` type from the Agda Standard Library along with a proof of left-uniqueness (i.e., if `(a, b)` and `(a, b')` belong to the relation, then `b ≡ b'`).

-  A couple of modifications to the original `TokenAlgebra` module were necessary. Some of these were done in a separate new `TokenAlgebraPoly` type. In particular,

   ```agda policies : Value → ℙ PolicyID ```

   was changed to

   ```agda policies : Value → Pred PolicyID 0ℓ ```

   but @WhatisRT noted that this won't work.

   We have commented out the `policies` field in the original `TokenAlgebra` record type, which is the one used in the example in `ValueSet.lagda`.

-  If we want to use the `REL` type of the standard library, then it's not possible to keep the `TokenAlgebraPoly` type at level `Type₁` Therefore, the current implementation of `TransactionStructure`, which lives at level `Type₁`, must use the `TokenAlgebra` type based on `Set` (though we could simply change the universe level in the definition of `TransactionStructure` to make it compatible with `TokenAlgebraPoly` if desired).

-  We have left some holes that need filling which we're having trouble with because of the quirkiness of the special set theory.  We're still learning how to construct inhabitants of the `Set` type and functions/maps over that type.
 
-  `PolicyID` is no longer a parameter of `TokenAlgebra` module because we've added it to the `TransactionStructure` record type.