### PR TITLE
Fix missing latex dependency in `shell.nix`

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -44,6 +44,17 @@ rec {
   agdaWithStdLibMeta = agdaWithPkgs deps;
   agda = agdaWithPkgs (deps ++ [ formalLedger ]);
 
+  latex = texlive.combine {
+    inherit (texlive)
+      scheme-small
+      xits
+      collection-latexextra
+      collection-latexrecommended
+      collection-mathscience
+      bclogo
+      latexmk;
+  };
+
   formalLedger = customAgda.agdaPackages.mkDerivation {
     pname = "formal-ledger";
     version = "0.1";
@@ -82,19 +93,7 @@ rec {
         version = "0.1";
         src = "${formalLedger}";
         meta = { };
-        buildInputs = [
-           agdaWithStdLibMeta
-          (texlive.combine {
-            inherit (texlive)
-              scheme-small
-              xits
-              collection-latexextra
-              collection-latexrecommended
-              collection-mathscience
-              bclogo
-              latexmk;
-          })
-        ];
+        buildInputs = [ agdaWithStdLibMeta latex ];
         buildPhase = ''
           find ${dir} -name \*.lagda -exec agda --latex {} \;
           cd latex && latexmk -xelatex ${dir}/PDF.tex && cd ..

--- a/shell.nix
+++ b/shell.nix
@@ -13,6 +13,7 @@ in {
   shell = mkShell {
     nativeBuildInputs = [
       specs.agdaWithStdLibMeta
+      specs.latex
     ];
   };
 


### PR DESCRIPTION
# Description

This fixes that the proper latex distribution was missing from the default nix shell. Before, `nix-shell --pure --command make` would fail because `latexmk` was missing, and this fixes it.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] Code is formatted according to [CONTRIBUTING.md](https://github.com/input-output-hk/formal-ledger-specifications/blob/master/CONTRIBUTING.md)
- [x] Self-reviewed the diff
