### PR TITLE
Total Map utilities

### DIFF
--- a/src/Axiom/Set.agda
+++ b/src/Axiom/Set.agda
@@ -61,6 +61,7 @@ record Theory {ℓ} : Type (sucˡ ℓ) where
   field specification : (X : Set A) → specProperty P → ∃[ Y ] ∀ {a} → (P a × a ∈ X) ⇔ a ∈ Y
         unions        : (X : Set (Set A)) → ∃[ Y ] ∀ {a} → (∃[ T ] (T ∈ X × a ∈ T)) ⇔ a ∈ Y
         replacement   : (f : A → B) → (X : Set A) → ∃[ Y ] ∀ {b} → (∃[ a ] b ≡ f a × a ∈ X) ⇔ b ∈ Y
+        replacementOn : {A B : Type ℓ}{X : Set A}(f : Σ A (_∈ X) × B → A × B) → (R : Set (A × B)) → ∃[ Y ] ∀ {b} → (∃[ aa ] b ≡ f aa × (proj₁ (proj₁ aa) , proj₂ aa) ∈ R) ⇔ b ∈ Y
         listing       : (l : List A) → ∃[ X ] ∀ {a} → a ∈ˡ l ⇔ a ∈ X -- equivalent to pairing + empty set
         -- power-set     : (X : Set A) → ∃[ Y ] ∀ {T} → T ⊆ X → T ∈ Y
 
@@ -74,6 +75,9 @@ record Theory {ℓ} : Type (sucˡ ℓ) where
 
   _∉_ : A → Set A → Type
   _∉_ = ¬_ ∘₂ _∈_
+
+  ∈-irrelevant : Set A → Type ℓ
+  ∈-irrelevant X = ∀ {a} (p q : a ∈ X) → p ≡ q
 
   open Equivalence
 
@@ -136,6 +140,12 @@ record Theory {ℓ} : Type (sucˡ ℓ) where
 
   ∈-map′ : ∀ {f : A → B} {a} → a ∈ X → f a ∈ map f X
   ∈-map′ {a = a} a∈X = to ∈-map (a , refl , a∈X)
+
+  mapOn : {A B : Type ℓ}{X : Set A} → ((Σ A (_∈ X)) × B → A × B) → Set (A × B) → Set(A × B)
+  mapOn = proj₁ ∘₂ replacementOn
+
+  ∈-mapOn : ∀ {A B : Type ℓ}{X : Set A}{f : ((Σ A (_∈ X)) × B → A × B)}{R : Set (A × B)}{ab} → (∃[ aab ] ab ≡ f aab × (proj₁ (proj₁ aab) , proj₂ aab) ∈ R) ⇔ (ab ∈ mapOn f R)
+  ∈-mapOn = proj₂ $ replacementOn _ _
 
   -- don't know that there's a set containing all members of a type, which this is equivalent to
   -- _⁻¹_ : (A → B) → Set B → Set A

--- a/src/Axiom/Set/Map.agda
+++ b/src/Axiom/Set/Map.agda
@@ -47,6 +47,39 @@ private variable A A' B B' C D : Type
 left-unique : Rel A B → Type
 left-unique R = ∀ {a b b'} → (a , b) ∈ R → (a , b') ∈ R → b ≡ b'
 
