### PR TITLE
Token algebra example: ValueSet

### DIFF
--- a/src/Axiom/Set.agda
+++ b/src/Axiom/Set.agda
@@ -75,6 +75,9 @@ record Theory {ℓ} : Type (sucˡ ℓ) where
   _∉_ : A → Set A → Type
   _∉_ = ¬_ ∘₂ _∈_
 
+  ∈-irrelevant : Set A → Type ℓ
+  ∈-irrelevant X = ∀ {a} (p q : a ∈ X) → p ≡ q
+
   open Equivalence
 
   _Preservesˢ_ : (Set A → Set B) → (∀ {A} → Set A → Type) → Type ℓ
@@ -131,6 +134,9 @@ record Theory {ℓ} : Type (sucˡ ℓ) where
   map : (A → B) → Set A → Set B
   map = proj₁ ∘₂ replacement
 
+  -- mapOn : {X : Set A} → (Σ A (_∈ X) → B) → Set (Σ A (_∈ X)) → Set B
+  -- mapOn = proj₁ ∘₂ replacement
+
   ∈-map : ∀ {f : A → B} {b} → (∃[ a ] b ≡ f a × a ∈ X) ⇔ b ∈ map f X
   ∈-map = proj₂ $ replacement _ _
 
@@ -140,6 +146,9 @@ record Theory {ℓ} : Type (sucˡ ℓ) where
   -- don't know that there's a set containing all members of a type, which this is equivalent to
   -- _⁻¹_ : (A → B) → Set B → Set A
   -- f ⁻¹ X = {!!}
