### PR TITLE
Adjust maximize buildspace

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,6 +9,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - run: |
+           sudo apt-get update
       - name: Free disk space
         uses: jlumbroso/free-disk-space@main
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,14 +10,14 @@ jobs:
 
     steps:
       - run: |
-           sudo apt-get update
+          sudo apt-get update
       - name: Free disk space
         uses: jlumbroso/free-disk-space@main
         with:
           android: true
           dotnet: true
-          haskell: true
-          large-packages: true
+          haskell: false
+          large-packages: false
           docker-images: true
           swap-storage: true
 


### PR DESCRIPTION
# Description

To avoid the mirrors not being found when uninstalling things, we need to run `apt-get update` at the beginning. 

When uninstalling to free space, removing "large packages" seems to take the longest, but only frees about 4GBs, so I removed this action in order to save  some build time. 


<!-- Add your description here, if it fixes a particular issue please provide a
[link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=)
to the issue. -->

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] Code is formatted according to [CONTRIBUTING.md](https://github.com/input-output-hk/formal-ledger-specifications/blob/master/CONTRIBUTING.md)
- [ ] Self-reviewed the diff
