### PR TITLE
Cleanup imports in module `Utxo`

### DIFF
--- a/src/Interface/HasAdd.agda
+++ b/src/Interface/HasAdd.agda
@@ -1,0 +1,8 @@
+{-# OPTIONS --safe --cubical-compatible #-}
+module Interface.HasAdd where
+
+record HasAdd (A : Set) : Set where
+  infixl 7 _+_
+  field _+_ : A → A → A
+
+open HasAdd ⦃ ... ⦄ public

--- a/src/Interface/HasAdd/Instance.agda
+++ b/src/Interface/HasAdd/Instance.agda
@@ -1,0 +1,13 @@
+{-# OPTIONS --safe #-}
+module Interface.HasAdd.Instance where
+
+open import Interface.HasAdd
+open import Data.Integer using (ℤ) renaming (_+_ to _+ℤ_)
+open import Data.Nat using (ℕ) renaming (_+_ to _+ℕ_)
+
+instance
+  addInt : HasAdd ℤ
+  addInt = record { _+_ = _+ℤ_ }
+
+  addNat : HasAdd ℕ
+  addNat = record { _+_ = _+ℕ_ }

--- a/src/Ledger/Deleg.lagda
+++ b/src/Ledger/Deleg.lagda
@@ -6,6 +6,7 @@
 open import Ledger.Prelude
 open import Ledger.Epoch
 open import Ledger.Crypto
+
 import Ledger.PParams as PP
 
 module Ledger.Deleg
@@ -147,7 +148,7 @@ data _⊢_⇀⦇_,GOVCERT⦈_ : GovCertEnv → GState → DCert → GState → S
     (d ≡ drepDeposit × c ∉ dom (dReps ˢ)) ⊎ (d ≡ 0 × c ∈ dom (dReps ˢ))
     ────────────────────────────────
     ⟦ e , pp , vs ⟧ᶜ ⊢ ⟦ dReps , ccKeys ⟧ᵛ ⇀⦇ regdrep c d an ,GOVCERT⦈
-                       ⟦ ❴ c , e +ᵉ' drepActivity ❵ᵐ ∪ᵐˡ dReps , ccKeys ⟧ᵛ
+                       ⟦ ❴ c , e + drepActivity ❵ᵐ ∪ᵐˡ dReps , ccKeys ⟧ᵛ
 
   GOVCERT-deregdrep :
     c ∈ dom (dReps ˢ)
@@ -186,7 +187,7 @@ data _⊢_⇀⦇_,CERTBASE⦈_ : CertEnv → CertState → ⊤ → CertState →
     in ⊤ -- TODO: check that the withdrawals are correct here
     ────────────────────────────────
     ⟦ e , pp , vs ⟧ᶜ ⊢ st ⇀⦇ _ ,CERTBASE⦈ record st { gState = record gState
-                         { dreps = constMap refresh (e +ᵉ' drepActivity) ∪ᵐˡ dreps } }
+                         { dreps = constMap refresh (e + drepActivity) ∪ᵐˡ dreps } }
 
 -- TODO: use CERTBASE by modifying SS⇒BS to allow for a base case
 _⊢_⇀⦇_,CERTS⦈_ : CertEnv → CertState → List DCert → CertState → Set

--- a/src/Ledger/Epoch.agda
+++ b/src/Ledger/Epoch.agda
@@ -48,9 +48,9 @@ record EpochStructure : Set₁ where
   zero +ᵉ e = e
   suc n +ᵉ e = sucᵉ (n +ᵉ e)
 
+  open Semiring Slotʳ renaming (_+_ to _+ˢ_)
   _+ᵉ'_ : Epoch → Epoch → Epoch
   e +ᵉ' e' = epoch (firstSlot e +ˢ firstSlot e')
-    where open Semiring Slotʳ renaming (_+_ to _+ˢ_)
 
   _<ᵉ_ : Epoch → Epoch → Set
   e <ᵉ e' = firstSlot e <ˢ firstSlot e'
@@ -60,6 +60,13 @@ record EpochStructure : Set₁ where
 
   _≤ᵉ?_ : (e e' : Epoch) → Dec (e ≤ᵉ e')
   e ≤ᵉ? e' = firstSlot e ≤ˢ? firstSlot e'
+
+  instance
+    addSlot : HasAdd Slot
+    addSlot = record { _+_ = _+ˢ_ }
+
+    addEpoch : HasAdd Epoch
+    addEpoch = record { _+_ = _+ᵉ'_ }
 
 module _ (gc : GlobalConstants) where
   open GlobalConstants gc

--- a/src/Ledger/PPUp.lagda
+++ b/src/Ledger/PPUp.lagda
@@ -6,7 +6,7 @@
 open import Ledger.Transaction
 
 module Ledger.PPUp (txs : TransactionStructure) where
-open import Ledger.Prelude hiding (_+_; _*_)
+open import Ledger.Prelude hiding (_*_)
 
 open TransactionStructure txs
 
@@ -14,7 +14,7 @@ open import Algebra
 
 import Data.Nat as ℕ
 import Data.Unit.Polymorphic
-open Semiring Slotʳ
+open Semiring Slotʳ using (_*_)
 open import Algebra.Literals
 open import Data.Nat.Properties using (m+1+n≢m)
 open import Data.Product.Properties
@@ -50,8 +50,8 @@ record PPUpdateEnv : Set where
 \begin{figure*}[h]
 \begin{code}
 data pvCanFollow : ProtVer → ProtVer → Set where
-  canFollowMajor : pvCanFollow (m , n) (m ℕ.+ 1 , 0)
-  canFollowMinor : pvCanFollow (m , n) (m , n ℕ.+ 1)
+  canFollowMajor : pvCanFollow (m , n) (m + 1 , 0)
+  canFollowMinor : pvCanFollow (m , n) (m , n + 1)
 
 viablePParams : PParams → Set
 viablePParams pp = ⊤ -- TODO: block size check
@@ -73,7 +73,7 @@ viablePParams? : Dec₁ viablePParams
 viablePParams? pp = yes _
 
 pvCanFollow? : ∀ pv pv' → Dec (pvCanFollow pv pv')
-pvCanFollow? (m , n) pv with pv ≟ (m ℕ.+ 1 , 0) | pv ≟ (m , n ℕ.+ 1)
+pvCanFollow? (m , n) pv with pv ≟ (m + 1 , 0) | pv ≟ (m , n + 1)
 ... | no ¬p | no ¬p₁ = no (λ { canFollowMajor → ¬p _≡_.refl ; canFollowMinor → ¬p₁ _≡_.refl })
 ... | no ¬p | yes refl = yes canFollowMinor
 ... | yes refl | no ¬p = yes canFollowMajor

--- a/src/Ledger/Prelude.agda
+++ b/src/Ledger/Prelude.agda
@@ -18,9 +18,10 @@ open import Ledger.Prelude.Base public
 open import Interface.ComputationalRelation public
 open import Interface.DecEq public
 open import Ledger.Interface.HasCoin public
+open import Interface.HasAdd public
+open import Interface.HasAdd.Instance public
 open import Relation.Nullary public
 open import Relation.Unary using () renaming (Decidable to Dec₁) public
-
 open Computational public
 
 -- TODO: move this into Interface.DecEq

--- a/src/Ledger/Ratify.lagda
+++ b/src/Ledger/Ratify.lagda
@@ -83,7 +83,7 @@ mostStakeDRepDist-∅ {dist} = suc (Σᵐᵛ[ x ← dist ᶠᵐ ] x) , Propertie
                              (res-singleton' {m = dist} kv∈dist) ⟩
       Σᵐᵛ[ x ← (dist ∣ ❴ k ❵) ᶠᵐ ] x
         ≤⟨ m≤m+n _ _ ⟩
-      Σᵐᵛ[ x ← (dist ∣ ❴ k ❵) ᶠᵐ ] x + Σᵐᵛ[ x ← (dist ∣ ❴ k ❵ ᶜ) ᶠᵐ ] x
+      Σᵐᵛ[ x ← (dist ∣ ❴ k ❵) ᶠᵐ ] x +ℕ Σᵐᵛ[ x ← (dist ∣ ❴ k ❵ ᶜ) ᶠᵐ ] x
         ≡˘⟨ indexedSumᵐ-partition {m = dist ᶠᵐ} {(dist ∣ ❴ k ❵) ᶠᵐ} {(dist ∣ ❴ k ❵ ᶜ) ᶠᵐ}
                                   (res-ex-disj-∪ Properties.Dec-∈-singleton) ⟩
       Σᵐᵛ[ x ← dist ᶠᵐ ] x

--- a/src/Ledger/TokenAlgebra.lagda
+++ b/src/Ledger/TokenAlgebra.lagda
@@ -43,6 +43,12 @@ record TokenAlgebra : Set₁ where
 \end{code}
 \begin{code}[hide]
          instance DecEq-Value : DecEq Value
+
+  instance
+    addValue : HasAdd Value
+    addValue = record { _+_ = _+ᵛ_ }
+
+
 \end{code}
 \begin{code}
   sumᵛ : List Value → Value

--- a/src/Ledger/Utxo.lagda
+++ b/src/Ledger/Utxo.lagda
@@ -7,33 +7,25 @@ n\section{UTxO}
 {-# OPTIONS --safe #-}
 {-# OPTIONS --overlapping-instances #-}
 
-open import Ledger.Transaction
+open import Ledger.Transaction using (TransactionStructure)
 
 module Ledger.Utxo (txs : TransactionStructure) where
 
 open import Ledger.Prelude hiding (Dec₁)
 
-open import Algebra using (CommutativeMonoid)
-open import Algebra.Structures
-open import Data.Integer using (ℤ; _⊖_)
-open import Data.Integer.Ext
-open import Data.List as List
-open import Data.Nat using (_≤?_; _≤_)
-open import Data.Nat.Properties using (+-0-monoid ; +-0-commutativeMonoid)
-open import Data.Sign using (Sign)
-open import Interface.Decidable.Instance
+open import Algebra                        using (CommutativeMonoid)
+open import Data.Integer.Ext               using (posPart; negPart)
+open import Data.Nat                       using (_≤?_; _≤_)
+open import Data.Nat.Properties            using (+-0-monoid; +-0-commutativeMonoid)
+open import Interface.Decidable.Instance   using (Decidable²⇒Dec; Dec₁)
 
 open TransactionStructure txs
 open TxBody
-open TxWitnesses
-open Tx
 
-open import Ledger.Crypto
-open import Ledger.PParams epochStructure
-open import Ledger.TokenAlgebra using (TokenAlgebra)
+open import Ledger.PParams epochStructure  using (PParams)
+open import Ledger.TokenAlgebra            using (TokenAlgebra)
 
 open import MyDebugOptions
---open import Tactic.Defaults
 open import Tactic.DeriveComp
 open import Tactic.Derive.DecEq
 
@@ -45,19 +37,6 @@ instance
 
   HasCoin-Map : ∀ {A} → ⦃ DecEq A ⦄ → HasCoin (A ⇀ Coin)
   HasCoin-Map .getCoin s = Σᵐᵛ[ x ← s ᶠᵐ ] x
-
-
--- utxoEntrySizeWithoutVal = 27 words (8 bytes)
-utxoEntrySizeWithoutVal : MemoryEstimate
-utxoEntrySizeWithoutVal = 8
-
-utxoEntrySize : TxOut → MemoryEstimate
-utxoEntrySize (fst , v) = utxoEntrySizeWithoutVal + size v
-
--- TODO: fix this
-serSize : Value → MemoryEstimate
-serSize = λ _ → zero
-
 \end{code}
 
 Figure~\ref{fig:functions:utxo} defines functions needed for the UTxO transition system.

--- a/src/Ledger/Utxo.lagda
+++ b/src/Ledger/Utxo.lagda
@@ -1,4 +1,4 @@
-\section{UTxO}
+n\section{UTxO}
 \label{sec:utxo}
 
 \subsection{Accounting}
@@ -45,6 +45,7 @@ instance
 
   HasCoin-Map : ∀ {A} → ⦃ DecEq A ⦄ → HasCoin (A ⇀ Coin)
   HasCoin-Map .getCoin s = Σᵐᵛ[ x ← s ᶠᵐ ] x
+
 
 -- utxoEntrySizeWithoutVal = 27 words (8 bytes)
 utxoEntrySizeWithoutVal : MemoryEstimate
@@ -230,14 +231,14 @@ newDeposits pp st txb = posPart $ depositsChange pp txb deposits
 
 consumed : PParams → UTxOState → TxBody → Value
 consumed pp st txb = balance (UTxOState.utxo st ∣ txins txb)
-                   +ᵛ mint txb
-                   +ᵛ inject (depositRefunds pp st txb)
+                   + mint txb
+                   + inject (depositRefunds pp st txb)
 
 produced : PParams → UTxOState → TxBody → Value
 produced pp st txb = balance (outs txb)
-                   +ᵛ inject (txfee txb)
-                   +ᵛ inject (newDeposits pp st txb)
-                   +ᵛ inject (txdonation txb)
+                   + inject (txfee txb)
+                   + inject (newDeposits pp st txb)
+                   + inject (txdonation txb)
 
 \end{code}
 \caption{Functions used in UTxO rules, continued}

--- a/src/Ledger/Utxo/Properties.lagda
+++ b/src/Ledger/Utxo/Properties.lagda
@@ -8,8 +8,8 @@ open import Ledger.Transaction
 
 module Ledger.Utxo.Properties (txs : TransactionStructure) where
 
-open import Prelude hiding (_+_)
-open import Ledger.Prelude renaming (_+_ to _+ℕ_)
+open import Prelude
+open import Ledger.Prelude
 
 import Data.List as List
 import Data.Nat as ℕ
@@ -45,23 +45,6 @@ open Tactic.EquationalReasoning.≡-Reasoning {A = ℕ} (solve-macro (quoteTerm 
 instance
   _ = TokenAlgebra.Value-CommutativeMonoid tokenAlgebra
   _ = +-0-monoid
-
-record Add (A : Set) : Set where
-  infixl 7 _+_
-  field _+_ : A → A → A
-
-open Add ⦃ ... ⦄ public
-
-instance
-  addInt : Add ℤ
-  addInt = record { _+_ = ℤ._+_ }
-
-  addNat : Add ℕ
-  addNat = record { _+_ = _+ℕ_ }
-
-  addCommMon : Add (TokenAlgebra.Value tokenAlgebra)
-  addCommMon = record { _+_ = _+ᵛ_ }
-
 
 
 private variable

--- a/src/Ledger/Utxo/Properties.lagda
+++ b/src/Ledger/Utxo/Properties.lagda
@@ -11,35 +11,29 @@ module Ledger.Utxo.Properties (txs : TransactionStructure) where
 open import Prelude
 open import Ledger.Prelude
 
-import Data.List as List
 import Data.Nat as ℕ
-open import Algebra.Morphism
-open import Data.Nat.Properties using
-  (+-0-commutativeMonoid; +-0-monoid; +-comm; +-identityʳ; +-assoc; +-∸-assoc; m≤n⇒m≤n+o; ≤″⇒≤; m+[n∸m]≡n)
-open import Data.Sign using (Sign)
-open import Data.Integer as ℤ using (ℤ; _⊖_)
-open import Data.Integer.Ext
+open import Algebra.Morphism            using (module MonoidMorphisms; IsMagmaHomomorphism)
+open import Data.Nat.Properties         hiding (_≟_)
+open import Data.Sign                   using (Sign)
+open import Data.Integer as ℤ           using (ℤ; _⊖_)
+open import Data.Integer.Ext            using (posPart; negPart)
 import Data.Integer.Properties as ℤ
-open import Interface.ComputationalRelation
-open import Relation.Binary
-open import Tactic.Cong
-open import Tactic.EquationalReasoning
-open import Tactic.MonoidSolver
+open import Relation.Binary             using (IsEquivalence)
+open import Tactic.Cong                 using (cong!)
+open import Tactic.EquationalReasoning  using (module ≡-Reasoning)
+open import Tactic.MonoidSolver         using (solve-macro)
 
 open TransactionStructure txs
 
-open import Ledger.PParams epochStructure
-open import Ledger.TokenAlgebra ScriptHash
+open import Ledger.PParams epochStructure using (PParams)
+open import Ledger.TokenAlgebra ScriptHash using (TokenAlgebra)
 open import Ledger.Utxo txs renaming (Computational-UTXO to Computational-UTXO')
 
 open TxBody
-open TxWitnesses
-open Tx
 
 open Equivalence
 open Properties
 
-import Data.Nat.Tactic.RingSolver as ℕ
 open Tactic.EquationalReasoning.≡-Reasoning {A = ℕ} (solve-macro (quoteTerm +-0-monoid))
 
 instance
@@ -49,14 +43,11 @@ instance
 
 private variable
   tx : TxBody
-  utxo utxo' utxo1 utxo2 : UTxO
-  fee fee' fees fees' : Coin
-  utxoState utxoState' utxoState1 utxoState2 : UTxOState
+  utxo utxo' : UTxO
+  utxoState utxoState' : UTxOState
   deposits deposits' : DepositPurpose ⇀ Coin
-  donation donations donations' : Coin
+  fees fees' donations donations' : Coin
   Γ : UTxOEnv
-  s s' : UTxOState
-  A : Set
 
 abstract
   Computational-UTXO : Computational _⊢_⇀⦇_,UTXO⦈_

--- a/src/Ledger/Utxo/Properties.lagda
+++ b/src/Ledger/Utxo/Properties.lagda
@@ -8,23 +8,24 @@ open import Ledger.Transaction
 
 module Ledger.Utxo.Properties (txs : TransactionStructure) where
 
-open import Prelude
-open import Ledger.Prelude
+open import Prelude hiding (_+_)
+open import Ledger.Prelude renaming (_+_ to _+ℕ_)
 
-import Data.List as List
-import Data.Nat as ℕ
-open import Algebra.Morphism
-open import Data.Nat.Properties using
-  (+-0-commutativeMonoid; +-0-monoid; +-comm; +-identityʳ; +-assoc; +-∸-assoc; m≤n⇒m≤n+o; ≤″⇒≤; m+[n∸m]≡n)
-open import Data.Sign using (Sign)
-open import Data.Integer as ℤ using (ℤ; _⊖_)
-open import Data.Integer.Ext
-import Data.Integer.Properties as ℤ
-open import Interface.ComputationalRelation
-open import Relation.Binary
+open import Algebra              using     (CommutativeMonoid ; Monoid)
+open import Algebra.Morphism     using     (module MonoidMorphisms ; IsMagmaHomomorphism)
+open import Data.Integer         using     (ℤ; _⊖_ ; _-_ ; 0ℤ)
+                                 renaming  (_+_ to _+ℤ_ ; +_ to _⁺ ; -_ to _⁻)
+open import Data.Integer.Ext     using     (posPart ; negPart)
+open import Data.Nat.Properties  hiding    (_≟_)
+open import Data.Sign            using     (Sign)
+open import Relation.Binary      using     (IsEquivalence)
+
 open import Tactic.Cong
 open import Tactic.EquationalReasoning
 open import Tactic.MonoidSolver
+
+import Data.Nat as ℕ
+import Data.Integer.Properties as ℤ
 
 open TransactionStructure txs
 
@@ -39,23 +40,35 @@ open Tx
 open Equivalence
 open Properties
 
-import Data.Nat.Tactic.RingSolver as ℕ
 open Tactic.EquationalReasoning.≡-Reasoning {A = ℕ} (solve-macro (quoteTerm +-0-monoid))
 
 instance
   _ = TokenAlgebra.Value-CommutativeMonoid tokenAlgebra
   _ = +-0-monoid
 
+record Add (A : Set) : Set where
+  infixl 7 _+_
+  field _+_ : A → A → A
+
+open Add ⦃ ... ⦄ public
+
+instance
+  addInt : Add ℤ
+  addInt = record { _+_ = _+ℤ_ }
+
+  addNat : Add ℕ
+  addNat = record { _+_ = _+ℕ_ }
+
+  addCommMon : Add (TokenAlgebra.Value tokenAlgebra)
+  addCommMon = record { _+_ = _+ᵛ_ }
+
 private variable
-  tx : TxBody
-  utxo utxo' utxo1 utxo2 : UTxO
-  fee fee' fees fees' : Coin
-  utxoState utxoState' utxoState1 utxoState2 : UTxOState
-  deposits deposits' : DepositPurpose ⇀ Coin
-  donation donations donations' : Coin
-  Γ : UTxOEnv
-  s s' : UTxOState
-  A : Set
+  tx                               : TxBody
+  utxo utxo'                       : UTxO
+  Γ                                : UTxOEnv
+  utxoState utxoState'             : UTxOState
+  fees fees' donations donations'  : Coin
+  deposits deposits'               : DepositPurpose ⇀ Coin
 
 abstract
   Computational-UTXO : Computational _⊢_⇀⦇_,UTXO⦈_
@@ -79,7 +92,7 @@ balance-∪ {utxo} {utxo'} h = begin
     ≡⟨ ⟦⟧-cong coinIsMonoidHomomorphism (indexedSumᵐ-cong {x = (utxo ∪ᵐˡ utxo') ᶠᵐ} {(utxo ᶠᵐ) ∪ᵐˡᶠ (utxo' ᶠᵐ)} (id , id)) ⟩
   coin (indexedSumᵐ _ ((utxo ᶠᵐ) ∪ᵐˡᶠ (utxo' ᶠᵐ)))
     ≡⟨ ⟦⟧-cong coinIsMonoidHomomorphism (indexedSumᵐ-∪ {X = utxo ᶠᵐ} {utxo' ᶠᵐ} h) ⟩
-  coin (balance utxo +ᵛ balance utxo')
+  coin (balance utxo + balance utxo')
     ≡⟨ ∙-homo-Coin  _ _ ⟩
   cbalance utxo + cbalance utxo' ∎
 
@@ -91,39 +104,42 @@ consumedCoinEquality : ∀ {pp} → coin (mint tx) ≡ 0
                      → coin (consumed pp utxoState tx)
                      ≡ cbalance ((UTxOState.utxo utxoState) ∣ txins tx) + depositRefunds pp utxoState tx
 consumedCoinEquality {tx} {utxoState} {pp} h = let utxo = UTxOState.utxo utxoState in begin
-  coin (balance (utxo ∣ txins tx) +ᵛ mint tx +ᵛ inject (depositRefunds pp utxoState tx))
+  coin (balance (utxo ∣ txins tx) + mint tx + inject (depositRefunds pp utxoState tx))
     ≡⟨ ∙-homo-Coin _ _ ⟩
-  coin (balance (utxo ∣ txins tx) +ᵛ mint tx) + coin (inject $ depositRefunds pp utxoState tx)
-    ≡⟨ cong (coin (balance (utxo ∣ txins tx) +ᵛ mint tx) +_) (property _) ⟩
-  coin (balance (utxo ∣ txins tx) +ᵛ mint tx) + depositRefunds pp utxoState tx
-    ≡⟨ cong! (∙-homo-Coin _ _) ⟩
+  coin (balance (utxo ∣ txins tx) + mint tx) + coin (inject $ depositRefunds pp utxoState tx)
+    ≡⟨ cong (coin (balance (utxo ∣ txins tx) + mint tx) +_) (property _) ⟩
+  coin (balance (utxo ∣ txins tx) + mint tx) + depositRefunds pp utxoState tx
+    ≡⟨ cong (_+ depositRefunds pp utxoState tx) (∙-homo-Coin _ _) ⟩
   coin (balance (utxo ∣ txins tx)) + coin (mint tx) + depositRefunds pp utxoState tx
     ≡⟨ cong (λ x → cbalance (utxo ∣ txins tx) + x + depositRefunds pp utxoState tx) h ⟩
   cbalance (utxo ∣ txins tx) + 0 + depositRefunds pp utxoState tx
-    ≡⟨ cong! (+-identityʳ (cbalance (utxo ∣ txins tx))) ⟩
+    ≡⟨ cong (_+ depositRefunds pp utxoState tx) (+-identityʳ (cbalance (utxo ∣ txins tx))) ⟩
   cbalance (utxo ∣ txins tx) + depositRefunds pp utxoState tx                        ∎
 
-producedCoinEquality : ∀ {pp} → coin (produced pp utxoState tx)
-                              ≡ cbalance (outs tx) + (txfee tx) + newDeposits pp utxoState tx + txdonation tx
+
+producedCoinEquality : ∀ {pp}
+  → coin (produced pp utxoState tx) ≡ cbalance (outs tx) + txfee tx + newDeposits pp utxoState tx + txdonation tx
+
 producedCoinEquality {utxoState} {tx} {pp} = begin
-  coin (balance (outs tx) +ᵛ inject (txfee tx) +ᵛ inject (newDeposits pp utxoState tx) +ᵛ inject (txdonation tx))
-    ≡⟨ ∙-homo-Coin _ _ ⟩
-  coin (balance (outs tx) +ᵛ inject (txfee tx) +ᵛ inject (newDeposits pp utxoState tx)) + coin (inject (txdonation tx))
-    ≡⟨ cong (_+ coin (inject (txdonation tx))) (begin
-      coin (balance (outs tx) +ᵛ inject (txfee tx) +ᵛ inject (newDeposits pp utxoState tx))
-        ≡⟨ ∙-homo-Coin _ _ ⟩
-      coin (balance (outs tx) +ᵛ inject (txfee tx)) + coin (inject (newDeposits pp utxoState tx))
-        ≡⟨ cong! (property _) ⟩
-      coin (balance (outs tx) +ᵛ inject (txfee tx)) + newDeposits pp utxoState tx
-        ≡⟨ cong! (∙-homo-Coin _ _) ⟩
-      coin (balance (outs tx)) + coin (inject (txfee tx)) + newDeposits pp utxoState tx
-        ≡⟨ cong (λ x → cbalance (outs tx) + x + newDeposits pp utxoState tx) (property (txfee tx)) ⟩
-      cbalance (outs tx) + (txfee tx) + newDeposits pp utxoState tx                     ∎
-    )⟩
-  cbalance (outs tx) + (txfee tx) + newDeposits pp utxoState tx + coin (inject (txdonation tx))
-    ≡⟨ cong (cbalance (outs tx) + (txfee tx) + newDeposits pp utxoState tx +_) (property _) ⟩
-  cbalance (outs tx) + (txfee tx) + newDeposits pp utxoState tx + txdonation tx
-    ∎
+  coin (balOut + inject (txfee tx) + inject newDep + inject don)         ≡⟨ ∙-homo-Coin _ _ ⟩
+  coin (balOut + inject (txfee tx) + inject newDep) + coin (inject don)  ≡⟨ cong (_+ coin (inject don)) γ ⟩
+  coin balOut + txfee tx + newDep + coin (inject don)                    ≡⟨ cong (coin balOut + txfee tx + newDep +_)(property _) ⟩
+  coin balOut + txfee tx + newDep + don                                  ∎
+    where
+    newDep don : Coin
+    newDep = newDeposits pp utxoState tx
+    don = txdonation tx
+
+    balOut : Value
+    balOut = balance (outs tx)
+
+    γ : coin (balOut + inject (txfee tx) + inject newDep) ≡ cbalance (outs tx) + txfee tx + newDep
+    γ = begin
+      coin (balOut + inject (txfee tx) + inject newDep)              ≡⟨ ∙-homo-Coin _ _ ⟩
+      coin (balOut + inject (txfee tx)) + coin (inject newDep)       ≡⟨ cong (_+ coin (inject newDep)) (∙-homo-Coin _ _)  ⟩
+      coin balOut + coin (inject (txfee tx)) + coin (inject newDep)  ≡⟨ cong (coin balOut + coin (inject (txfee tx)) +_)(property _) ⟩
+      coin balOut + coin (inject (txfee tx)) + newDep                ≡⟨ cong (λ x → coin balOut + x + newDep) (property _) ⟩
+      coin balOut + txfee tx + newDep                                ∎
 
 balValueToCoin : ∀ {pp} → coin (mint tx) ≡ 0 → consumed pp utxoState tx ≡ produced pp utxoState tx
                → cbalance ((UTxOState.utxo utxoState) ∣ txins tx) + depositRefunds pp utxoState tx
@@ -135,8 +151,9 @@ balValueToCoin {tx} {utxoState} {pp} h h' = begin
   coin (produced pp utxoState tx) ≡⟨ producedCoinEquality {utxoState} {tx} {pp} ⟩
   cbalance (outs tx) + (txfee tx) + newDeposits pp utxoState tx + txdonation tx ∎
 
+
 posPart-negPart≡x : ∀ {x} → posPart x ⊖ negPart x ≡ x
-posPart-negPart≡x {ℤ.+_ n}     = refl
+posPart-negPart≡x {n ⁺}     = refl
 posPart-negPart≡x {ℤ.negsuc n} = refl
 
 module DepositHelpers
@@ -153,34 +170,43 @@ module DepositHelpers
   private
     pp : PParams
     pp = UTxOEnv.pparams Γ
-    dep : Coin
-    dep = getCoin deposits
-    uDep : Coin
-    uDep = getCoin (updateDeposits pp tx deposits)
-    Δdep : ℤ
-    Δdep = depositsChange pp tx deposits
+
     utxoSt : UTxOState
     utxoSt = ⟦ utxo , fees , deposits , donations ⟧ᵘ
-    ref : Coin
-    ref = depositRefunds pp utxoSt tx
-    tot : Coin
-    tot = newDeposits    pp utxoSt tx
-    h : disjoint (dom ((utxo ∣ txins tx ᶜ) ˢ)) (dom (outs tx ˢ))
+
+    utxoIns utxoInsᶜ : UTxO
+    utxoInsᶜ = utxo ∣ txins tx ᶜ
+    utxoIns = utxo ∣ txins tx
+
+    dep uDep ref tot remDepTot don tot+remDep : Coin
+    dep         = getCoin deposits
+    uDep        = getCoin (updateDeposits pp tx deposits)
+    ref         = depositRefunds pp utxoSt tx
+    tot         = newDeposits pp utxoSt tx
+    remDepTot   = getCoin deposits ∸ ref
+    don         = txdonation tx
+    tot+remDep  = tot + remDepTot
+
+    Δdep : ℤ
+    Δdep = depositsChange pp tx deposits
+
+    h : disjoint (dom (utxoInsᶜ ˢ)) (dom (outs tx ˢ))
     h = λ h₁ h₂ → ∉-∅ $ proj₁ (newTxid⇒disj {tx = tx} {utxo} h') $ to ∈-∩ (res-comp-domᵐ h₁ , h₂)
-    newBal'
-      : Γ ⊢ ⟦ utxo , fees , deposits , donations ⟧ᵘ ⇀⦇ tx ,UTXO⦈ ⟦ utxo' , fees' , deposits' , donations' ⟧ᵘ
-      → consumed pp utxoSt tx ≡ produced pp utxoSt tx
+
+    newBal'  : Γ ⊢ ⟦ utxo , fees , deposits , donations ⟧ᵘ ⇀⦇ tx ,UTXO⦈ ⟦ utxo' , fees' , deposits' , donations' ⟧ᵘ
+             → consumed pp utxoSt tx ≡ produced pp utxoSt tx
     newBal' (UTXO-inductive _ _ _ _ x _ _) = x
+
     newBal : consumed pp utxoSt tx ≡ produced pp utxoSt tx
     newBal = newBal' step
-    noMintAda'
-      : Γ ⊢ ⟦ utxo , fees , deposits , donations ⟧ᵘ ⇀⦇ tx ,UTXO⦈ ⟦ utxo' , fees' , deposits' , donations' ⟧ᵘ
-      → coin (mint tx) ≡ 0
+
+    noMintAda'  : Γ ⊢ ⟦ utxo , fees , deposits , donations ⟧ᵘ ⇀⦇ tx ,UTXO⦈ ⟦ utxo' , fees' , deposits' , donations' ⟧ᵘ
+                → coin (mint tx) ≡ 0
     noMintAda' (UTXO-inductive _ _ _ _ _ x _) = x
+
     noMintAda : coin (mint tx) ≡ 0
     noMintAda = noMintAda' step
-    remDepTot : Coin
-    remDepTot = getCoin deposits ∸ ref
+
 
   uDep≡
     : Γ ⊢ ⟦ utxo , fees , deposits , donations ⟧ᵘ ⇀⦇ tx ,UTXO⦈ ⟦ utxo' , fees' , deposits' , donations' ⟧ᵘ
@@ -192,22 +218,22 @@ module DepositHelpers
 
   dep-ref : tot ≡ 0 → uDep + ref ≡ dep
   dep-ref tot≡0 = ℤ.+-injective $ begin
-    ℤ.+_ (uDep + ref)          ≡⟨ ℤ.pos-+ uDep ref ⟩
-    ℤ.+_ uDep ℤ.+ (ref ⊖ 0)    ≡˘⟨ cong! tot≡0 ⟩
-    ℤ.+_ uDep ℤ.+ (ref ⊖ tot)  ≡⟨ cong (ℤ._+_ (ℤ.+ uDep)) (ℤ.⊖-swap ref tot) ⟩
-    ℤ.+_ uDep ℤ.- (tot ⊖ ref)  ≡˘⟨ cong! deposits-change' ⟩
-    ℤ.+_ uDep ℤ.- Δdep         ≡˘⟨ cong (ℤ._+_ (ℤ.+ uDep)) (ℤ.⊖-swap dep uDep) ⟩
-    ℤ.+_ uDep ℤ.+ (dep ⊖ uDep) ≡⟨ ℤ.distribʳ-⊖-+-pos uDep dep uDep ⟩
-    (uDep + dep) ⊖ uDep        ≡⟨ cong (_⊖ uDep) (+-comm uDep dep) ⟩
-    (dep + uDep) ⊖ uDep        ≡˘⟨ ℤ.distribʳ-⊖-+-pos dep uDep uDep ⟩
-    ℤ.+_ dep ℤ.+ (uDep ⊖ uDep) ≡⟨ cong! (ℤ.n⊖n≡0 uDep) ⟩
-    ℤ.+_ dep ℤ.+ ℤ.0ℤ          ≡⟨ ℤ.+-identityʳ _ ⟩
-    ℤ.+_ dep ∎
+    (uDep + ref)⁺           ≡⟨ ℤ.pos-+ uDep ref ⟩
+    uDep ⁺ + (ref ⊖ 0)      ≡˘⟨ cong (λ x → uDep ⁺ + (ref ⊖ x)) tot≡0 ⟩
+    uDep ⁺ + (ref ⊖ tot)    ≡⟨ cong (_+_ (uDep ⁺)) (ℤ.⊖-swap ref tot) ⟩
+    uDep ⁺ - (tot ⊖ ref)    ≡˘⟨ cong! deposits-change' ⟩
+    uDep ⁺ - Δdep           ≡˘⟨ cong (uDep ⁺ +_) (ℤ.⊖-swap dep uDep) ⟩
+    uDep ⁺ + (dep ⊖ uDep)   ≡⟨ ℤ.distribʳ-⊖-+-pos uDep dep uDep ⟩
+    uDep + dep ⊖ uDep       ≡⟨ cong (_⊖ uDep) (+-comm uDep dep) ⟩
+    dep + uDep ⊖ uDep       ≡˘⟨ ℤ.distribʳ-⊖-+-pos dep uDep uDep ⟩
+    dep ⁺  + (uDep ⊖ uDep)  ≡⟨ cong (dep ⁺ +_) (ℤ.n⊖n≡0 uDep) ⟩
+    dep ⁺ + 0ℤ              ≡⟨ ℤ.+-identityʳ _ ⟩
+    dep ⁺                   ∎
 
   ref-tot-0 : ref ≢ 0 → tot ≡ 0
   ref-tot-0 ref≢0 with Δdep
-  ... | ℤ.+_ n     = ⊥-elim (ref≢0 refl)
-  ... | ℤ.negsuc n = refl
+  ... | n ⁺         = ⊥-elim (ref≢0 refl)
+  ... | ℤ.negsuc n  = refl
 
   ref≤dep : ref ℕ.≤ dep
   ref≤dep with ref ≟ 0
@@ -219,63 +245,58 @@ module DepositHelpers
 
   deposits-change : uDep ≡ dep + tot ∸ ref
   deposits-change = ℤ.+-injective $ begin
-    ℤ.+_ uDep                                 ≡˘⟨ ℤ.+-identityʳ _ ⟩
-    ℤ.+_ uDep ℤ.+ ℤ.0ℤ                        ≡˘⟨ cong! (ℤ.+-inverseˡ (ℤ.+_ dep)) ⟩
-    ℤ.+_ uDep ℤ.+ (ℤ.-_ (ℤ.+_ dep) ℤ.+ (ℤ.+_ dep))
-      ≡˘⟨ ℤ.+-assoc (ℤ.+_ uDep) (ℤ.-_ (ℤ.+_ dep)) (ℤ.+_ dep) ⟩
-    (ℤ.+_ uDep ℤ.- (ℤ.+_ dep)) ℤ.+ (ℤ.+_ dep) ≡⟨ cong! (ℤ.m-n≡m⊖n uDep dep) ⟩
-    Δdep ℤ.+ (ℤ.+_ dep)                       ≡⟨ ℤ.+-comm Δdep (ℤ.+_ dep) ⟩
-    (ℤ.+_ dep) ℤ.+ Δdep                       ≡⟨ cong! deposits-change' ⟩
-    (ℤ.+_ dep) ℤ.+ (tot ⊖ ref)                ≡⟨ ℤ.distribʳ-⊖-+-pos dep tot ref ⟩
-    (dep + tot) ⊖ ref                         ≡⟨ ℤ.⊖-≥ (m≤n⇒m≤n+o tot ref≤dep) ⟩
-    ℤ.+_ (dep + tot ∸ ref) ∎
+    uDep ⁺                        ≡˘⟨ ℤ.+-identityʳ _ ⟩
+    uDep ⁺ + 0ℤ                   ≡˘⟨ cong (uDep ⁺ +_) (ℤ.+-inverseˡ (dep ⁺)) ⟩
+    uDep ⁺ + ((dep ⁺) ⁻ + dep ⁺)  ≡˘⟨ ℤ.+-assoc (uDep ⁺) ((dep ⁺) ⁻) (dep ⁺) ⟩
+    (uDep ⁺ - dep ⁺) + dep ⁺      ≡⟨ cong (_+ dep ⁺) (ℤ.m-n≡m⊖n uDep dep) ⟩
+    Δdep + dep ⁺                  ≡⟨ ℤ.+-comm Δdep (dep ⁺) ⟩
+    dep ⁺ + Δdep                  ≡⟨ cong (dep ⁺ +_) deposits-change' ⟩
+    dep ⁺ + (tot ⊖ ref)           ≡⟨ ℤ.distribʳ-⊖-+-pos dep tot ref ⟩
+    dep + tot ⊖ ref               ≡⟨ ℤ.⊖-≥ (m≤n⇒m≤n+o tot ref≤dep) ⟩
+    (dep + tot ∸ ref) ⁺ ∎
 
-  utxo-ref-prop :
-    cbalance utxo + ref ≡
-    (cbalance ((utxo ∣ txins tx ᶜ) ∪ᵐˡ outs tx) + txfee tx) + txdonation tx + tot
+  utxo-ref-prop : cbalance utxo + ref ≡ (cbalance (utxoInsᶜ ∪ᵐˡ outs tx) + txfee tx) + don + tot
   utxo-ref-prop = begin
-    cbalance utxo + ref
-      ≡˘⟨ cong (_+ ref) (balance-cong-coin {utxo = (utxo ∣ txins tx ᶜ) ∪ᵐˡ (utxo ∣ txins tx)} {utxo' = utxo}
+    cbalance utxo + ref ≡˘⟨ γ ⟩
+    cbalance (utxoInsᶜ ∪ᵐˡ utxoIns) + ref                              ≡⟨ cong (_+ ref) (balance-∪ {utxoInsᶜ} {utxoIns} (flip res-ex-disjoint)) ⟩
+    cbalance utxoInsᶜ + cbalance utxoIns + ref                         ≡⟨ +-assoc (cbalance utxoInsᶜ) (cbalance utxoIns) ref ⟩
+    cbalance utxoInsᶜ + (cbalance utxoIns + ref)                       ≡⟨ cong (cbalance utxoInsᶜ +_) (balValueToCoin {tx} {utxoSt} noMintAda newBal) ⟩
+    cbalance utxoInsᶜ + (cbalance (outs tx) + txfee tx + tot + don)    ≡⟨ cong (cbalance utxoInsᶜ +_ ) (+-assoc (cbalance (outs tx) + txfee tx) tot don) ⟩
+    cbalance utxoInsᶜ + (cbalance (outs tx) + txfee tx + (tot + don))  ≡⟨ cong (λ x → cbalance utxoInsᶜ + (cbalance (outs tx) + txfee tx + x)) (+-comm tot don) ⟩
+    cbalance utxoInsᶜ + (cbalance (outs tx) + txfee tx + (don + tot))  ≡˘⟨ +-assoc (cbalance utxoInsᶜ) (cbalance (outs tx) + txfee tx) (don + tot) ⟩
+    cbalance utxoInsᶜ + (cbalance (outs tx) + txfee tx) + (don + tot)  ≡˘⟨ cong (_+ (don + tot)) (+-assoc (cbalance utxoInsᶜ) (cbalance (outs tx)) (txfee tx)) ⟩
+    cbalance utxoInsᶜ + cbalance (outs tx) + txfee tx + (don + tot)    ≡˘⟨ cong (λ x → x + (txfee tx) + (don + tot)) (balance-∪ {utxoInsᶜ} {outs tx} h) ⟩
+    cbalance (utxoInsᶜ ∪ᵐˡ outs tx) + txfee tx + (don + tot)           ≡˘⟨ +-assoc (cbalance (utxoInsᶜ ∪ᵐˡ outs tx) + txfee tx) don tot ⟩
+    cbalance (utxoInsᶜ ∪ᵐˡ outs tx) + txfee tx + don + tot             ∎
+    where
+      γ : cbalance (utxoInsᶜ ∪ᵐˡ utxoIns) + ref ≡ cbalance utxo + ref
+      γ = cong (_+ ref) (balance-cong-coin {utxo = utxoInsᶜ ∪ᵐˡ utxoIns} {utxo' = utxo}
           let open IsEquivalence ≡ᵉ-isEquivalence renaming (trans to _≡ᵉ-∘_)
-          in (disjoint-∪ᵐˡ-∪ (disjoint-sym res-ex-disjoint) ≡ᵉ-∘ ∪-sym) ≡ᵉ-∘ res-ex-∪ (_∈? txins tx)) ⟩
-    cbalance ((utxo ∣ txins tx ᶜ) ∪ᵐˡ (utxo ∣ txins tx)) + ref
-      ≡⟨ cong (_+ ref) (balance-∪ {utxo ∣ txins tx ᶜ} {utxo ∣ txins tx} (flip res-ex-disjoint)) ⟩
-    cbalance (utxo ∣ txins tx ᶜ) + cbalance (utxo ∣ txins tx) + ref ≡t⟨⟩
-    cbalance (utxo ∣ txins tx ᶜ) + (cbalance (utxo ∣ txins tx) + ref)
-      ≡⟨ cong (cbalance (utxo ∣ txins tx ᶜ) +_)
-         (balValueToCoin {tx} {utxoSt} {UTxOEnv.pparams Γ} noMintAda newBal) ⟩
-    cbalance (utxo ∣ txins tx ᶜ) + (cbalance (outs tx) + txfee tx + tot + txdonation tx) ≡t⟨⟩
-    (cbalance (utxo ∣ txins tx ᶜ) + cbalance (outs tx) + txfee tx) + tot + txdonation tx
-      ≡˘⟨ cong (λ x → (x + txfee tx) + tot + txdonation tx) (balance-∪ {utxo ∣ txins tx ᶜ} {outs tx} h) ⟩
-    (cbalance ((utxo ∣ txins tx ᶜ) ∪ᵐˡ outs tx) + txfee tx) + tot + txdonation tx ≡t⟨⟩
-    (cbalance ((utxo ∣ txins tx ᶜ) ∪ᵐˡ outs tx) + txfee tx) + (tot + txdonation tx)
-      ≡⟨ cong ((cbalance ((utxo ∣ txins tx ᶜ) ∪ᵐˡ outs tx) + txfee tx) +_) (+-comm tot (txdonation tx)) ⟩
-    (cbalance ((utxo ∣ txins tx ᶜ) ∪ᵐˡ outs tx) + txfee tx) + (txdonation tx + tot) ≡t⟨⟩
-    (cbalance ((utxo ∣ txins tx ᶜ) ∪ᵐˡ outs tx) + txfee tx) + txdonation tx + tot ∎
+          in (disjoint-∪ᵐˡ-∪ (disjoint-sym res-ex-disjoint) ≡ᵉ-∘ ∪-sym) ≡ᵉ-∘ res-ex-∪ (_∈? txins tx))
 
-  rearrange0 : txfee tx + txdonation tx + (tot + remDepTot) + fees ≡
-        fees + txfee tx + getCoin deposits' + txdonation tx
+
+  rearrange0 : txfee tx + don + (tot + remDepTot) + fees ≡ fees + txfee tx + getCoin deposits' + don
   rearrange0 = begin
-    txfee tx + txdonation tx + (tot + remDepTot) + fees
-      ≡⟨ +-comm (txfee tx + txdonation tx + (tot + remDepTot)) fees ⟩
-    fees + (txfee tx + txdonation tx + (tot + remDepTot)) ≡t⟨⟩
-    (fees + txfee tx) + (txdonation tx + (tot + remDepTot))
-      ≡⟨ cong ((fees + txfee tx) +_) (+-comm (txdonation tx) (tot + remDepTot)) ⟩
-    (fees + txfee tx) + ((tot + remDepTot) + txdonation tx) ≡t⟨⟩
-    (fees + txfee tx) + (tot + remDepTot) + txdonation tx
-      ≡⟨ cong (λ x → (fees + txfee tx) + x + txdonation tx) (
-        begin
-          tot + (dep ∸ ref) ≡˘⟨ +-∸-assoc tot ref≤dep ⟩
-          (tot + dep) ∸ ref ≡⟨ cong (_∸ ref) (+-comm tot dep) ⟩
-          (dep + tot) ∸ ref ≡˘⟨ deposits-change ⟩
-          uDep ≡⟨ cong getCoin (sym $ uDep≡ step) ⟩
-          getCoin deposits' ∎
-      )⟩
-    (fees + txfee tx) + getCoin deposits' + txdonation tx ∎
+    txfee tx + don + tot+remDep + fees         ≡⟨ +-comm (txfee tx + don + tot+remDep) fees ⟩
+    fees + (txfee tx + don + tot+remDep)       ≡⟨ cong (fees +_) (+-assoc (txfee tx) don tot+remDep) ⟩
+    fees + (txfee tx + (don + tot+remDep))     ≡˘⟨ +-assoc fees (txfee tx) (don + tot+remDep) ⟩
+    fees + txfee tx + (don + tot+remDep)       ≡⟨ cong (fees + txfee tx +_) (+-comm don tot+remDep) ⟩
+    fees + txfee tx + (tot + remDepTot + don)  ≡˘⟨ +-assoc (fees + txfee tx) tot+remDep don ⟩
+    fees + txfee tx + tot+remDep + don         ≡⟨ cong (λ x → (fees + txfee tx) + x + don) γ ⟩
+    fees + txfee tx + getCoin deposits' + don  ∎
+      where
 
-  rearrange1 : cbalance ((utxo ∣ txins tx ᶜ) ∪ᵐˡ outs tx) + (txfee tx + txdonation tx + (tot + remDepTot) + fees)
-          ≡ cbalance ((utxo ∣ txins tx ᶜ) ∪ᵐˡ outs tx) + ((fees + txfee tx) + getCoin deposits' + txdonation tx)
-  rearrange1 = cong (cbalance ((utxo ∣ txins tx ᶜ) ∪ᵐˡ outs tx) +_) rearrange0
+      γ : tot + remDepTot ≡ getCoin deposits'
+      γ = begin
+        tot + (dep ∸ ref)  ≡˘⟨ +-∸-assoc tot ref≤dep ⟩
+        tot + dep ∸ ref    ≡⟨ cong (_∸ ref) (+-comm tot dep) ⟩
+        dep + tot ∸ ref    ≡˘⟨ deposits-change ⟩
+        uDep               ≡⟨ cong getCoin (sym $ uDep≡ step) ⟩
+        getCoin deposits'  ∎
+
+  rearrange1 : cbalance (utxoInsᶜ ∪ᵐˡ outs tx) + (txfee tx + don + (tot + remDepTot) + fees)
+          ≡ cbalance (utxoInsᶜ ∪ᵐˡ outs tx) + ((fees + txfee tx) + getCoin deposits' + don)
+  rearrange1 = cong (cbalance (utxoInsᶜ ∪ᵐˡ outs tx) +_) rearrange0
 
 \end{code}
 
@@ -318,31 +339,44 @@ then
       getCoin ⟦ utxo , fees , deposits , donations ⟧ᵘ ≡ getCoin ⟦ utxo' , fees' , deposits' , donations' ⟧ᵘ
 \end{code}
 \begin{code}[hide]
-pov {tx} {utxo} {_} {fees} {deposits} {donations} {utxo'} {fees'} {deposits'} {donations'} h' step@(UTXO-inductive {Γ} _ _ _ _ newBal noMintAda _) =
-  let h : disjoint (dom ((utxo ∣ txins tx ᶜ) ˢ)) (dom (outs tx ˢ))
-      h = λ h₁ h₂ → ∉-∅ $ proj₁ (newTxid⇒disj {tx = tx} {utxo} h') $ to ∈-∩ (res-comp-domᵐ h₁ , h₂)
-      utxoSt = ⟦ utxo , fees , deposits , donations ⟧ᵘ
+pov {tx} {utxo} {_} {fees} {deps} {dons} {_} {fees'} {deps'} h' step@(UTXO-inductive {Γ} _ _ _ _ _ _ _) =
+  let  utxoInsᶜ = utxo ∣ txins tx ᶜ
+       donate = txdonation tx in
+  begin
+    cbalance utxo + fees + dep + dons   ≡⟨ cong (_+ dons) γ ⟩
+    cbalance (utxoInsᶜ ∪ᵐˡ outs tx) + ((fees + txfee tx) + getCoin deps' + donate) + dons ≡⟨ cong (λ x → cbalance (utxoInsᶜ ∪ᵐˡ outs tx) + x + dons) (+-assoc (fees + txfee tx) (getCoin deps') (donate)) ⟩
+    cbalance (utxoInsᶜ ∪ᵐˡ outs tx) + ((fees + txfee tx) + (getCoin deps' + donate)) + dons ≡˘⟨ cong (_+ dons) (+-assoc (cbalance (utxoInsᶜ ∪ᵐˡ outs tx)) (fees + txfee tx) (getCoin deps' + donate)) ⟩
+    cbalance (utxoInsᶜ ∪ᵐˡ outs tx) + (fees + txfee tx) + (getCoin deps' + donate) + dons ≡˘⟨ cong (_+ dons) (+-assoc (cbalance (utxoInsᶜ ∪ᵐˡ outs tx) + (fees + txfee tx)) (getCoin deps') (donate)) ⟩
+    cbalance (utxoInsᶜ ∪ᵐˡ outs tx) + (fees + txfee tx) + getCoin deps' + donate + dons ≡⟨ +-assoc (cbalance (utxoInsᶜ ∪ᵐˡ outs tx) + (fees + txfee tx) + getCoin deps') (donate) dons ⟩
+    cbalance (utxoInsᶜ ∪ᵐˡ outs tx) + (fees + txfee tx) + getCoin deps' + (donate + dons)
+      ≡⟨ cong (λ x → cbalance (utxoInsᶜ ∪ᵐˡ outs tx) + (fees + txfee tx) + getCoin deps' + x) (+-comm (donate) dons) ⟩
+    cbalance (utxoInsᶜ ∪ᵐˡ outs tx) + (fees + txfee tx) + getCoin deps' + (dons + donate) ∎
+      where
+      utxoSt = ⟦ utxo , fees , deps , dons ⟧ᵘ
+      dep = getCoin deps
       pp = UTxOEnv.pparams Γ
       ref = depositRefunds pp utxoSt tx
+      remDepTot = getCoin deps ∸ ref
       tot = newDeposits pp utxoSt tx
-      dep = getCoin deposits
-      remDepTot = getCoin deposits ∸ ref
+      donate = txdonation tx
+      utxoInsᶜ = utxo ∣ txins tx ᶜ
       open DepositHelpers step h'
-  in begin
-    cbalance utxo + fees + dep + donations   ≡⟨ cong (_+ donations) (
-        begin
-          cbalance utxo + fees + dep ≡tˡ⟨ cong (cbalance utxo +_) (+-comm fees dep) ⟩
-          cbalance utxo + (dep + fees) ≡˘⟨ cong (λ x → cbalance utxo + (x + fees)) (m+[n∸m]≡n ref≤dep) ⟩
-          cbalance utxo + ((ref + remDepTot) + fees) ≡t⟨⟩
-          cbalance utxo + ref + (remDepTot + fees) ≡⟨ cong (_+ (remDepTot + fees)) utxo-ref-prop ⟩
-          (cbalance ((utxo ∣ txins tx ᶜ) ∪ᵐˡ outs tx) + txfee tx) + txdonation tx + tot + (remDepTot + fees) ≡t⟨⟩
-          cbalance ((utxo ∣ txins tx ᶜ) ∪ᵐˡ outs tx) + (txfee tx + txdonation tx + (tot + remDepTot) + fees) ≡⟨ rearrange1 ⟩
-          cbalance ((utxo ∣ txins tx ᶜ) ∪ᵐˡ outs tx) + ((fees + txfee tx) + getCoin deposits' + txdonation tx) ∎
-      )⟩
-    cbalance ((utxo ∣ txins tx ᶜ) ∪ᵐˡ outs tx) + ((fees + txfee tx) + getCoin deposits' + txdonation tx) + donations ≡t⟨⟩
-    cbalance ((utxo ∣ txins tx ᶜ) ∪ᵐˡ outs tx) + (fees + txfee tx) + getCoin deposits' + (txdonation tx + donations)
-      ≡⟨ cong (cbalance ((utxo ∣ txins tx ᶜ) ∪ᵐˡ outs tx) + (fees + txfee tx) + getCoin deposits' +_) (+-comm (txdonation tx) donations) ⟩
-    cbalance ((utxo ∣ txins tx ᶜ) ∪ᵐˡ outs tx) + (fees + txfee tx) + getCoin deposits' + (donations + txdonation tx) ∎
+      γ : cbalance utxo + fees + dep ≡ cbalance (utxoInsᶜ ∪ᵐˡ outs tx) + ((fees + txfee tx) + getCoin deps' + donate)
+      γ = begin
+          cbalance utxo + fees + dep                                                       ≡⟨ +-assoc (cbalance utxo) fees dep ⟩
+          cbalance utxo + (fees + dep)                                                     ≡⟨ cong (cbalance utxo +_) (+-comm fees dep) ⟩
+          cbalance utxo + (dep + fees)                                                     ≡˘⟨ cong (λ x → cbalance utxo + (x + fees)) (m+[n∸m]≡n ref≤dep) ⟩
+          cbalance utxo + (ref + remDepTot + fees)                                         ≡⟨ cong (cbalance utxo +_) (+-assoc ref remDepTot fees) ⟩
+          cbalance utxo + (ref + (remDepTot + fees))                                       ≡˘⟨ +-assoc (cbalance utxo ) ref (remDepTot + fees) ⟩
+          cbalance utxo + ref + (remDepTot + fees)                                         ≡⟨ cong (_+ (remDepTot + fees)) utxo-ref-prop ⟩
+          cbalance (utxoInsᶜ ∪ᵐˡ outs tx) + txfee tx + donate + tot + (remDepTot + fees)    ≡˘⟨ +-assoc (cbalance (utxoInsᶜ ∪ᵐˡ outs tx) + txfee tx + donate + tot) remDepTot fees ⟩
+          cbalance (utxoInsᶜ ∪ᵐˡ outs tx) + txfee tx + donate + tot + remDepTot + fees      ≡⟨ cong (_+ fees) (+-assoc (cbalance (utxoInsᶜ ∪ᵐˡ outs tx) + txfee tx + donate) tot remDepTot) ⟩
+          cbalance (utxoInsᶜ ∪ᵐˡ outs tx) + txfee tx + donate + (tot + remDepTot) + fees    ≡⟨ cong (λ x → x + (tot + remDepTot) + fees) (+-assoc (cbalance (utxoInsᶜ ∪ᵐˡ outs tx)) (txfee tx) donate) ⟩
+          cbalance (utxoInsᶜ ∪ᵐˡ outs tx) + (txfee tx + donate) + (tot + remDepTot) + fees  ≡⟨ cong (_+ fees) (+-assoc (cbalance (utxoInsᶜ ∪ᵐˡ outs tx)) (txfee tx + donate) (tot + remDepTot)) ⟩
+          cbalance (utxoInsᶜ ∪ᵐˡ outs tx) + (txfee tx + donate + (tot + remDepTot)) + fees  ≡⟨ +-assoc (cbalance (utxoInsᶜ ∪ᵐˡ outs tx)) (txfee tx + donate + (tot + remDepTot)) fees ⟩
+          cbalance (utxoInsᶜ ∪ᵐˡ outs tx) + (txfee tx + donate + (tot + remDepTot) + fees)  ≡⟨ rearrange1 ⟩
+          cbalance (utxoInsᶜ ∪ᵐˡ outs tx) + (fees + txfee tx + getCoin deps' + donate)  ∎
+
 \end{code}
 
 \end{property}

--- a/src/MidnightExample/Ledger.lagda
+++ b/src/MidnightExample/Ledger.lagda
@@ -5,7 +5,7 @@
 open import Interface.DecEq
 open import Interface.Hashable
 
-open import Prelude hiding (_+_; _<ᵇ_; _∧_) renaming (_×_ to _∧_)
+open import Prelude hiding (_<ᵇ_; _∧_) renaming (_×_ to _∧_)
 open import Ledger.Prelude using (indexedSumL)
 open import Data.Integer hiding (_/_; _≟_)
 

--- a/src/Prelude.agda
+++ b/src/Prelude.agda
@@ -14,7 +14,8 @@ open import Data.Maybe hiding (_>>=_; align; alignWith; ap; fromMaybe; map; zip;
 open import Data.Unit hiding (_≟_) public
 open import Data.Sum hiding (assocʳ; assocˡ; map; map₁; map₂; reduce; swap) public
 open import Data.Product hiding (assocʳ; assocˡ; map; map₁; map₂; swap) public
-open import Data.Nat hiding (_≟_; _≤_; _≤?_; _<_; _<?_; _≤ᵇ_; _≡ᵇ_) public
+open import Data.Nat hiding (_≟_; _≤_; _≤?_; _<_; _<?_; _≤ᵇ_; _≡ᵇ_) renaming (_+_ to _+ℕ_) public
+open import Data.Integer as ℤ using (ℤ; _⊖_) renaming (_+_ to _+ℤ_) public
 open import Data.String using (String; _<+>_) public
 
 open import Relation.Nullary.Negation public

--- a/src/Tactic/DeriveComp.agda
+++ b/src/Tactic/DeriveComp.agda
@@ -27,6 +27,8 @@ open import Generics.Core
 open import Interface.ComputationalRelation
 open import Interface.DecEq
 open import Interface.Decidable.Instance
+open import Interface.HasAdd
+open import Interface.HasAdd.Instance
 
 open import Interface.Monad.Instance
 open import Interface.MonadReader.Instance


### PR DESCRIPTION
# Description
This cleans up imports of one module---Utxo.Properties

It is based on [william/34-type-classes](https://github.com/input-output-hk/formal-ledger-specifications/tree/william/34-type-classes) and [william/183-cleanup-imports-utxo-properties](https://github.com/input-output-hk/formal-ledger-specifications/tree/william/183-cleanup-imports-utxo-properties) so the diffs will be large at first, but will become small---limited to just the imports of the `Utxo` module---once those two prior branches are merged.

# Checklist

- [X] Commit sequence broadly makes sense and commits have useful messages
- [X] Code is formatted according to [CONTRIBUTING.md](https://github.com/input-output-hk/formal-ledger-specifications/blob/master/CONTRIBUTING.md)
- [X] Self-reviewed the diff