+  ≡∈ : {X : Set A}{a a' : A} → a ∈ X → a ≡ a' → a' ∈ X
+  ≡∈ {a = a}{.a}a∈X refl = a∈X
+
 
   filter : {P : A → Type} → specProperty P → Set A → Set A
   filter = proj₁ ∘₂ flip specification

--- a/src/Axiom/Set/Map.agda
+++ b/src/Axiom/Set/Map.agda
@@ -61,6 +61,13 @@ left-unique-mapˢ : {f : A → B} (X : Set A) → left-unique (mapˢ (λ y → (
 left-unique-mapˢ _ p q with from ∈-map p | from ∈-map q
 ... | _ , refl , _ | _ , refl , _ = refl
 
+-- Set⇒DSet : (X : Set A) → Set(Σ A (_∈ X))
+-- Set⇒DSet X = proj₁ (dreplacement X id)
+
+-- left-unique-mapOn : (X : Set A)(∈-uip : ∈-irrelevant X){f : Σ A (_∈ X) → B} → left-unique (mapˢ (λ x → proj₁ x , f x) (Set⇒DSet X))
+-- left-unique-mapOn _ ∈-uip {f} p q with from ∈-map p | from ∈-map q
+-- ... | (_ , a∈X) , refl , aa∈ | (_ , a∈X') , refl , aa'∈ = cong f (Σ-≡,≡→≡ (refl , ∈-uip a∈X a∈X'))
+
 Map : Type → Type → Type
 Map A B = Σ (Rel A B) left-unique
 

--- a/src/Axiom/Set/Properties.agda
+++ b/src/Axiom/Set/Properties.agda
@@ -88,6 +88,10 @@ cong-⊆⇒cong₂ h X≡ᵉX' Y≡ᵉY' = h (proj₁ X≡ᵉX') (proj₁ Y≡�
 ⊆-Transitive : Transitive (_⊆_ {A})
 ⊆-Transitive X⊆Y Y⊆Z = Y⊆Z ∘ X⊆Y
 
+∈-⊆ : {A : Type ℓ}{a : A}{X Y : Set A} → a ∈ X → X ⊆ Y → a ∈ Y
+∈-⊆ a∈X X⊆Y = X⊆Y a∈X
+
+
 ≡ᵉ-isEquivalence : IsEquivalence (_≡ᵉ_ {A})
 ≡ᵉ-isEquivalence = record
   { refl  = id , id

--- a/src/Axiom/Set/TotalMap.agda
+++ b/src/Axiom/Set/TotalMap.agda
@@ -7,12 +7,13 @@ module Axiom.Set.TotalMap (th : Theory) where
 open import Prelude hiding (lookup)
 
 open import Agda.Primitive              using () renaming (Set to Type)
-open import Axiom.Set.Map th            using (left-unique; Map ; mapWithKey-uniq)
+open import Function.Related.TypeIsomorphisms  using (Σ-≡,≡→≡)
+open import Axiom.Set.Map th            using (left-unique; Map ; mapWithKey-uniq ; left-unique-mapˢ)
 open import Axiom.Set.Rel th            using (Rel ; dom ; dom∈)
 open import Interface.DecEq             using (DecEq ; _≟_)
 open import Relation.Nullary.Decidable  using (yes ; no)
 
-open Theory th    using (_∈_ ; map ; Set ; ∈-map ; ∈-map′)
+open Theory th    using (_∈_ ; map ; Set ; ∈-map ; ∈-map′ ; isMaximal)
 open Equivalence  using (to ; from)
 
 private variable A B : Type
@@ -39,8 +40,8 @@ record TotalMap (A B : Type) : Type where
   lookup∈rel = proj₂ (to dom∈ total-rel)
 
   -- this is useful for proving equalities involving lookup
-  rel⇒lookup : {a : A}{b : B} → (a , b) ∈ rel → lookup a ≡ b
-  rel⇒lookup ab∈rel = sym (left-unique-rel ab∈rel (proj₂ (to dom∈ total-rel)))
+  ∈-rel→lookup-≡ : {a : A}{b : B} → (a , b) ∈ rel → lookup a ≡ b
+  ∈-rel→lookup-≡ ab∈rel = sym (left-unique-rel ab∈rel (proj₂ (to dom∈ total-rel)))
 
 
 module Update {B : Type} ⦃ _ : DecEq A ⦄ where
@@ -51,6 +52,12 @@ module Update {B : Type} ⦃ _ : DecEq A ⦄ where
     ... | yes  _ = b
     ... | no   _ = y
 
+  updateFn-id : {a : A}{b b' : B} → b ≡ updateFn (a , b) a b'
+  updateFn-id {a = a} with (a ≟ a)
+  ... | yes _ = refl
+  ... | no ¬p = ⊥-elim (¬p refl)
+
+
   open TotalMap
 
   mapWithKey : {B' : Type} → (A → B → B') → TotalMap A B → TotalMap A B'
@@ -60,3 +67,65 @@ module Update {B : Type} ⦃ _ : DecEq A ⦄ where
 
   update : A → B → TotalMap A B → TotalMap A B
   update a b = mapWithKey (updateFn (a , b))
+
+
+
+module LookupUpdate
+  {X : Set A}
+  {a : A} {a∈X : a ∈ X}
+  {b : B}
+  ⦃ decEqA : DecEq A ⦄ where
+
+  open TotalMap
+  open Update
+
+  ∈-rel-update  : (tm : TotalMap A B) → (a , b) ∈ rel (update a b tm)
+  ∈-rel-update tm = to ∈-map ((a , lookup tm a) , Σ-≡,≡→≡ (refl , updateFn-id{A = A}) , lookup∈rel tm)
+
+  lookup-update-id  : (tm : TotalMap A B) → (lookup (update a b tm)) a ≡ b
+  lookup-update-id tm = ∈-rel→lookup-≡ (update _ _ tm) (∈-rel-update tm)
+
+
+
+------------------------------------------------------
+-- Correspondences between total maps and functions --
+
+module FunTot {X : Set A}{⋁A≡X : isMaximal X} where
+  open TotalMap
+
+  Fun⇒Map : ∀{A B}{f : A → B} (X : Set A) → Map A B
+  Fun⇒Map {f = f} X = map (λ x → (x , f x)) X , left-unique-mapˢ X
+
+
+  Fun⇒TotalMap : (f : A → B) → TotalMap A B
+  Fun⇒TotalMap f .rel              = map (λ x → (x , f x)) X
+  Fun⇒TotalMap _ .left-unique-rel  = left-unique-mapˢ X
+  Fun⇒TotalMap _ .total-rel        = ∈-map′ (∈-map′ ⋁A≡X)
+
+  Fun∈TotalMap  : {f : A → B}{a : A}
+                → a ∈ X → (a , f a) ∈ rel (Fun⇒TotalMap f)
+  Fun∈TotalMap a∈X = ∈-map′ a∈X
+
+  lookup∘Fun⇒TotalMap-id  : {f : A → B}{a : A}
+                          → lookup (Fun⇒TotalMap f) a ≡ f a
+  lookup∘Fun⇒TotalMap-id {f = f} = ∈-rel→lookup-≡ ((Fun⇒TotalMap f)) (Fun∈TotalMap ⋁A≡X)
+
+
+  -- Set⇒DSet : Set(Σ A (_∈ X))
+  -- Set⇒DSet = proj₁ (dreplacement X id)
+
+  -- ∈-DSet : {aa : Σ A (_∈ X)} → aa ∈ Set⇒DSet
+  -- ∈-DSet{aa = aa} = to (proj₂ (dreplacement X id)) (aa , (refl , proj₂ aa))
+
+  -- FunOn⇒TotalMapOn : (∈-uip : ∈-irrelevant X)(f : Σ A (_∈ X) → B) → TotalMapOn X B
+  -- FunOn⇒TotalMapOn _      f  .rel                = map (λ x → proj₁ x , f x) Set⇒DSet
+  -- FunOn⇒TotalMapOn ∈-uip  _  .left-unique-rel    = left-unique-mapOn X ∈-uip
+  -- FunOn⇒TotalMapOn _      f  .total-rel {a} a∈X  = to ∈-map ((a , f (a , a∈X)) , refl , (∈-map′ ∈-DSet))
+
+  -- FunOn∈TotalMapOn  : (∈-uip : ∈-irrelevant X){f : Σ A (_∈ X) → B}{aa : Σ A (_∈ X)}
+  --                   → (proj₁ aa , f aa) ∈ rel (FunOn⇒TotalMapOn ∈-uip f)
+  -- FunOn∈TotalMapOn _ = ∈-map′ ∈-DSet
+
+  -- lookup∘FunOn⇒TotalMapOn-id  : (∈-uip : ∈-irrelevant X){f : Σ A (_∈ X) → B}{aa : Σ A (_∈ X)}
+  --                             → lookup (FunOn⇒TotalMapOn ∈-uip f) aa ≡ f aa
+  -- lookup∘FunOn⇒TotalMapOn-id ∈-uip {f} = ∈-rel→lookup-≡ ((FunOn⇒TotalMapOn ∈-uip f)) (FunOn∈TotalMapOn ∈-uip)

--- a/src/Axiom/Set/TotalMapOn.agda
+++ b/src/Axiom/Set/TotalMapOn.agda
@@ -6,14 +6,16 @@ module Axiom.Set.TotalMapOn (th : Theory) where
 
 open import Prelude hiding (lookup)
 
-open import Agda.Primitive              using () renaming (Set to Type)
-open import Axiom.Set.Map th            using (left-unique ; Map ; mapWithKey-uniq)
-open import Axiom.Set.Rel th            using (Rel ; dom ; dom∈)
-open import Interface.DecEq             using (DecEq ; _≟_)
-open import Relation.Nullary.Decidable  using (Dec ; yes ; no)
+open import Agda.Primitive                     using () renaming (Set to Type)
+open import Function.Related.TypeIsomorphisms  using (Σ-≡,≡→≡)
+open import Relation.Nullary.Decidable         using (Dec ; yes ; no)
 
-open Theory th    using ( Set ; _⊆_ ; _∈_ ; map ; ∈-map′ )
-open Equivalence  using (to)
+open import Axiom.Set.Map th                   using (left-unique ; Map ; mapWithKey-uniq ; left-unique-mapˢ)
+open import Axiom.Set.Rel th                   using (Rel ; dom ; dom∈)
+open import Interface.DecEq                    using (DecEq ; _≟_)
+
+open Theory th
+open Equivalence using (to)
 
 private variable A B : Type
 
@@ -21,7 +23,7 @@ _TotalOn_ : Rel A B → Set A → Type
 R TotalOn X = X ⊆ dom R
 
 
-record TotalMapOn {A : Type}(X : Set A)(B : Type) : Type where
+record TotalMapOn (X : Set A)(B : Type) : Type where
   field  rel              : Set (A × B)
          left-unique-rel  : left-unique rel
          total-rel        : rel TotalOn X
@@ -32,22 +34,29 @@ record TotalMapOn {A : Type}(X : Set A)(B : Type) : Type where
   lookup : Σ A (_∈ X) → B
   lookup (_ , a∈X) = proj₁ (to dom∈ (total-rel a∈X))
 
+  lookup' : (a : A) → (a ∈ X) → B
+  lookup' _ a∈X = proj₁ (to dom∈ (total-rel a∈X))
+
   -- verify that lookup is what we expect
   lookup∈rel : {a : A} (a∈X : a ∈ X) → (a , lookup (a , a∈X)) ∈ rel
   lookup∈rel a∈X = proj₂ (to dom∈ (total-rel a∈X))
 
   -- this is useful for proving equalities involving lookup
-  rel⇒lookup : {a : A} {a∈dom : a ∈ X} {b : B} → (a , b) ∈ rel → lookup (a , a∈dom) ≡ b
-  rel⇒lookup {a} {a∈dom} ab∈rel = sym (left-unique-rel ab∈rel (proj₂ (to dom∈ (total-rel a∈dom))))
+  ∈-rel→lookup-≡ : {a : A} {a∈dom : a ∈ X} {b : B} → (a , b) ∈ rel → lookup (a , a∈dom) ≡ b
+  ∈-rel→lookup-≡ {a} {a∈dom} ab∈rel = sym (left-unique-rel ab∈rel (proj₂ (to dom∈ (total-rel a∈dom))))
 
 
-module UpdateOn {B : Type} ⦃ _ : DecEq A ⦄ where
+module UpdateOn ⦃ _ : DecEq A ⦄ where
 
-  private
-    updateFn : A × B → A → B → B
-    updateFn (a , b) x y with (x ≟ a)
-    ... | yes  _ = b
-    ... | no   _ = y
+  updateFn : A × B → A → B → B
+  updateFn (a , b) x y with (x ≟ a)
+  ... | yes  _ = b
+  ... | no   _ = y
+
+  updateFn-id : {a : A}{b b' : B} → b ≡ updateFn (a , b) a b'
+  updateFn-id {a = a} with (a ≟ a)
+  ... | yes _ = refl
+  ... | no ¬p = ⊥-elim (¬p refl)
 
   open TotalMapOn
 
@@ -59,3 +68,61 @@ module UpdateOn {B : Type} ⦃ _ : DecEq A ⦄ where
   -- Return a new total map which is the same as the given total map except at a.
   update : {X : Set A} → A → B → TotalMapOn X B → TotalMapOn X B
   update a b = mapWithKeyOn (updateFn (a , b))
+
+
+module LookupUpdateOn
+  {X : Set A}
+  {a : A} {a∈X : a ∈ X}
+  {b : B}
+  ⦃ decEqA : DecEq A ⦄ where
+
+  open TotalMapOn
+  open UpdateOn
+
+  ∈-rel-update  : (tm : TotalMapOn X B) → (a , b) ∈ rel (update a b tm)
+  ∈-rel-update tm = to ∈-map  ( (a , lookup tm (a , a∈X))
+                              , (Σ-≡,≡→≡ (refl , updateFn-id {A}))
+                              , lookup∈rel tm a∈X )
+
+  lookup-update-id  : (tm : TotalMapOn X B) → (lookup (update a b tm)) (a , a∈X) ≡ b
+  lookup-update-id tm = ∈-rel→lookup-≡ (update _ _ tm) (∈-rel-update tm)
+
+
+------------------------------------------------------
+-- Correspondences between total maps and functions --
+
+module _ {X : Set A} where
+  open TotalMapOn
+
+  Fun⇒TotalMapOn : (f : A → B) → TotalMapOn X B
+  Fun⇒TotalMapOn f .rel              = map (λ x → (x , f x)) X
+  Fun⇒TotalMapOn _ .left-unique-rel  = left-unique-mapˢ X
+  Fun⇒TotalMapOn _ .total-rel a∈X    = ∈-map′ (∈-map′ a∈X)
+
+  Fun∈TotalMapOn  : {f : A → B}{a : A}
+                  → a ∈ X → (a , f a) ∈ rel (Fun⇒TotalMapOn f)
+  Fun∈TotalMapOn a∈X = ∈-map′ a∈X
+
+  lookup∘Fun⇒TotalMapOn-id  : {f : A → B}{a : A}
+                            → (a∈X : a ∈ X) → lookup (Fun⇒TotalMapOn f) (a , a∈X) ≡ f a
+  lookup∘Fun⇒TotalMapOn-id {f = f} a∈X = ∈-rel→lookup-≡ ((Fun⇒TotalMapOn f)) (Fun∈TotalMapOn a∈X)
+
+
+  -- Set⇒DSet : Set(Σ A (_∈ X))
+  -- Set⇒DSet = proj₁ (dreplacement X id)
+
+  -- ∈-DSet : {aa : Σ A (_∈ X)} → aa ∈ Set⇒DSet
+  -- ∈-DSet{aa = aa} = to (proj₂ (dreplacement X id)) (aa , (refl , proj₂ aa))
+
+  -- FunOn⇒TotalMapOn : (∈-uip : ∈-irrelevant X)(f : Σ A (_∈ X) → B) → TotalMapOn X B
+  -- FunOn⇒TotalMapOn _      f  .rel                = map (λ x → proj₁ x , f x) Set⇒DSet
+  -- FunOn⇒TotalMapOn ∈-uip  _  .left-unique-rel    = left-unique-mapOn X ∈-uip
+  -- FunOn⇒TotalMapOn _      f  .total-rel {a} a∈X  = to ∈-map ((a , f (a , a∈X)) , refl , (∈-map′ ∈-DSet))
+
+  -- FunOn∈TotalMapOn  : (∈-uip : ∈-irrelevant X){f : Σ A (_∈ X) → B}{aa : Σ A (_∈ X)}
+  --                   → (proj₁ aa , f aa) ∈ rel (FunOn⇒TotalMapOn ∈-uip f)
+  -- FunOn∈TotalMapOn _ = ∈-map′ ∈-DSet
+
+  -- lookup∘FunOn⇒TotalMapOn-id  : (∈-uip : ∈-irrelevant X){f : Σ A (_∈ X) → B}{aa : Σ A (_∈ X)}
+  --                             → lookup (FunOn⇒TotalMapOn ∈-uip f) aa ≡ f aa
+  -- lookup∘FunOn⇒TotalMapOn-id ∈-uip {f} = ∈-rel→lookup-≡ ((FunOn⇒TotalMapOn ∈-uip f)) (FunOn∈TotalMapOn ∈-uip)

--- a/src/Ledger/Foreign/HSLedger.agda
+++ b/src/Ledger/Foreign/HSLedger.agda
@@ -6,6 +6,9 @@ open import Ledger.Prelude
 import Data.Maybe as M
 import Data.Rational as ℚ
 
+open import Algebra              using (CommutativeMonoid)
+open import Algebra.Morphism     using (module MonoidMorphisms)
+open import Data.Nat.Properties  using (+-0-monoid)
 open import Data.Nat using (_≤_; _≤ᵇ_)
 open import Data.Nat.Properties using (+-*-semiring; <-isStrictTotalOrder)
 
@@ -91,29 +94,31 @@ HSP2ScriptStructure .validPlutusScript?    = λ ()
 HSScriptStructure : ScriptStructure ℕ ℕ ℕ
 HSScriptStructure = record { p1s = HSP1ScriptStructure ; ps = HSP2ScriptStructure }
 
-open import Data.Nat
-open import Data.Nat.Properties using (+-0-commutativeMonoid; _≟_)
-open import Ledger.TokenAlgebra
 open import Ledger.Transaction
+import Ledger.TokenAlgebra as TA
+open import Data.Nat.Properties using (+-0-commutativeMonoid; _≟_)
+open import Data.Nat
 
-coinTokenAlgebra : TokenAlgebra
-coinTokenAlgebra = record
-  { PolicyId                = ℕ
-  ; Value-CommutativeMonoid = +-0-commutativeMonoid
-  ; coin                    = id
-  ; inject                  = id
-  ; policies                = λ x → ∅
-  ; size                    = λ x → 1 -- there is only ada in this token algebra
-  ; property                = λ x → refl
-  ; coinIsMonoidMorphism    = record
-    { mn-homo = record
-      { sm-homo = record { ⟦⟧-cong = λ z → z ; ∙-homo  = λ x y → refl }
-      ; ε-homo  = refl
+module _ where
+
+  open TA ℕ
+  open TA.TokenAlgebra
+  coinTokenAlgebra : TokenAlgebra
+  Value-CommutativeMonoid coinTokenAlgebra    = +-0-commutativeMonoid
+  coin coinTokenAlgebra                       = id
+  inject coinTokenAlgebra                     = id
+  policies coinTokenAlgebra                   = λ _ → ∅
+  size coinTokenAlgebra                       = λ x → 1 -- there is only ada in this token algebra
+  _≤ᵗ_ coinTokenAlgebra                       = _≤_
+  AssetName coinTokenAlgebra                  = String
+  specialAsset coinTokenAlgebra               = "Ada"
+  property coinTokenAlgebra                   = λ _ → refl
+  coinTokenAlgebra .coinIsMonoidHomomorphism  =
+    record
+      { isMagmaHomomorphism  = record { isRelHomomorphism = record { cong = id } ; homo = λ _ _ → refl }
+      ; ε-homo               = refl
       }
-    }
-  ; _≤ᵗ_                    = _≤_
-  ; DecEq-Value             = record { _≟_ = Data.Nat._≟_ }
-  }
+  DecEq-Value coinTokenAlgebra                = record { _≟_ = Data.Nat._≟_ }
 
 module _ where
   open TransactionStructure

--- a/src/Ledger/PDF.lagda
+++ b/src/Ledger/PDF.lagda
@@ -88,6 +88,8 @@ open import Ledger.PPUp
 open import Ledger.PPUp.Properties
 
 open import Ledger.Ledger.Properties
+
+open import Ledger.TokenAlgebra.ValueSet
 \end{code}
 
 \include{Ledger/Introduction}

--- a/src/Ledger/Prelude.agda
+++ b/src/Ledger/Prelude.agda
@@ -86,7 +86,7 @@ open import Axiom.Set.Map th public
   renaming (Map to _⇀_)
 
 open import Axiom.Set.TotalMap th public
-open import Axiom.Set.TotalMapOn th public
+open import Axiom.Set.TotalMapOn th
 
 open L.Decˡ public
   hiding (_∈?_; ≟-∅)

--- a/src/Ledger/TokenAlgebra.lagda
+++ b/src/Ledger/TokenAlgebra.lagda
@@ -1,40 +1,50 @@
 \section{Token algebras}
+\label{sec:token-algebra}
+
 \begin{code}[hide]
 {-# OPTIONS --safe #-}
-module Ledger.TokenAlgebra where
+
+module Ledger.TokenAlgebra (PolicyId : Set) where
 
 open import Ledger.Prelude
 
-open import Algebra using (CommutativeMonoid)
-open import Algebra.Morphism
-open import Data.Integer
-open import Data.Nat.Properties using (+-0-commutativeMonoid)
+open import Algebra              using (CommutativeMonoid ; Monoid)
+open import Algebra.Morphism     using (module MonoidMorphisms )
+open import Data.Nat.Properties  using (+-0-monoid)
+open import Relation.Binary      using (Rel)
+open import Relation.Unary       using (Pred)
 \end{code}
 
 \begin{figure*}
 \begin{code}
 record TokenAlgebra : Set₁ where
-  field PolicyId : Set
-        Value-CommutativeMonoid : CommutativeMonoid 0ℓ 0ℓ
+  field  Value-CommutativeMonoid : CommutativeMonoid 0ℓ 0ℓ
 
+  MemoryEstimate : Set
   MemoryEstimate = ℕ
 \end{code}
 \begin{code}[hide]
-  open CommutativeMonoid Value-CommutativeMonoid using (_≈_; ε)
-       renaming (Carrier to Value; refl to reflᵛ; _∙_ to _+ᵛ_) public
+  open CommutativeMonoid Value-CommutativeMonoid public
+    using ( _≈_ ; ε ; monoid ; rawMonoid)
+    renaming  ( Carrier  to Value
+              ; refl     to reflᵛ
+              ; _∙_      to _+ᵛ_
+              )
+  open MonoidMorphisms (rawMonoid) (Monoid.rawMonoid +-0-monoid) public
 \end{code}
 \begin{code}
-  field coin      : Value → Coin
-        inject    : Coin → Value
-        policies  : Value → ℙ PolicyId
-        size      : Value → MemoryEstimate
-        _≤ᵗ_      : Value → Value → Set
-
-        property             : coin ∘ inject ≗ id
-        coinIsMonoidMorphism : coin Is Value-CommutativeMonoid -CommutativeMonoid⟶ +-0-commutativeMonoid
+  field  coin                      : Value → Coin
+         inject                    : Coin → Value
+         policies                  : Value → ℙ PolicyId
+         size                      : Value → MemoryEstimate
+         _≤ᵗ_                      : Value → Value → Set
+         AssetName                 : Set
+         specialAsset              : AssetName
+         property                  : coin ∘ inject ≗ id
+         coinIsMonoidHomomorphism  : IsMonoidHomomorphism coin
 \end{code}
 \begin{code}[hide]
-        instance DecEq-Value : DecEq Value
+         instance DecEq-Value : DecEq Value
 \end{code}
 \begin{code}
   sumᵛ : List Value → Value

--- a/src/Ledger/TokenAlgebra/ValueSet.lagda
+++ b/src/Ledger/TokenAlgebra/ValueSet.lagda
@@ -1,0 +1,276 @@
+\subsection{Value Set}
+
+\begin{code}[hide]
+{-# OPTIONS --safe --no-import-sorts #-}
+{-# OPTIONS -v allTactics:100 #-}
+
+open import Agda.Primitive using () renaming (Set to Type)
+open import Axiom.Set using ( Theory )
+
+
+module Ledger.TokenAlgebra.ValueSet (PolicyId AssetName : Type) where
+
+open import Ledger.Prelude using (_×_ ; ℙ_ ; module Equivalence ; _≡_ ; _,_ ; 0ℓ ; proj₁ ; proj₂ ; Coin ; _∘_ ; _≗_ ; id ; th) -- hiding (lookup )
+                            renaming (TotalMap to _⇒_ ) using (module FunTot ; module Update ; module LookupUpdate)
+
+open import Ledger.TokenAlgebra PolicyId  using (TokenAlgebra )
+open import Interface.DecEq               using (DecEq)
+
+open import Algebra                       using (CommutativeMonoid ; Op₂ ; IsSemigroup ; IsMonoid)
+open import Algebra.Morphism              using (module MonoidMorphisms ; IsMagmaHomomorphism)
+open import Data.Nat                      using (ℕ ; _≤_ ; _+_)
+open import Data.Nat.Properties           using (+-0-commutativeMonoid ; +-comm ; +-assoc ; +-identityʳ)
+open import Function.Related.TypeIsomorphisms using (Σ-≡,≡→≡)
+open import Relation.Binary               using (IsEquivalence)
+                                          renaming (Decidable to Dec₂)
+
+open import Relation.Binary.PropositionalEquality.Core using ( module ≡-Reasoning ; cong)
+
+import Relation.Binary.PropositionalEquality as ≡
+import Relation.Binary.Core  as stdlib
+
+open Theory th                          using (∈-irrelevant ; _∈_ ; ∈-map ; ∈-map′ ; ≡∈ ; singleton; isMaximal )
+                                        renaming (map to mapˢ ) -- ; Set to ℙ )
+
+
+\end{code}
+
+\subsubsection{Derived types}
+
+(See Fig 3 of the
+\href{https://github.com/input-output-hk/cardano-ledger/releases/latest/download/mary-ledger.pdf}%
+{Mary ledger specification}.)
+
+\begin{itemize}
+\item \AgdaBound{AssetName} is a byte string used to distinguish different assets with the same \AgdaBound{PolicyId}.
+\item \AgdaBound{AssetId} is a product type consisting of a \AgdaBound{PolicyId} and an \AgdaBound{AssetName}.
+\item \AgdaBound{AdaId} is the Id for the asset Ada.
+\item \AgdaBound{Quantity} is the type of amounts of assets.
+\end{itemize}
+
+In the formal ledger specification \AgdaBound{AssetId} is sometimes viewed as a direct sum type,
+the inhabitants of which belong to either \AgdaBound{AdaIdType} or the product
+\AgdaBound{PolicyId}~\AgdaBound{×}~\AgdaBound{AssetName}; if we were adhering to that point of view,
+then we would have defined
+\AgdaBound{AssetId}
+  = \AgdaBound{AdaIdType}~\AgdaBound{⊎}~(\AgdaBound{PolicyId}~\AgdaBound{×}~\AgdaBound{AssetName}).
+
+Finally, we define a record type with a single inhabitant with which we may wish to
+represent the type of Ada (rather than viewing Ada as just another asset).
+
+\begin{code}
+record AdaIdType : Type where
+  instance constructor AdaId
+\end{code}
+
+
+\subsection{Definition of the value monoid}
+
+An inhabitant of `Value` is a map denoting a finite collection of quantities of assets.
+
+\begin{code}
+open CommutativeMonoid renaming (_∙_ to _⋆_) hiding (refl ; sym ; trans)
+
+AssetId : Type
+AssetId = PolicyId × AssetName
+
+module _ {X : ℙ AssetId} {⋁A : isMaximal X} where
+
+  open _⇒_
+  open ≡-Reasoning
+  open Equivalence
+  open FunTot {AssetId}{X}{⋁A}
+
+  Quantity : Type
+  Quantity = ℕ
+
+
+  _⊕_ : Op₂ (AssetId ⇒ Quantity)
+  u ⊕ v = Fun⇒TotalMap f+g
+    where
+    f g f+g : AssetId → Quantity
+    f = lookup u
+    g = lookup v
+    f+g aa = f aa + g aa
+
+  ⊕-lemma : (u v : AssetId ⇒ Quantity) → (aa : AssetId)
+   →       lookup (u ⊕ v) aa ≡ lookup u aa + lookup v aa
+  ⊕-lemma u v a = begin
+    lookup (u ⊕ v) a ≡⟨ ≡.refl ⟩
+    lookup (Fun⇒TotalMap (λ x → lookup u x + lookup v x)) a ≡⟨ lookup∘Fun⇒TotalMap-id ⟩
+    lookup u a + lookup v a ∎
+
+
+  zeroFun : AssetId → Quantity
+  zeroFun = λ _ → 0
+
+  zeroMap : AssetId ⇒ Quantity
+  zeroMap = Fun⇒TotalMap zeroFun
+
+  ι : AssetId ⇒ Quantity
+  ι = Fun⇒TotalMap zeroFun
+
+  ι-lem0 :  ∀{a} → lookup ι a ≡ 0
+  ι-lem0 {a} = ∈-rel→lookup-≡ ι (∈-map′ ⋁A)
+
+  ι-lem1 : ∀{a} → (a , lookup ι a) ∈ rel ι
+  ι-lem1 {a} = lookup∈rel ι
+
+  ι-lem2 : ∀{a : AssetId} → (a , 0) ∈ rel ι
+  ι-lem2 {a} = ≡∈ ι-lem1 (Σ-≡,≡→≡ (≡.refl , ι-lem0))
+
+  _≋_ : stdlib.Rel (AssetId ⇒ Quantity) 0ℓ
+  tm ≋ tm' = ∀{aa} → (lookup tm) aa ≡ (lookup tm') aa
+
+
+  open IsEquivalence
+  ≋-isEquivalence : IsEquivalence {0ℓ} _≋_
+  ≋-isEquivalence .refl = ≡.refl
+  IsEquivalence.sym ≋-isEquivalence x≋y = ≡.sym x≋y
+  IsEquivalence.trans ≋-isEquivalence x y = ≡.trans x y
+
+
+  ⊕-cong : Algebra.Congruent₂ _≋_ _⊕_
+  ⊕-cong {x} {y} {u} {v} x≋y u≋v {a} = Goal
+    where
+    Goal : lookup (x ⊕ u) a ≡ lookup (y ⊕ v) a
+    Goal = begin
+      lookup (x ⊕ u) a         ≡⟨ ⊕-lemma x u a ⟩
+      lookup x a + lookup u a  ≡⟨ cong (λ w → w + lookup u a) x≋y ⟩
+      lookup y a + lookup u a  ≡⟨ cong (λ w → lookup y a + w) u≋v ⟩
+      lookup y a + lookup v a  ≡⟨ ≡.sym (⊕-lemma y v a) ⟩
+      lookup (y ⊕ v) a         ∎
+
+
+  ⊕-comm : Algebra.Commutative _≋_ _⊕_
+  ⊕-comm u v {aa} = Goal
+    where
+    Goal : lookup (u ⊕ v) aa ≡ lookup (v ⊕ u) aa
+    Goal = begin
+      lookup (u ⊕ v) aa          ≡⟨ ⊕-lemma u v aa ⟩
+      lookup u aa + lookup v aa  ≡⟨ +-comm (lookup u aa) (lookup v aa) ⟩
+      lookup v aa + lookup u aa  ≡⟨ ≡.sym (⊕-lemma v u aa) ⟩
+      lookup (v ⊕ u) aa          ∎
+
+  ⊕-assoc : Algebra.Associative _≋_ _⊕_
+  ⊕-assoc x y z {a} = Goal
+    where
+    Goal : lookup ((x ⊕ y) ⊕ z) a ≡ lookup (x ⊕ (y ⊕ z)) a
+    Goal = begin
+      lookup ((x ⊕ y) ⊕ z) a                  ≡⟨ ⊕-lemma (x ⊕ y) z a ⟩
+      lookup (x ⊕ y) a + lookup z a           ≡⟨ cong (λ w → w + lookup z a) (⊕-lemma x y a) ⟩
+      lookup x a + lookup y a + lookup z a    ≡⟨ +-assoc (lookup x a) (lookup y a) (lookup z a) ⟩
+      lookup x a + (lookup y a + lookup z a)  ≡⟨ cong (λ w → lookup x a + w) (≡.sym (⊕-lemma y z a)) ⟩
+      lookup x a + (lookup (y ⊕ z) a)         ≡⟨ ≡.sym (⊕-lemma x (y ⊕ z) a) ⟩
+      lookup (x ⊕ (y ⊕ z)) a                  ∎
+
+
+  ι-zero : ∀{a : AssetId} → lookup ι a ≡ 0
+  ι-zero {aa} = (left-unique-rel ι) ι-lem1  (ι-lem2 {aa})
+
+  ι-identity : Algebra.Identity _≋_ ι _⊕_
+  proj₁ ι-identity tm {aa} = lid
+    where
+    lid : lookup (ι ⊕ tm) aa ≡ lookup tm aa
+    lid = begin
+      lookup (ι ⊕ tm) aa          ≡⟨ ⊕-lemma ι tm aa ⟩
+      lookup ι aa + lookup tm aa  ≡⟨ cong (λ x → x + lookup tm aa) ι-zero ⟩
+      lookup tm aa                ∎
+
+  proj₂ ι-identity tm {aa} = begin
+    lookup (tm ⊕ ι) aa          ≡⟨ ⊕-lemma tm ι aa ⟩
+    lookup tm aa + lookup ι aa  ≡⟨ cong (λ x → lookup tm aa + x) ι-zero ⟩
+    lookup tm aa + 0            ≡⟨ +-identityʳ (lookup tm aa) ⟩
+    lookup tm aa                ∎
+
+  isSemigrp : IsSemigroup _≋_ _⊕_
+  isSemigrp = record
+    { isMagma = record
+        { isEquivalence = ≋-isEquivalence
+        ; ∙-cong = λ{u}{v}{w}{x} y z → ⊕-cong {u}{v}{w}{x} y z }
+    ; assoc = ⊕-assoc }
+
+  ≋-⊕-ι-isMonoid : IsMonoid _≋_ _⊕_ ι
+  ≋-⊕-ι-isMonoid = record { isSemigroup = isSemigrp ; identity = ι-identity }
+
+
+
+  Value-TokenAlgebra  :  ( specialPolicy  : PolicyId                            )
+                         ( specialAsset   : AssetName                           )
+                         ( specId∈X         : (specialPolicy , specialAsset) ∈ X  )
+                         ( policies       : (AssetId ⇒ Quantity) → ℙ PolicyId           )
+                         ( size           : AssetId ⇒ Quantity → ℕ                    )
+
+       { decTot  : DecEq (AssetId ⇒ Quantity) }
+       ⦃ dec     : DecEq (PolicyId × AssetName) ⦄
+       { _∈?_    : ⦃ DecEq (PolicyId × AssetName) ⦄ → Dec₂ (_∈_ {A = PolicyId × AssetName}) }
+       {∈-uip    : ∈-irrelevant X}
+       ---------------------------------------------------------------------------------------
+    →  TokenAlgebra
+
+  Value-TokenAlgebra specialPolicy specialAsset specId∈X policies size {decTot} ⦃ dec ⦄ { _∈?_ }{∈-uip} =
+    record
+      { Value-CommutativeMonoid = Vcm
+      ; coin = λ tm → lookup tm (specialPolicy , specialAsset)
+      ; inject = inj
+      ; policies = policies
+      ; size = size
+      ; _≤ᵗ_ = λ u v → ∀ {a}{a∈X} → lookup u (a , a∈X) ≤ lookup v (a , a∈X)
+      ; AssetName = AssetName
+      ; specialAsset = specialAsset
+      ; property = compose-to-id
+      ; coinIsMonoidHomomorphism = CoinMonHom
+      ; DecEq-Value = decTot
+      }
+    where
+
+
+    specId : AssetId
+    specId = (specialPolicy , specialAsset)
+
+    open Update ⦃ dec ⦄
+
+    inj : Coin → AssetId ⇒ Quantity
+    inj c = update specId c zeroMap
+
+    compose-to-id : (λ m → lookup m specId) ∘ inj ≗ id
+    compose-to-id q = lookup-update-id zeroMap
+      where open LookupUpdate {X = X}{specId}{⋁A}
+
+
+    Vcm : CommutativeMonoid 0ℓ 0ℓ
+    Vcm =
+      record
+        { Carrier = AssetId ⇒ Quantity
+        ; _≈_ = _≋_
+        ; _∙_ = _⊕_
+        ; ε = ι
+        ; isCommutativeMonoid = record { isMonoid = ≋-⊕-ι-isMonoid ; comm = ⊕-comm }
+        }
+
+
+    open CommutativeMonoid Vcm renaming ( rawMonoid to Vcm-mon ) using ()
+    open CommutativeMonoid +-0-commutativeMonoid renaming ( rawMonoid to ℕ-mon) using ( _≈_ )
+    open Algebra using (module RawMonoid)
+    -- open RawMonoid Vcm-mon renaming ( _∙_ to _⊞_ ; ε to ι )
+    open RawMonoid ℕ-mon renaming ( _≈_ to _≈ℕ_ ; _∙_ to _◦_ )
+
+    open IsMagmaHomomorphism using ( isRelHomomorphism ; homo )
+    open MonoidMorphisms Vcm-mon ℕ-mon using ( IsMonoidHomomorphism )
+    open IsMonoidHomomorphism using ( isMagmaHomomorphism ; ε-homo )
+
+    CoinMonHom : IsMonoidHomomorphism (λ u → lookup u specId)
+    isMagmaHomomorphism CoinMonHom .isRelHomomorphism  = record { cong = λ x → x }
+    isMagmaHomomorphism CoinMonHom .homo x y           = ⊕-lemma x y specId
+
+    CoinMonHom .ε-homo = ι-lem0
+
+    ------------------------------------------------------------------------------------------------------
+    -- odds and ends -------------------------------------------------------------------------------------
+    coinQzeroAsSet : ℙ (AssetId × Quantity)
+    coinQzeroAsSet = singleton (specId , 0)
+
+    P : AssetId × Quantity → Type
+    P ( _ , q) = q ≡ 0
+
+\end{code}

--- a/src/Ledger/Transaction.lagda
+++ b/src/Ledger/Transaction.lagda
@@ -12,10 +12,10 @@ open import Ledger.Prelude
 
 open import Ledger.Crypto
 open import Ledger.Epoch
-open import Ledger.TokenAlgebra
 import Ledger.PParams
 import Ledger.Script
 import Ledger.GovernanceActions
+import Ledger.TokenAlgebra as TA
 
 record TransactionStructure : Set₁ where
   field
@@ -53,17 +53,19 @@ the transaction body are:
         ppUpd                               : Ledger.PParams.PParamsDiff epochStructure
         txidBytes                           : TxId → Crypto.Ser crypto
         networkId                           : Network
-        tokenAlgebra                        : TokenAlgebra
         instance DecEq-TxId  : DecEq TxId
                  DecEq-Ix    : DecEq Ix
                  DecEq-Netw  : DecEq Network
                  DecEq-UpdT  : DecEq (Ledger.PParams.PParamsDiff.UpdateT ppUpd)
 
   open Crypto crypto public
-  open TokenAlgebra tokenAlgebra public
+  open TA ScriptHash
   open isHashableSet adHashingScheme renaming (THash to ADHash) public
 
-  field ss : Ledger.Script.ScriptStructure KeyHash ScriptHash Slot
+  field  ss            : Ledger.Script.ScriptStructure KeyHash ScriptHash Slot
+         tokenAlgebra  : TokenAlgebra
+
+  open TokenAlgebra tokenAlgebra public
 
   open Ledger.Script.ScriptStructure ss public
 

--- a/src/Ledger/Utxo/Properties.lagda
+++ b/src/Ledger/Utxo/Properties.lagda
@@ -29,7 +29,7 @@ open import Tactic.MonoidSolver
 open TransactionStructure txs
 
 open import Ledger.PParams epochStructure
-open import Ledger.TokenAlgebra using (TokenAlgebra)
+open import Ledger.TokenAlgebra ScriptHash
 open import Ledger.Utxo txs renaming (Computational-UTXO to Computational-UTXO')
 
 open TxBody
@@ -61,24 +61,25 @@ abstract
   Computational-UTXO : Computational _⊢_⇀⦇_,UTXO⦈_
   Computational-UTXO = Computational-UTXO'
 
-⟦⟧-cong-Coin = IsCommutativeMonoidMorphism.⟦⟧-cong coinIsMonoidMorphism
-∙-homo-Coin = IsCommutativeMonoidMorphism.∙-homo
-
 balance-cong : proj₁ utxo ≡ᵉ proj₁ utxo' → balance utxo ≈ balance utxo'
 balance-cong {utxo} {utxo'} = indexedSumᵐ-cong {x = utxo ᶠᵐ} {utxo' ᶠᵐ}
 
 balance-cong-coin : proj₁ utxo ≡ᵉ proj₁ utxo' → cbalance utxo ≡ cbalance utxo'
-balance-cong-coin {utxo} {utxo'} x = ⟦⟧-cong-Coin (balance-cong {utxo} {utxo'} x)
+balance-cong-coin {utxo} {utxo'} x = IsMonoidHomomorphism.⟦⟧-cong coinIsMonoidHomomorphism (balance-cong {utxo} {utxo'} x)
+
+open MonoidMorphisms.IsMonoidHomomorphism
+private
+  ∙-homo-Coin = IsMagmaHomomorphism.homo (isMagmaHomomorphism coinIsMonoidHomomorphism)
 
 balance-∪ : disjoint (dom (utxo ˢ)) (dom (utxo' ˢ))
                      → cbalance (utxo ∪ᵐˡ utxo') ≡ cbalance utxo + cbalance utxo'
 balance-∪ {utxo} {utxo'} h = begin
   cbalance (utxo ∪ᵐˡ utxo')
-    ≡⟨ ⟦⟧-cong-Coin (indexedSumᵐ-cong {x = (utxo ∪ᵐˡ utxo') ᶠᵐ} {(utxo ᶠᵐ) ∪ᵐˡᶠ (utxo' ᶠᵐ)} (id , id)) ⟩
+    ≡⟨ ⟦⟧-cong coinIsMonoidHomomorphism (indexedSumᵐ-cong {x = (utxo ∪ᵐˡ utxo') ᶠᵐ} {(utxo ᶠᵐ) ∪ᵐˡᶠ (utxo' ᶠᵐ)} (id , id)) ⟩
   coin (indexedSumᵐ _ ((utxo ᶠᵐ) ∪ᵐˡᶠ (utxo' ᶠᵐ)))
-    ≡⟨ ⟦⟧-cong-Coin (indexedSumᵐ-∪ {X = utxo ᶠᵐ} {utxo' ᶠᵐ} h) ⟩
+    ≡⟨ ⟦⟧-cong coinIsMonoidHomomorphism (indexedSumᵐ-∪ {X = utxo ᶠᵐ} {utxo' ᶠᵐ} h) ⟩
   coin (balance utxo +ᵛ balance utxo')
-    ≡⟨ ∙-homo-Coin coinIsMonoidMorphism _ _ ⟩
+    ≡⟨ ∙-homo-Coin  _ _ ⟩
   cbalance utxo + cbalance utxo' ∎
 
 newTxid⇒disj : txid tx ∉ map proj₁ (dom (utxo ˢ)) → disjoint' (dom (utxo ˢ)) (dom ((outs tx) ˢ))
@@ -90,11 +91,11 @@ consumedCoinEquality : ∀ {pp} → coin (mint tx) ≡ 0
                      ≡ cbalance ((UTxOState.utxo utxoState) ∣ txins tx) + depositRefunds pp utxoState tx
 consumedCoinEquality {tx} {utxoState} {pp} h = let utxo = UTxOState.utxo utxoState in begin
   coin (balance (utxo ∣ txins tx) +ᵛ mint tx +ᵛ inject (depositRefunds pp utxoState tx))
-    ≡⟨ ∙-homo-Coin coinIsMonoidMorphism _ _ ⟩
+    ≡⟨ ∙-homo-Coin _ _ ⟩
   coin (balance (utxo ∣ txins tx) +ᵛ mint tx) + coin (inject $ depositRefunds pp utxoState tx)
     ≡⟨ cong (coin (balance (utxo ∣ txins tx) +ᵛ mint tx) +_) (property _) ⟩
   coin (balance (utxo ∣ txins tx) +ᵛ mint tx) + depositRefunds pp utxoState tx
-    ≡⟨ cong! (∙-homo-Coin coinIsMonoidMorphism _ _) ⟩
+    ≡⟨ cong! (∙-homo-Coin _ _) ⟩
   coin (balance (utxo ∣ txins tx)) + coin (mint tx) + depositRefunds pp utxoState tx
     ≡⟨ cong (λ x → cbalance (utxo ∣ txins tx) + x + depositRefunds pp utxoState tx) h ⟩
   cbalance (utxo ∣ txins tx) + 0 + depositRefunds pp utxoState tx
@@ -105,15 +106,15 @@ producedCoinEquality : ∀ {pp} → coin (produced pp utxoState tx)
                               ≡ cbalance (outs tx) + (txfee tx) + newDeposits pp utxoState tx + txdonation tx
 producedCoinEquality {utxoState} {tx} {pp} = begin
   coin (balance (outs tx) +ᵛ inject (txfee tx) +ᵛ inject (newDeposits pp utxoState tx) +ᵛ inject (txdonation tx))
-    ≡⟨ ∙-homo-Coin coinIsMonoidMorphism _ _ ⟩
+    ≡⟨ ∙-homo-Coin _ _ ⟩
   coin (balance (outs tx) +ᵛ inject (txfee tx) +ᵛ inject (newDeposits pp utxoState tx)) + coin (inject (txdonation tx))
     ≡⟨ cong (_+ coin (inject (txdonation tx))) (begin
       coin (balance (outs tx) +ᵛ inject (txfee tx) +ᵛ inject (newDeposits pp utxoState tx))
-        ≡⟨ ∙-homo-Coin coinIsMonoidMorphism _ _ ⟩
+        ≡⟨ ∙-homo-Coin _ _ ⟩
       coin (balance (outs tx) +ᵛ inject (txfee tx)) + coin (inject (newDeposits pp utxoState tx))
         ≡⟨ cong! (property _) ⟩
       coin (balance (outs tx) +ᵛ inject (txfee tx)) + newDeposits pp utxoState tx
-        ≡⟨ cong! (∙-homo-Coin coinIsMonoidMorphism _ _) ⟩
+        ≡⟨ cong! (∙-homo-Coin _ _) ⟩
       coin (balance (outs tx)) + coin (inject (txfee tx)) + newDeposits pp utxoState tx
         ≡⟨ cong (λ x → cbalance (outs tx) + x + newDeposits pp utxoState tx) (property (txfee tx)) ⟩
       cbalance (outs tx) + (txfee tx) + newDeposits pp utxoState tx                     ∎


### PR DESCRIPTION
This PR provides a new module called `Ledger.TokenAlgebra.ValueSet` which uses the new functionality in `TotalMap` to define a token algebra using the `Theory` record of the `Axiom.Set` module.

To implement a token algebra using `Set` and modeling the value type as a *total* function on a given `X : Set A` I needed to add some functionality to `TotalMap` (and similar functionality to a new module, called `TotalMapOn` which restricts maps to the set `X`, but I have since abandoned the approach using `TotalMapOn` as I couldn't get it to work without adding a dependently typed version of the `replacement` axiom of the `Set` module, and we don't want to add axioms at this point for a number of reasons; this is why the comments below are crossed out).

The new functionality in `TotalMap` is part of [a separate PR](https://github.com/input-output-hk/formal-ledger-specifications/pull/138) which should be merged before this one.

~I considered somehow using @WhatisRT's restriction operator but the approach using records seems natural to me.  If someone wants to try integrating the existing restriction operator, by all means go for it or explain to me how it could/should be done.~

~I found it very difficult to get this to work and it seems I need a new axiom called `dreplacement` which is a version of `replacement` that works for functions whose domains are dependent pair (sigma) types.~

~To complete this example, so that `Everything` type-checks, would require expanding the `List` types that require a case for each axiom.  I haven't done that yet.  I started looking at it, but it seems complicated; maybe that's only because I don't understand the set-based list types yet.~