### PR TITLE
Type classes for common structures: subtraction

### DIFF
--- a/src/Interface/HasSubtract.agda
+++ b/src/Interface/HasSubtract.agda
@@ -1,0 +1,8 @@
+{-# OPTIONS --safe --cubical-compatible #-}
+module Interface.HasSubtract where
+
+record HasSubtract (A : Set) : Set where
+  infixl 7 _-_
+  field _-_ : A → A → A
+
+open HasSubtract ⦃ ... ⦄ public

--- a/src/Interface/HasSubtract/Instance.agda
+++ b/src/Interface/HasSubtract/Instance.agda
@@ -1,0 +1,15 @@
+{-# OPTIONS --safe #-}
+
+module Interface.HasSubtract.Instance where
+
+open import Interface.HasSubtract
+
+open import Data.Integer  using (ℤ) renaming (_-_ to _-ℤ_)
+open import Data.Nat      using (ℕ) renaming (_∸_ to _-ℕ_)
+
+instance
+  subtractInt : HasSubtract ℤ
+  subtractInt = record { _-_ = _-ℤ_ }
+
+  subtractNat : HasSubtract ℕ
+  subtractNat = record { _-_ = _-ℕ_ }

--- a/src/Ledger/GovernanceActions.lagda
+++ b/src/Ledger/GovernanceActions.lagda
@@ -332,7 +332,7 @@ It represents how the \AgdaBound{EnactState} changes when a specific governance 
     ────────────────────────────────
     ⟦ gid ⟧ᵉ ⊢ s ⇀⦇ TreasuryWdrl wdrl  ,ENACT⦈
       record s { withdrawals  = s .withdrawals  ∪⁺ wdrl
-               ; treasury     = s .treasury     ∸  newWdrls }
+               ; treasury     = s .treasury     -  newWdrls }
   Enact-Info      : ⟦ gid ⟧ᵉ ⊢ s ⇀⦇ Info  ,ENACT⦈ s
 \end{code}
 } %% end small

--- a/src/Ledger/Prelude.agda
+++ b/src/Ledger/Prelude.agda
@@ -20,6 +20,8 @@ open import Interface.DecEq public
 open import Ledger.Interface.HasCoin public
 open import Interface.HasAdd public
 open import Interface.HasAdd.Instance public
+open import Interface.HasSubtract public
+open import Interface.HasSubtract.Instance public
 open import Relation.Nullary public
 open import Relation.Unary using () renaming (Decidable to Dec₁) public
 open Computational public

--- a/src/Ledger/Utxo/Properties.lagda
+++ b/src/Ledger/Utxo/Properties.lagda
@@ -171,7 +171,7 @@ module DepositHelpers
     noMintAda : coin (mint tx) ≡ 0
     noMintAda = noMintAda' step
     remDepTot : Coin
-    remDepTot = getCoin deposits ∸ ref
+    remDepTot = getCoin deposits - ref
 
   uDep≡
     : Γ ⊢ ⟦ utxo , fees , deposits , donations ⟧ᵘ ⇀⦇ tx ,UTXO⦈ ⟦ utxo' , fees' , deposits' , donations' ⟧ᵘ
@@ -208,7 +208,7 @@ module DepositHelpers
     dep        ∎
   ... | yes p rewrite p = z≤n
 
-  deposits-change : uDep ≡ dep + tot ∸ ref
+  deposits-change : uDep ≡ dep + tot - ref
   deposits-change = ℤ.+-injective $ begin
     ℤ.+_ uDep                                 ≡˘⟨ ℤ.+-identityʳ _ ⟩
     ℤ.+_ uDep ℤ.+ ℤ.0ℤ                        ≡˘⟨ cong! (ℤ.+-inverseˡ (ℤ.+_ dep)) ⟩
@@ -219,7 +219,7 @@ module DepositHelpers
     (ℤ.+_ dep) ℤ.+ Δdep                       ≡⟨ cong! deposits-change' ⟩
     (ℤ.+_ dep) ℤ.+ (tot ⊖ ref)                ≡⟨ ℤ.distribʳ-⊖-+-pos dep tot ref ⟩
     (dep + tot) ⊖ ref                         ≡⟨ ℤ.⊖-≥ (m≤n⇒m≤n+o tot ref≤dep) ⟩
-    ℤ.+_ (dep + tot ∸ ref) ∎
+    ℤ.+_ (dep + tot - ref) ∎
 
   utxo-ref-prop :
     cbalance utxo + ref ≡
