### PR TITLE
Total map infrastructure

### DIFF
--- a/src/Axiom/Set/TotalMap.agda
+++ b/src/Axiom/Set/TotalMap.agda
@@ -19,58 +19,44 @@ private variable A B : Type
 
 
 -- defines a total map for a given set
-total-map : Rel A B → Type
-total-map R = ∀ {a} → a ∈ map proj₁ R
+total : Rel A B → Type
+total R = ∀ {a} → a ∈ dom R
 
 
 record TotalMap (A B : Type) : Type where
-  field  rel : Set (A × B)
-         lun : left-unique rel
-         tot : ∀{a : A} → a ∈ dom rel
+  field  rel              : Set (A × B)
+         left-unique-rel  : left-unique rel
+         total-rel        : total rel
 
-
-  MapReduct : Map A B
-  MapReduct = rel , lun
-
+  toMap : Map A B
+  toMap = rel , left-unique-rel
 
   lookup : A → B
-  lookup a = proj₁ ξ
-    where
-    ξ : ∃[ b ] (a , b) ∈ rel
-    ξ = to dom∈ tot
+  lookup _ = proj₁ (to dom∈ total-rel)
+
+  -- verify that lookup is what we expect
+  lookup∈rel : {a : A} → (a , lookup a) ∈ rel
+  lookup∈rel = proj₂ (to dom∈ total-rel)
+
+  -- this is useful for proving equalities involving lookup
+  rel⇒lookup : {a : A}{b : B} → (a , b) ∈ rel → lookup a ≡ b
+  rel⇒lookup ab∈rel = sym (left-unique-rel ab∈rel (proj₂ (to dom∈ total-rel)))
 
 
-  lookupCert : {a : A} → (a , lookup a) ∈ rel
-  lookupCert = proj₂ (to dom∈ tot)
+module Update {B : Type} ⦃ _ : DecEq A ⦄ where
 
-
-  lookupLemma : {a : A}{b : B} → (a , b) ∈ rel → lookup a ≡ b
-  lookupLemma {a} ab∈rel = sym (lun ab∈rel alu∈rel)
-    where
-    alu∈rel : (a , lookup a) ∈ rel
-    alu∈rel = proj₂ (to dom∈ tot)
-
-
-module Unionᵗᵐ {B : Type} ⦃ _ : DecEq A ⦄ where
-
-  -- updateFn:  Helper for defining update functions.
-  --            Given (a , b) and x y, if x ≡ a return b, otherwise return y.
-  updateFn : A × B → A → B → B
-  updateFn (a , b) x y with (x ≟ a)
-  ... | yes _ = b
-  ... | no _ = y
+  private
+    updateFn : A × B → A → B → B
+    updateFn (a , b) x y with (x ≟ a)
+    ... | yes  _ = b
+    ... | no   _ = y
 
   open TotalMap
 
-  mapWithKeyTotal : ∀{B'}{f : A → B → B'}{R : Rel A B} → total-map R → total-map (map (λ { (x , y) → x , f x y }) R)
-  mapWithKeyTotal {f = f}{R} tot {a} = ψ (ϕ tot)
-    where
-    ϕ : a ∈ dom R → Σ (Σ A (λ x₁ → B)) (λ a₁ → a ≡ proj₁ a₁ × a₁ ∈ R)
-    ϕ = from ∈-map
-    ψ : Σ (Σ A (λ _ → B)) (λ uv → a ≡ proj₁ uv × uv ∈ R) → a ∈ dom (map (λ {(x , y) → x , f x y}) R)
-    ψ (_ , refl , aRb) = ∈-map′ (∈-map′ aRb)
+  mapWithKey : {B' : Type} → (A → B → B') → TotalMap A B → TotalMap A B'
+  mapWithKey f tm .rel              = map (λ{(x , y) → x , f x y}) (rel tm)
+  mapWithKey _ tm .left-unique-rel  = mapWithKey-uniq (left-unique-rel tm)
+  mapWithKey _ tm .total-rel        = ∈-map′ (∈-map′ (proj₂ (to dom∈ (total-rel tm))))
 
   update : A → B → TotalMap A B → TotalMap A B
