### PR TITLE
Add witness checks for certificates

### DIFF
--- a/src/Ledger/Deleg.lagda
+++ b/src/Ledger/Deleg.lagda
@@ -40,6 +40,14 @@ data DCert : Set where
   deregdrep   : Credential → DCert
   ccreghot    : Credential → Maybe KeyHash → DCert
 
+cwitness : DCert → Credential
+cwitness (delegate c _ _ _)  = c
+cwitness (regpool c _)       = c
+cwitness (retirepool c _)    = c
+cwitness (regdrep c _ _)     = c
+cwitness (deregdrep c)       = c
+cwitness (ccreghot c _)      = c
+
 record CertEnv : Set where
   constructor ⟦_,_,_⟧ᶜ
   field epoch  : Epoch


### PR DESCRIPTION
# Description

Closes #148. ATM all certs require a credential, which is not true in Shelley, but that's a problem to solve in the future.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] Code is formatted according to [CONTRIBUTING.md](https://github.com/input-output-hk/formal-ledger-specifications/blob/master/CONTRIBUTING.md)
- [x] Self-reviewed the diff
