### PR TITLE
Maximize build space

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,6 +9,16 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Free disk space
+        uses: jlumbroso/free-disk-space@main
+        with:
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: true
+          docker-images: true
+          swap-storage: true
+
       - uses: actions/checkout@v3
 
       - uses: cachix/install-nix-action@v20


### PR DESCRIPTION
# Description

Closes #167 

Adds a job at the beginning of the workflow which removes unnecessary software, thus allowing more space for the build. 

Below is the screenshot of running `df -a` at the end of the workflow, showing that the risk of running out of disk space is (currently) alleviated 

![2023-08-08_12-34](https://github.com/input-output-hk/formal-ledger-specifications/assets/2070003/cdcf4b4b-813e-43dc-b9cd-2c1145dc5aa6)



<!-- Add your description here, if it fixes a particular issue please provide a
[link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=)
to the issue. -->

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] Code is formatted according to [CONTRIBUTING.md](https://github.com/input-output-hk/formal-ledger-specifications/blob/master/CONTRIBUTING.md)
- [ ] Self-reviewed the diff