+  -- mapOn : {A B : Type ℓ}{X : Set A} → ((Σ A (_∈ X)) × B → A × B) → Set (A × B) → Set(A × B)
+  -- mapOn = proj₁ ∘₂ replacementOn
+
+-- open I.≡-Reasoning
+-- left-unique-mapOn : {X : Set A} {f : (Σ A (_∈ X)) × B → A × B}{R : Set (A × B)} → ∈-irrelevant X → left-unique (mapOn (λ (aab : Σ A (_∈ X) × B) → f aab) R)
+-- left-unique-mapOn {A} {B} {X} {f} {R} ∈-uip {a} {b} {b'} ab∈ ab'∈ with (from ∈-mapOn ab∈) | (from ∈-mapOn ab'∈)
+-- ... | ((a₀ , a₀∈X) , b₀) , p , ab∈R | ((a₁ , a₁∈X) , b₁) , q , ab'∈R = goal
+--   where
+
+--   aa₀ : a ≡ a₀
+--   aa₀ = begin
+--     a ≡⟨ {!!} ⟩
+--     proj₁ (a , b)  ≡⟨ refl ⟩
+--     proj₁ (a , proj₂ (f ((a₀ , a₀∈X) , b₀)))  ≡⟨ cong (λ x → proj₁ x) {!!} ⟩
+--     proj₁ (f ((a₀ , a₀∈X) , b₀))  ≡⟨ {!!} ⟩
+--     a₀ ∎
+--   goal : b ≡ b' -- f (a , a∈X) ≡ f (a , a∈X')
+--   goal = {!!}  -- cong f ?  -- uip
+
+  -- ∈-mapOn : ∀ {A B : Type ℓ}{X : Set A}{f : ((Σ A (_∈ X)) × B → A × B)}{R : Set (A × B)}{ab} → (∃[ aab ] ab ≡ f aab × (proj₁ (proj₁ aab) , proj₂ aab) ∈ R) ⇔ (ab ∈ mapOn f R)
+  -- ∈-mapOn = proj₂ $ replacementOn _ _
+
+
+-- {a} {b} {b'} p q = ?
+-- with (from (∈-mapOn X) p) | (from (∈-mapOn X) q)
+-- ... | (.a , a∈X) , refl , c | (.a , a∈X') , refl , d = goal
+--   where
+--   uip : (a , a∈X) ≡ (a , a∈X')
+--   uip = Σ-≡,≡→≡ (refl , (∈-uip a∈X a∈X'))
+--   goal : f (a , a∈X) ≡ f (a , a∈X')
+--   goal = cong f uip
+
+
 record IsLeftUnique (R : Rel A B) : Type where
   field isLeftUnique : left-unique R
 

--- a/src/Axiom/Set/TotalMap.agda
+++ b/src/Axiom/Set/TotalMap.agda
@@ -36,11 +36,6 @@ private macro
 total-map : Rel A B → Type
 total-map R = ∀ {a} → a ∈ map proj₁ R
 
--- TotalMap : Type → Type → Type
--- TotalMap A B = Σ (Rel A B) (λ R → left-unique R × total-map R)
-
--- lookupMapᵗ : TotalMap A B → A → B
--- lookupMapᵗ (_ , _ , tot) a = proj₂ (proj₁ (∈⇔P (tot {a})))
 
 record TotalMap (A B : Type) : Type where
   field  rel : Set (A × B)
@@ -68,6 +63,7 @@ record TotalMap (A B : Type) : Type where
     where
     alu∈rel : (a , lookup a) ∈ rel
     alu∈rel = proj₂ (to dom∈ tot)
+
 
 module Unionᵗᵐ {B : Type} ⦃ _ : DecEq A ⦄ ⦃ _ : DecEq B ⦄ where
 

--- a/src/Axiom/Set/TotalMap.agda
+++ b/src/Axiom/Set/TotalMap.agda
@@ -1,12 +1,12 @@
 {-# OPTIONS --safe --no-import-sorts #-}
 {-# OPTIONS -v allTactics:100 #-}
 
-open import Agda.Primitive renaming (Set to Type)
-open import Axiom.Set
+open import Agda.Primitive using () renaming (Set to Type)
+open import Axiom.Set using ( Theory )
 
 module Axiom.Set.TotalMap (th : Theory) where
 
-open import Prelude
+open import Prelude hiding (lookup)
 
 open Theory th
 open import Axiom.Set.Map th
@@ -14,6 +14,15 @@ open import Axiom.Set.Properties th
 open import Axiom.Set.Rel th
 open import Tactic.AnyOf
 open import Tactic.Defaults
+
+open import Interface.DecEq
+open import Relation.Binary.PropositionalEquality using ( _≡_ ; cong ; module ≡-Reasoning )
+open import Relation.Binary using () renaming (Decidable to Dec₂)
+open import Relation.Nullary.Decidable using (Dec ; yes ; no)
+open import Relation.Unary using () renaming (Decidable to Dec₁)
+
+
+open Equivalence
 
 private variable A B : Type
 
@@ -27,8 +36,62 @@ private macro
 total-map : Rel A B → Type
 total-map R = ∀ {a} → a ∈ map proj₁ R
 
-TotalMap : Type → Type → Type
-TotalMap A B = Σ (Rel A B) (λ R → left-unique R × total-map R)
+-- TotalMap : Type → Type → Type
+-- TotalMap A B = Σ (Rel A B) (λ R → left-unique R × total-map R)
 
-lookupMapᵗ : TotalMap A B → A → B
-lookupMapᵗ (_ , _ , tot) a = proj₂ (proj₁ (∈⇔P (tot {a})))
+-- lookupMapᵗ : TotalMap A B → A → B
+-- lookupMapᵗ (_ , _ , tot) a = proj₂ (proj₁ (∈⇔P (tot {a})))
+
+record TotalMap (A B : Type) : Type where
+  field  rel : Set (A × B)
+         lun : left-unique rel
+         tot : ∀{a : A} → a ∈ dom rel
+
+
+  MapReduct : Map A B
+  MapReduct = rel , lun
+
+
+  lookup : A → B
+  lookup a = proj₁ ξ
+    where
+    ξ : ∃[ b ] (a , b) ∈ rel
+    ξ = to dom∈ tot
+
+
+  lookupCert : {a : A} → (a , lookup a) ∈ rel
+  lookupCert = proj₂ (to dom∈ tot)
+
+
+  lookupLemma : {a : A}{b : B} → (a , b) ∈ rel → lookup a ≡ b
+  lookupLemma {a} ab∈rel = sym (lun ab∈rel alu∈rel)
+    where
+    alu∈rel : (a , lookup a) ∈ rel
+    alu∈rel = proj₂ (to dom∈ tot)
+
+module Unionᵗᵐ {B : Type} ⦃ _ : DecEq A ⦄ ⦃ _ : DecEq B ⦄ where
+
+  updateFn : A × B → A → B → B
+  updateFn (a , b) x y with (x ≟ a)
+  ... | yes _ = b
+  ... | no _ = y
+
+  updateMap : (A → B → B) → A × B → A → B → B
+  updateMap f (a , b) x y with (x ≟ a)
+  ... | yes _ = b
+  ... | no _ = f x y
+
+  open TotalMap
+
+  mapWithKeyTotal : ∀{B'}{f : A → B → B'}{R : Rel A B} → total-map R → total-map (map (λ { (x , y) → x , f x y }) R)
+  mapWithKeyTotal {f = f}{R} tot {a} = ψ (ϕ tot)
+    where
+    ϕ : a ∈ dom R → Σ (Σ A (λ x₁ → B)) (λ a₁ → a ≡ proj₁ a₁ × a₁ ∈ R)
+    ϕ = from ∈-map
+    ψ : Σ (Σ A (λ _ → B)) (λ uv → a ≡ proj₁ uv × uv ∈ R) → a ∈ dom (map (λ {(x , y) → x , f x y}) R)
+    ψ (_ , refl , aRb) = ∈-map′ (∈-map′ aRb)
+
+  update : A → B → TotalMap A B → TotalMap A B
+  update a b tm .rel = map (λ { (x , y) → x , updateFn (a , b) x y}) (rel tm)
+  update _ _ tm .lun = mapWithKey-uniq (lun tm)
+  update a b tm .tot {a'} = mapWithKeyTotal (tot tm)

--- a/src/Axiom/Set/TotalMapOn.agda
+++ b/src/Axiom/Set/TotalMapOn.agda
@@ -62,7 +62,7 @@ record TotalMapOn {A : Type}(X : Set A)(B : Type) : Type where
   lookupLemma-Σ {aa} = lookupLemma {proj₁ aa}{proj₂ aa}
 
 
-module Unionᵗᵐᵒ  {B : Type} ⦃ _ : DecEq A ⦄ ⦃ _ : DecEq B ⦄ where
+module Union-tm  {B : Type} ⦃ _ : DecEq A ⦄ ⦃ _ : DecEq B ⦄ where
 
   updateFn : A × B → A → B → B
   updateFn (a , b) x y with (x ≟ a)

--- a/src/Axiom/Set/TotalMapOn.agda
+++ b/src/Axiom/Set/TotalMapOn.agda
@@ -10,6 +10,7 @@ open import Prelude hiding ( lookup )
 
 open Theory th
 open import Axiom.Set.Map th using ( left-unique ; Map ; mapWithKey-uniq)
+open import Axiom.Set.TotalMap th using (total-map)
 open import Axiom.Set.Rel th
 
 open import Interface.DecEq
@@ -21,10 +22,6 @@ open import Relation.Unary using () renaming (Decidable to Dec₁)
 open Equivalence
 
 private variable A B : Type
-
-total-map : Rel A B → Type
-total-map R = ∀ {a} → a ∈ map proj₁ R
-
 
 _TotalOn_ : Rel A B → Set A → Type
 R TotalOn X = X ⊆ dom R
@@ -60,19 +57,19 @@ record TotalMapOn {A : Type}(X : Set A)(B : Type) : Type where
     alu∈rel = proj₂ (to dom∈ (total (proj₂ aa)))
 
 
-module Unionᵗᵐ  {B : Type} ⦃ _ : DecEq A ⦄ ⦃ _ : DecEq B ⦄ where
+module Unionᵗᵐᵒ  {B : Type} ⦃ _ : DecEq A ⦄ ⦃ _ : DecEq B ⦄ where
 
   updateFn : A × B → A → B → B
   updateFn (a , b) x y with (x ≟ a)
   ... | yes _ = b
   ... | no _ = y
 
-
   open TotalMapOn
-  mapWithKeyTotalOn :  (X : Set A){B' : Type}{f : A → B → B'}{R : Rel A B}
+
+  mapWithKeyTotalOn :  {X : Set A}{B' : Type}{f : A → B → B'}{R : Rel A B}
     →                  R TotalOn X → (map (λ { (x , y) → x , f x y }) R) TotalOn X
 
-  mapWithKeyTotalOn X {B'}{f}{R} tot {a} a∈X = Goal
+  mapWithKeyTotalOn {B' = B'}{f}{R} tot {a} a∈X = Goal
     where
     R' : Rel A B'
     R' = map (λ { (x , y) → x , f x y }) R
@@ -87,9 +84,9 @@ module Unionᵗᵐ  {B : Type} ⦃ _ : DecEq A ⦄ ⦃ _ : DecEq B ⦄ where
     Goal = ∈-map′ (proj₂ h')
 
   mapWithKeyOn : {X : Set A}{B' : Type} → (A → B → B') → TotalMapOn X B → TotalMapOn X B'
-  mapWithKeyOn {X} f tm .rel = map (λ { (x , y) → x , f x y}) (rel tm)
-  mapWithKeyOn _ tm .lun = mapWithKey-uniq (lun tm)
-  mapWithKeyOn {X} _ tm .total = mapWithKeyTotalOn X (total tm)
+  mapWithKeyOn f tm .rel    = map (λ { (x , y) → x , f x y}) (rel tm)
+  mapWithKeyOn _ tm .lun    = mapWithKey-uniq (lun tm)
+  mapWithKeyOn _ tm .total  = mapWithKeyTotalOn (total tm)
 
   updateOn : {X : Set A} → A → B → TotalMapOn X B → TotalMapOn X B
   updateOn a b t = mapWithKeyOn (updateFn (a , b)) t

--- a/src/Axiom/Set/TotalMapOn.agda
+++ b/src/Axiom/Set/TotalMapOn.agda
@@ -8,16 +8,24 @@ module Axiom.Set.TotalMapOn (th : Theory) where
 
 open import Prelude hiding ( lookup )
 
-open Theory th
-open import Axiom.Set.Map th using ( left-unique ; Map ; mapWithKey-uniq)
-open import Axiom.Set.TotalMap th using (total-map)
-open import Axiom.Set.Rel th
+open import Algebra                using ( Op₂ )
+open Theory th                     using ( Set ; _⊆_ ; _∈_ ; map ; ∈-map′ ; spec-∈ ; mapOn)
+open import Axiom.Set.Map th       using ( left-unique ; Map ; mapWithKey-uniq ; module Lookupᵐ ; module Unionᵐ )
+open import Axiom.Set.TotalMap th  using ( total-map )
+open import Axiom.Set.Rel th       using ( Rel ; dom ; dom∈ ; module Restriction)
+open import Axiom.Set.Properties th
+open import Interface.DecEq        using (DecEq ; _≟_)
 
-open import Interface.DecEq
-open import Relation.Binary.PropositionalEquality using ( _≡_ ; cong ; module ≡-Reasoning )
-open import Relation.Binary using () renaming (Decidable to Dec₂)
-open import Relation.Nullary.Decidable using (Dec ; yes ; no)
-open import Relation.Unary using () renaming (Decidable to Dec₁)
+open import Relation.Binary             using ( ) renaming ( Decidable to Dec₂ )
+open import Relation.Binary.PropositionalEquality
+                                        using ( _≡_ ; cong ; module ≡-Reasoning )
+open import Relation.Nullary.Decidable  using ( Dec ; yes ; no )
+open import Relation.Unary              using ( ) renaming ( Decidable to Dec₁ )
+
+open import Tactic.AnyOf
+open import Tactic.Assumption
+open import Tactic.Defaults
+open import Tactic.Helpers
 
 open Equivalence
 
@@ -50,11 +58,8 @@ record TotalMapOn {A : Type}(X : Set A)(B : Type) : Type where
     alu∈rel : (a , lookup (a , a∈dom)) ∈ rel
     alu∈rel = proj₂ (to dom∈ (total a∈dom))
 
-  lookupLemma' : {aa : Σ A (_∈ domain)} {b : B} → (proj₁ aa , b) ∈ rel → lookup aa ≡ b
-  lookupLemma' {aa} ab∈rel = sym (lun ab∈rel alu∈rel)
-    where
-    alu∈rel : (proj₁ aa , lookup aa) ∈ rel
-    alu∈rel = proj₂ (to dom∈ (total (proj₂ aa)))
+  lookupLemma-Σ : {aa : Σ A (_∈ domain)} {b : B} → (proj₁ aa , b) ∈ rel → lookup aa ≡ b
+  lookupLemma-Σ {aa} = lookupLemma {proj₁ aa}{proj₂ aa}
 
 
 module Unionᵗᵐᵒ  {B : Type} ⦃ _ : DecEq A ⦄ ⦃ _ : DecEq B ⦄ where
@@ -88,5 +93,7 @@ module Unionᵗᵐᵒ  {B : Type} ⦃ _ : DecEq A ⦄ ⦃ _ : DecEq B ⦄ where
   mapWithKeyOn _ tm .lun    = mapWithKey-uniq (lun tm)
   mapWithKeyOn _ tm .total  = mapWithKeyTotalOn (total tm)
 
-  updateOn : {X : Set A} → A → B → TotalMapOn X B → TotalMapOn X B
-  updateOn a b t = mapWithKeyOn (updateFn (a , b)) t
+  update : {X : Set A} → A → B → TotalMapOn X B → TotalMapOn X B
+  update a b t = mapWithKeyOn (updateFn (a , b)) t
+
+

--- a/src/Axiom/Set/TotalMapOn.agda
+++ b/src/Axiom/Set/TotalMapOn.agda
@@ -1,0 +1,95 @@
+{-# OPTIONS --safe --no-import-sorts #-}
+{-# OPTIONS -v allTactics:100 #-}
+
+open import Agda.Primitive  using ( ) renaming ( Set to Type )
+open import Axiom.Set       using ( Theory )
+
+module Axiom.Set.TotalMapOn (th : Theory) where
+
+open import Prelude hiding ( lookup )
+
+open Theory th
+open import Axiom.Set.Map th using ( left-unique ; Map ; mapWithKey-uniq)
+open import Axiom.Set.Rel th
+
+open import Interface.DecEq
+open import Relation.Binary.PropositionalEquality using ( _≡_ ; cong ; module ≡-Reasoning )
+open import Relation.Binary using () renaming (Decidable to Dec₂)
+open import Relation.Nullary.Decidable using (Dec ; yes ; no)
+open import Relation.Unary using () renaming (Decidable to Dec₁)
+
+open Equivalence
+
+private variable A B : Type
+
+total-map : Rel A B → Type
+total-map R = ∀ {a} → a ∈ map proj₁ R
+
+
+_TotalOn_ : Rel A B → Set A → Type
+R TotalOn X = X ⊆ dom R
+
+
+record TotalMapOn {A : Type}(X : Set A)(B : Type) : Type where
+  field  rel     : Set (A × B)
+         lun     : left-unique rel
+         total   : rel TotalOn X
+
+  domain : Set A
+  domain = X
+
+  MapReduct : Map A B
+  MapReduct = rel , lun
+
+  lookup : Σ A (_∈ domain) → B
+  lookup (_ , a∈X) = proj₁ (to dom∈ (total a∈X))
+
+  lookupCert : {a : A} (a∈X : a ∈ domain) → (a , lookup (a , a∈X)) ∈ rel
+  lookupCert a∈X = proj₂ (to dom∈ (total a∈X))
+
+  lookupLemma : {a : A} {a∈dom : a ∈ domain} {b : B} → (a , b) ∈ rel → lookup (a , a∈dom) ≡ b
+  lookupLemma {a} {a∈dom} ab∈rel = sym (lun ab∈rel alu∈rel)
+    where
+    alu∈rel : (a , lookup (a , a∈dom)) ∈ rel
+    alu∈rel = proj₂ (to dom∈ (total a∈dom))
+
+  lookupLemma' : {aa : Σ A (_∈ domain)} {b : B} → (proj₁ aa , b) ∈ rel → lookup aa ≡ b
+  lookupLemma' {aa} ab∈rel = sym (lun ab∈rel alu∈rel)
+    where
+    alu∈rel : (proj₁ aa , lookup aa) ∈ rel
+    alu∈rel = proj₂ (to dom∈ (total (proj₂ aa)))
+
+
+module Unionᵗᵐ  {B : Type} ⦃ _ : DecEq A ⦄ ⦃ _ : DecEq B ⦄ where
+
+  updateFn : A × B → A → B → B
+  updateFn (a , b) x y with (x ≟ a)
+  ... | yes _ = b
+  ... | no _ = y
+
+
+  open TotalMapOn
+  mapWithKeyTotalOn :  (X : Set A){B' : Type}{f : A → B → B'}{R : Rel A B}
+    →                  R TotalOn X → (map (λ { (x , y) → x , f x y }) R) TotalOn X
+
+  mapWithKeyTotalOn X {B'}{f}{R} tot {a} a∈X = Goal
+    where
+    R' : Rel A B'
+    R' = map (λ { (x , y) → x , f x y }) R
+
+    h : ∃[ b ] (a , b) ∈ R
+    h = to dom∈ (tot a∈X)
+
+    h' : ∃[ b ] (a , b) ∈ R'
+    h' = (f a (proj₁ h)) , (∈-map′ (proj₂ h))
+
+    Goal : a ∈ dom R'
+    Goal = ∈-map′ (proj₂ h')
+
+  mapWithKeyOn : {X : Set A}{B' : Type} → (A → B → B') → TotalMapOn X B → TotalMapOn X B'
+  mapWithKeyOn {X} f tm .rel = map (λ { (x , y) → x , f x y}) (rel tm)
+  mapWithKeyOn _ tm .lun = mapWithKey-uniq (lun tm)
+  mapWithKeyOn {X} _ tm .total = mapWithKeyTotalOn X (total tm)
+
+  updateOn : {X : Set A} → A → B → TotalMapOn X B → TotalMapOn X B
+  updateOn a b t = mapWithKeyOn (updateFn (a , b)) t

--- a/src/Ledger/Prelude.agda
+++ b/src/Ledger/Prelude.agda
@@ -87,6 +87,8 @@ open import Axiom.Set.Map th public
 
 open import Axiom.Set.TotalMap th public
 
+open import Axiom.Set.TotalMapOn th public
+
 open L.Decˡ public
   hiding (_∈?_; ≟-∅)
 


### PR DESCRIPTION
+  adds functionality to TotalMap module analogous to some of the definitions in the Map module but using record types.

+  adds a new TotalMapOn module for maps that are total on a given set `X : Set A`.

+  includes lookup and update functions as well as some lemmas about them.