### PR TITLE
Cleanup imports in module `Utxo.Properties`

### DIFF
--- a/src/Ledger/Utxo.lagda
+++ b/src/Ledger/Utxo.lagda
@@ -1,4 +1,4 @@
-\section{UTxO}
+n\section{UTxO}
 \label{sec:utxo}
 
 \subsection{Accounting}

--- a/src/Ledger/Utxo.lagda
+++ b/src/Ledger/Utxo.lagda
@@ -1,4 +1,4 @@
-n\section{UTxO}
+\section{UTxO}
 \label{sec:utxo}
 
 \subsection{Accounting}

--- a/src/Ledger/Utxo/Properties.lagda
+++ b/src/Ledger/Utxo/Properties.lagda
@@ -11,17 +11,15 @@ module Ledger.Utxo.Properties (txs : TransactionStructure) where
 open import Prelude
 open import Ledger.Prelude
 
-import Data.List as List
 import Data.Nat as ℕ
 open import Algebra.Morphism
-open import Data.Nat.Properties using
-  (+-0-commutativeMonoid; +-0-monoid; +-comm; +-identityʳ; +-assoc; +-∸-assoc; m≤n⇒m≤n+o; ≤″⇒≤; m+[n∸m]≡n)
+open import Data.Nat.Properties hiding (_≟_)
 open import Data.Sign using (Sign)
 open import Data.Integer as ℤ using (ℤ; _⊖_)
-open import Data.Integer.Ext
+open import Data.Integer.Ext           using (posPart ; negPart)
 import Data.Integer.Properties as ℤ
-open import Interface.ComputationalRelation
-open import Relation.Binary
+-- open import Interface.ComputationalRelation
+open import Relation.Binary         using (IsEquivalence)
 open import Tactic.Cong
 open import Tactic.EquationalReasoning
 open import Tactic.MonoidSolver
@@ -39,24 +37,19 @@ open Tx
 open Equivalence
 open Properties
 
-import Data.Nat.Tactic.RingSolver as ℕ
 open Tactic.EquationalReasoning.≡-Reasoning {A = ℕ} (solve-macro (quoteTerm +-0-monoid))
 
 instance
   _ = TokenAlgebra.Value-CommutativeMonoid tokenAlgebra
   _ = +-0-monoid
 
-
 private variable
-  tx : TxBody
-  utxo utxo' utxo1 utxo2 : UTxO
-  fee fee' fees fees' : Coin
-  utxoState utxoState' utxoState1 utxoState2 : UTxOState
-  deposits deposits' : DepositPurpose ⇀ Coin
-  donation donations donations' : Coin
-  Γ : UTxOEnv
-  s s' : UTxOState
-  A : Set
+  tx                               : TxBody
+  utxo utxo'                       : UTxO
+  Γ                                : UTxOEnv
+  utxoState utxoState'             : UTxOState
+  fees fees' donations donations'  : Coin
+  deposits deposits'               : DepositPurpose ⇀ Coin
 
 abstract
   Computational-UTXO : Computational _⊢_⇀⦇_,UTXO⦈_

--- a/src/Ledger/Utxo/Properties.lagda
+++ b/src/Ledger/Utxo/Properties.lagda
@@ -12,27 +12,24 @@ open import Prelude
 open import Ledger.Prelude
 
 import Data.Nat as ℕ
-open import Algebra.Morphism
-open import Data.Nat.Properties hiding (_≟_)
-open import Data.Sign using (Sign)
-open import Data.Integer as ℤ using (ℤ; _⊖_)
-open import Data.Integer.Ext           using (posPart ; negPart)
+open import Algebra.Morphism            using (module MonoidMorphisms; IsMagmaHomomorphism)
+open import Data.Nat.Properties         hiding (_≟_)
+open import Data.Sign                   using (Sign)
+open import Data.Integer as ℤ           using (ℤ; _⊖_)
+open import Data.Integer.Ext            using (posPart; negPart)
 import Data.Integer.Properties as ℤ
--- open import Interface.ComputationalRelation
-open import Relation.Binary         using (IsEquivalence)
-open import Tactic.Cong
-open import Tactic.EquationalReasoning
-open import Tactic.MonoidSolver
+open import Relation.Binary             using (IsEquivalence)
+open import Tactic.Cong                 using (cong!)
+open import Tactic.EquationalReasoning  using (module ≡-Reasoning)
+open import Tactic.MonoidSolver         using (solve-macro)
 
 open TransactionStructure txs
 
-open import Ledger.PParams epochStructure
-open import Ledger.TokenAlgebra ScriptHash
+open import Ledger.PParams epochStructure using (PParams)
+open import Ledger.TokenAlgebra ScriptHash using (TokenAlgebra)
 open import Ledger.Utxo txs renaming (Computational-UTXO to Computational-UTXO')
 
 open TxBody
-open TxWitnesses
-open Tx
 
 open Equivalence
 open Properties


### PR DESCRIPTION
# Description

This cleans up imports of one module---`Utxo.Properties`

It is based on [william/34-type-classes](https://github.com/input-output-hk/formal-ledger-specifications/tree/william/34-type-classes), so the diffs will be large at first, but will become small---limited to just the imports and private variable definitions of the `Utxo.Properties` module---once `william/34-type-classes` is merged.

# Checklist

- [X] Commit sequence broadly makes sense and commits have useful messages
- [X] Code is formatted according to [CONTRIBUTING.md](https://github.com/input-output-hk/formal-ledger-specifications/blob/master/CONTRIBUTING.md)
- [X] Self-reviewed the diff