-  update a b tm .rel = map (λ { (x , y) → x , updateFn (a , b) x y}) (rel tm)
-  update _ _ tm .lun = mapWithKey-uniq (lun tm)
-  update a b tm .tot {a'} = mapWithKeyTotal (tot tm)
+  update a b = mapWithKey (updateFn (a , b))

--- a/src/Axiom/Set/TotalMap.agda
+++ b/src/Axiom/Set/TotalMap.agda
@@ -1,34 +1,76 @@
 {-# OPTIONS --safe --no-import-sorts #-}
-{-# OPTIONS -v allTactics:100 #-}
 
-open import Agda.Primitive renaming (Set to Type)
-open import Axiom.Set
+open import Axiom.Set using ( Theory )
 
 module Axiom.Set.TotalMap (th : Theory) where
 
-open import Prelude
+open import Prelude hiding (lookup)
 
-open Theory th
-open import Axiom.Set.Map th
-open import Axiom.Set.Properties th
-open import Axiom.Set.Rel th
-open import Tactic.AnyOf
-open import Tactic.Defaults
+open import Agda.Primitive              using () renaming (Set to Type)
+open import Axiom.Set.Map th            using (left-unique; Map ; mapWithKey-uniq)
+open import Axiom.Set.Rel th            using (Rel ; dom ; dom∈)
+open import Interface.DecEq             using (DecEq ; _≟_)
+open import Relation.Nullary.Decidable  using (yes ; no)
+
+open Theory th    using (_∈_ ; map ; Set ; ∈-map ; ∈-map′)
+open Equivalence  using (to ; from)
 
 private variable A B : Type
 
--- Because of missing macro hygiene, we have to copy&paste this. https://github.com/agda/agda/issues/3819
-private macro
-  ∈⇒P = anyOfⁿᵗ (quote ∈-filter⁻' ∷ quote ∈-∪⁻ ∷ quote ∈-map⁻' ∷ quote ∈-fromList⁻ ∷ [])
-  P⇒∈ = anyOfⁿᵗ (quote ∈-filter⁺' ∷ quote ∈-∪⁺ ∷ quote ∈-map⁺' ∷ quote ∈-fromList⁺ ∷ [])
-  ∈⇔P = anyOfⁿᵗ (quote ∈-filter⁻' ∷ quote ∈-∪⁻ ∷ quote ∈-map⁻' ∷ quote ∈-fromList⁻ ∷ quote ∈-filter⁺' ∷ quote ∈-∪⁺ ∷ quote ∈-map⁺' ∷ quote ∈-fromList⁺ ∷ [])
 
 -- defines a total map for a given set
 total-map : Rel A B → Type
 total-map R = ∀ {a} → a ∈ map proj₁ R
 
-TotalMap : Type → Type → Type
-TotalMap A B = Σ (Rel A B) (λ R → left-unique R × total-map R)
 
-lookupMapᵗ : TotalMap A B → A → B
-lookupMapᵗ (_ , _ , tot) a = proj₂ (proj₁ (∈⇔P (tot {a})))
+record TotalMap (A B : Type) : Type where
+  field  rel : Set (A × B)
+         lun : left-unique rel
+         tot : ∀{a : A} → a ∈ dom rel
+
+
+  MapReduct : Map A B
+  MapReduct = rel , lun
+
+
+  lookup : A → B
+  lookup a = proj₁ ξ
+    where
+    ξ : ∃[ b ] (a , b) ∈ rel
+    ξ = to dom∈ tot
+
+
+  lookupCert : {a : A} → (a , lookup a) ∈ rel
+  lookupCert = proj₂ (to dom∈ tot)
+
+
+  lookupLemma : {a : A}{b : B} → (a , b) ∈ rel → lookup a ≡ b
+  lookupLemma {a} ab∈rel = sym (lun ab∈rel alu∈rel)
+    where
+    alu∈rel : (a , lookup a) ∈ rel
+    alu∈rel = proj₂ (to dom∈ tot)
+
+
+module Unionᵗᵐ {B : Type} ⦃ _ : DecEq A ⦄ where
+
+  -- updateFn:  Helper for defining update functions.
+  --            Given (a , b) and x y, if x ≡ a return b, otherwise return y.
+  updateFn : A × B → A → B → B
+  updateFn (a , b) x y with (x ≟ a)
+  ... | yes _ = b
+  ... | no _ = y
+
+  open TotalMap
+
+  mapWithKeyTotal : ∀{B'}{f : A → B → B'}{R : Rel A B} → total-map R → total-map (map (λ { (x , y) → x , f x y }) R)
+  mapWithKeyTotal {f = f}{R} tot {a} = ψ (ϕ tot)
+    where
+    ϕ : a ∈ dom R → Σ (Σ A (λ x₁ → B)) (λ a₁ → a ≡ proj₁ a₁ × a₁ ∈ R)
+    ϕ = from ∈-map
+    ψ : Σ (Σ A (λ _ → B)) (λ uv → a ≡ proj₁ uv × uv ∈ R) → a ∈ dom (map (λ {(x , y) → x , f x y}) R)
+    ψ (_ , refl , aRb) = ∈-map′ (∈-map′ aRb)
+
+  update : A → B → TotalMap A B → TotalMap A B
+  update a b tm .rel = map (λ { (x , y) → x , updateFn (a , b) x y}) (rel tm)
+  update _ _ tm .lun = mapWithKey-uniq (lun tm)
+  update a b tm .tot {a'} = mapWithKeyTotal (tot tm)

--- a/src/Axiom/Set/TotalMapOn.agda
+++ b/src/Axiom/Set/TotalMapOn.agda
@@ -1,0 +1,84 @@
+{-# OPTIONS --safe --no-import-sorts #-}
+
+open import Axiom.Set using (Theory)
+
+module Axiom.Set.TotalMapOn (th : Theory) where
+
+open import Prelude hiding (lookup)
+
+open import Agda.Primitive              using () renaming (Set to Type)
+open import Axiom.Set.Map th            using (left-unique ; Map ; mapWithKey-uniq)
+open import Axiom.Set.Rel th            using (Rel ; dom ; dom∈)
+open import Axiom.Set.TotalMap th       using (module Unionᵗᵐ)
+open import Interface.DecEq             using (DecEq ; _≟_)
+open import Relation.Nullary.Decidable  using (Dec ; yes ; no)
+
+open Theory th    using ( Set ; _⊆_ ; _∈_ ; map ; ∈-map′ )
+open Equivalence  using (to)
+open Unionᵗᵐ       using (updateFn)
+
+private variable A B : Type
+
+_TotalOn_ : Rel A B → Set A → Type
+R TotalOn X = X ⊆ dom R
+
+
+record TotalMapOn {A : Type}(X : Set A)(B : Type) : Type where
+  field  rel     : Set (A × B)
+         lun     : left-unique rel
+         total   : rel TotalOn X
+
+  domain : Set A
+  domain = X
+
+  MapReduct : Map A B
+  MapReduct = rel , lun
+
+  lookup : Σ A (_∈ domain) → B
+  lookup (_ , a∈X) = proj₁ (to dom∈ (total a∈X))
+
+  -- verify that lookup is what we expect
+  lookupCert : {a : A} (a∈X : a ∈ domain) → (a , lookup (a , a∈X)) ∈ rel
+  lookupCert a∈X = proj₂ (to dom∈ (total a∈X))
+
+  -- a lemma that's useful for proving equalities involving lookup
+  lookupLemma : {a : A} {a∈dom : a ∈ domain} {b : B} → (a , b) ∈ rel → lookup (a , a∈dom) ≡ b
+  lookupLemma {a} {a∈dom} ab∈rel = sym (lun ab∈rel alu∈rel)
+    where
+    alu∈rel : (a , lookup (a , a∈dom)) ∈ rel
+    alu∈rel = proj₂ (to dom∈ (total a∈dom))
+
+  lookupLemma-Σ : {aa : Σ A (_∈ domain)} {b : B} → (proj₁ aa , b) ∈ rel → lookup aa ≡ b
+  lookupLemma-Σ {aa} = lookupLemma {proj₁ aa}{proj₂ aa}
+
+
+module Union-tm {B : Type} ⦃ _ : DecEq A ⦄ where
+
+  open TotalMapOn
+
+  mapWithKeyTotalOn :  {X : Set A}{B' : Type}{f : A → B → B'}{R : Rel A B}
+    →                  R TotalOn X → (map (λ { (x , y) → x , f x y }) R) TotalOn X
+
+  mapWithKeyTotalOn {B' = B'}{f}{R} tot {a} a∈X = Goal
+    where
+    R' : Rel A B'
+    R' = map (λ { (x , y) → x , f x y }) R
+
+    h : ∃[ b ] (a , b) ∈ R
+    h = to dom∈ (tot a∈X)
+
+    h' : ∃[ b ] (a , b) ∈ R'
+    h' = (f a (proj₁ h)) , (∈-map′ (proj₂ h))
+
+    Goal : a ∈ dom R'
+    Goal = ∈-map′ (proj₂ h')
+
+  mapWithKeyOn : {X : Set A}{B' : Type} → (A → B → B') → TotalMapOn X B → TotalMapOn X B'
+  mapWithKeyOn f tm .rel    = map (λ { (x , y) → x , f x y}) (rel tm)
+  mapWithKeyOn _ tm .lun    = mapWithKey-uniq (lun tm)
+  mapWithKeyOn _ tm .total  = mapWithKeyTotalOn (total tm)
+
+  update : {X : Set A} → A → B → TotalMapOn X B → TotalMapOn X B
+  update a b t = mapWithKeyOn (updateFn (a , b)) t
+
+

--- a/src/Axiom/Set/TotalMapOn.agda
+++ b/src/Axiom/Set/TotalMapOn.agda
@@ -9,13 +9,11 @@ open import Prelude hiding (lookup)
 open import Agda.Primitive              using () renaming (Set to Type)
 open import Axiom.Set.Map th            using (left-unique ; Map ; mapWithKey-uniq)
 open import Axiom.Set.Rel th            using (Rel ; dom ; dom∈)
-open import Axiom.Set.TotalMap th       using (module Unionᵗᵐ)
 open import Interface.DecEq             using (DecEq ; _≟_)
 open import Relation.Nullary.Decidable  using (Dec ; yes ; no)
 
 open Theory th    using ( Set ; _⊆_ ; _∈_ ; map ; ∈-map′ )
 open Equivalence  using (to)
-open Unionᵗᵐ       using (updateFn)
 
 private variable A B : Type
 
@@ -24,61 +22,40 @@ R TotalOn X = X ⊆ dom R
 
 
 record TotalMapOn {A : Type}(X : Set A)(B : Type) : Type where
-  field  rel     : Set (A × B)
-         lun     : left-unique rel
-         total   : rel TotalOn X
+  field  rel              : Set (A × B)
+         left-unique-rel  : left-unique rel
+         total-rel        : rel TotalOn X
 
-  domain : Set A
-  domain = X
+  toMap : Map A B
+  toMap = rel , left-unique-rel
 
-  MapReduct : Map A B
-  MapReduct = rel , lun
-
-  lookup : Σ A (_∈ domain) → B
-  lookup (_ , a∈X) = proj₁ (to dom∈ (total a∈X))
+  lookup : Σ A (_∈ X) → B
+  lookup (_ , a∈X) = proj₁ (to dom∈ (total-rel a∈X))
 
   -- verify that lookup is what we expect
-  lookupCert : {a : A} (a∈X : a ∈ domain) → (a , lookup (a , a∈X)) ∈ rel
-  lookupCert a∈X = proj₂ (to dom∈ (total a∈X))
+  lookup∈rel : {a : A} (a∈X : a ∈ X) → (a , lookup (a , a∈X)) ∈ rel
+  lookup∈rel a∈X = proj₂ (to dom∈ (total-rel a∈X))
 
-  -- a lemma that's useful for proving equalities involving lookup
-  lookupLemma : {a : A} {a∈dom : a ∈ domain} {b : B} → (a , b) ∈ rel → lookup (a , a∈dom) ≡ b
-  lookupLemma {a} {a∈dom} ab∈rel = sym (lun ab∈rel alu∈rel)
-    where
-    alu∈rel : (a , lookup (a , a∈dom)) ∈ rel
-    alu∈rel = proj₂ (to dom∈ (total a∈dom))
-
-  lookupLemma-Σ : {aa : Σ A (_∈ domain)} {b : B} → (proj₁ aa , b) ∈ rel → lookup aa ≡ b
-  lookupLemma-Σ {aa} = lookupLemma {proj₁ aa}{proj₂ aa}
+  -- this is useful for proving equalities involving lookup
+  rel⇒lookup : {a : A} {a∈dom : a ∈ X} {b : B} → (a , b) ∈ rel → lookup (a , a∈dom) ≡ b
+  rel⇒lookup {a} {a∈dom} ab∈rel = sym (left-unique-rel ab∈rel (proj₂ (to dom∈ (total-rel a∈dom))))
 
 
-module Union-tm {B : Type} ⦃ _ : DecEq A ⦄ where
+module UpdateOn {B : Type} ⦃ _ : DecEq A ⦄ where
+
+  private
+    updateFn : A × B → A → B → B
+    updateFn (a , b) x y with (x ≟ a)
+    ... | yes  _ = b
+    ... | no   _ = y
 
   open TotalMapOn
 
-  mapWithKeyTotalOn :  {X : Set A}{B' : Type}{f : A → B → B'}{R : Rel A B}
-    →                  R TotalOn X → (map (λ { (x , y) → x , f x y }) R) TotalOn X
-
-  mapWithKeyTotalOn {B' = B'}{f}{R} tot {a} a∈X = Goal
-    where
-    R' : Rel A B'
-    R' = map (λ { (x , y) → x , f x y }) R
-
-    h : ∃[ b ] (a , b) ∈ R
-    h = to dom∈ (tot a∈X)
-
-    h' : ∃[ b ] (a , b) ∈ R'
-    h' = (f a (proj₁ h)) , (∈-map′ (proj₂ h))
-
-    Goal : a ∈ dom R'
-    Goal = ∈-map′ (proj₂ h')
-
   mapWithKeyOn : {X : Set A}{B' : Type} → (A → B → B') → TotalMapOn X B → TotalMapOn X B'
-  mapWithKeyOn f tm .rel    = map (λ { (x , y) → x , f x y}) (rel tm)
-  mapWithKeyOn _ tm .lun    = mapWithKey-uniq (lun tm)
-  mapWithKeyOn _ tm .total  = mapWithKeyTotalOn (total tm)
+  mapWithKeyOn f tm .rel              = map (λ{(x , y) → x , f x y}) (rel tm)
+  mapWithKeyOn _ tm .left-unique-rel  = mapWithKey-uniq (left-unique-rel tm)
+  mapWithKeyOn _ tm .total-rel a∈X    = ∈-map′ (∈-map′ (proj₂ (to dom∈ ((total-rel tm) a∈X))))
 
+  -- Return a new total map which is the same as the given total map except at a.
   update : {X : Set A} → A → B → TotalMapOn X B → TotalMapOn X B
-  update a b t = mapWithKeyOn (updateFn (a , b)) t
-
-
+  update a b = mapWithKeyOn (updateFn (a , b))

--- a/src/Ledger/Prelude.agda
+++ b/src/Ledger/Prelude.agda
@@ -86,6 +86,7 @@ open import Axiom.Set.Map th public
   renaming (Map to _⇀_)
 
 open import Axiom.Set.TotalMap th public
+open import Axiom.Set.TotalMapOn th public
 
 open L.Decˡ public
   hiding (_∈?_; ≟-∅)


### PR DESCRIPTION
+  adds functionality to TotalMap module analogous to definitions in the Map module but using record types.

+  adds new module, `TotalMapOn`, with dependent record types for maps that are total on a given set `X : Set A`.

+  includes lookup and update functions as well as some lemmas about them.