### PR TITLE
build-improvements-unclobber

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,8 +6,8 @@ tex_files2 := $(addprefix src/latex/Ledger/, $(tex_files))
 src/latex/Ledger/%.tex: src/Ledger/%.lagda
 	cd src && agda --only-scope-checking --latex ../$<
 all: $(tex_files2)
-	cd src/latex && xelatex Ledger/PDF.tex
-	cp src/latex/PDF.pdf .
+	cd src/latex && latexmk -xelatex Ledger/PDF.tex
+	cp src/latex/PDF.pdf cardano-ledger.pdf
 clean:
 	rm -rf src/latex
 	rm -rf src/MAlonzo


### PR DESCRIPTION
# Description

Change Makefile to use latexmk (so we don't have to compile multiple times to ensure all references are resolved) and move the resulting pdf to a file called cardano-ledger.pdf.

Somehow these improvements disappeared from @WhatisRT's earlier PR just before it was merged and I didn't notice until it was too late.

# Checklist

- [X] Commit sequence broadly makes sense and commits have useful messages
- [X] Code is formatted according to [CONTRIBUTING.md](https://github.com/input-output-hk/formal-ledger-specifications/blob/master/CONTRIBUTING.md)
- [X] Self-reviewed the diff