@@ -256,9 +256,9 @@ module DepositHelpers
     (fees + txfee tx) ℕ.+ (tot + remDepTot) ℕ.+ txdonation tx
       ≡⟨ cong (λ x → (fees + txfee tx) + x + txdonation tx) (
         begin
-          tot + (dep ∸ ref) ≡˘⟨ +-∸-assoc tot ref≤dep ⟩
-          (tot + dep) ∸ ref ≡⟨ cong (_∸ ref) (+-comm tot dep) ⟩
-          (dep + tot) ∸ ref ≡˘⟨ deposits-change ⟩
+          tot + (dep - ref) ≡˘⟨ +-∸-assoc tot ref≤dep ⟩
+          (tot + dep) - ref ≡⟨ cong (_- ref) (+-comm tot dep) ⟩
+          (dep + tot) - ref ≡˘⟨ deposits-change ⟩
           uDep ≡⟨ cong getCoin (sym $ uDep≡ step) ⟩
           getCoin deposits' ∎
       )⟩
@@ -317,13 +317,13 @@ pov {tx} {utxo} {_} {fees} {deposits} {donations} {utxo'} {fees'} {deposits'} {d
       ref = depositRefunds pp utxoSt tx
       tot = newDeposits pp utxoSt tx
       dep = getCoin deposits
-      remDepTot = getCoin deposits ∸ ref
+      remDepTot = getCoin deposits - ref
       open DepositHelpers step h'
   in begin
     cbalance utxo + fees + dep + donations   ≡⟨ cong (_+ donations) (
         begin
           cbalance utxo ℕ.+ fees ℕ.+ dep ≡tˡ⟨ cong (cbalance utxo ℕ.+_) (+-comm fees dep) ⟩
-          cbalance utxo ℕ.+ (dep + fees) ≡˘⟨ cong (λ x → cbalance utxo + (x + fees)) (m+[n∸m]≡n ref≤dep) ⟩
+          cbalance utxo + (dep + fees) ≡˘⟨ cong (λ x → cbalance utxo + (x + fees)) (m+[n∸m]≡n ref≤dep) ⟩
           cbalance utxo ℕ.+ ((ref ℕ.+ remDepTot) ℕ.+ fees) ≡t⟨⟩
           cbalance utxo ℕ.+ ref ℕ.+ (remDepTot ℕ.+ fees) ≡⟨ cong (_+ (remDepTot + fees)) utxo-ref-prop ⟩
           (cbalance ((utxo ∣ txins tx ᶜ) ∪ᵐˡ outs tx) ℕ.+ txfee tx) ℕ.+ txdonation tx ℕ.+ tot ℕ.+ (remDepTot ℕ.+ fees) ≡t⟨⟩

--- a/src/Tactic/DeriveComp.agda
+++ b/src/Tactic/DeriveComp.agda
@@ -35,6 +35,9 @@ open import Interface.MonadReader.Instance
 open import Interface.MonadError.Instance
 open import Interface.MonadTC.Instance
 
+open import Interface.HasSubtract
+open import Interface.HasSubtract.Instance
+
 instance
   _ = ContextMonad-MonadTC
 
@@ -49,7 +52,7 @@ record STSConstr : Set where
     result  : Term
 
 conOrVarToPattern : ℕ → Term → Maybe Pattern
-conOrVarToPattern k (♯ v) = just (Pattern.var (v ∸ k))
+conOrVarToPattern k (♯ v) = just (Pattern.var (v - k))
 conOrVarToPattern k (con c args) =
   Pattern.con c <$> (sequenceList $ conOrVarToPattern′ k args)
   where
@@ -67,11 +70,11 @@ toSTSConstr (n , (cs , def _ args)) with args | mapMaybe (conOrVarToPattern (len
   return record
     { name = n
     ; params = takeWhile isArg cs
-    ; clauses = zipWithIndex (λ i → mapVars (_∸ i)) $ (unArg ∘ unAbs) <$> dropWhile isArg cs
+    ; clauses = zipWithIndex (λ i → mapVars (_- i)) $ (unArg ∘ unAbs) <$> dropWhile isArg cs
     ; context = c
     ; state = s
     ; signal = sig
-    ; result = mapVars (_∸ (length $ dropWhile isArg cs)) $ unArg r }
+    ; result = mapVars (_- (length $ dropWhile isArg cs)) $ unArg r }
 ... | l | l' =
   error1 ("toSTSConstr: wrong number of arguments:" <+> ℕ.show (length l) <+> "," <+> ℕ.show (length l'))
 toSTSConstr _ = error1 "toSTSConstr: wrong constructor"


### PR DESCRIPTION
# Description

This addresses issue #34 for the special case of subtraction in the `GovernanceActions`, `Utxo.Properties`, and `Tactic/DeriveComp` modules.

The goal of this PR is to allow us to use a single operation symbol, _-_, to denote subtraction over each of the types ℤ, ℕ, and Coin (which is currently just an alias for ℕ).

# Checklist

- [X] Commit sequence broadly makes sense and commits have useful messages
- [X] Code is formatted according to [CONTRIBUTING.md](https://github.com/input-output-hk/formal-ledger-specifications/blob/master/CONTRIBUTING.md)
- [X] Self-reviewed the diff
