### PR TITLE
Fix that governance actions were removed immediately

### DIFF
--- a/src/Ledger/Chain.lagda
+++ b/src/Ledger/Chain.lagda
@@ -94,9 +94,12 @@ data _⊢_⇀⦇_,NEWEPOCH⦈_ : NewEpochEnv → NewEpochState → Epoch → New
 
       retired = retiring ⁻¹ e
 
-      certState' = record certState {
-        pState = record pState { pools = pools ∣ retired ᶜ ; retiring = retiring ∣ retired ᶜ };
-        dState = record dState { rewards = rewards ∪⁺ refunds } }
+      certState' = record certState
+        { pState = record pState { pools = pools ∣ retired ᶜ ; retiring = retiring ∣ retired ᶜ }
+        ; dState = record dState { rewards = rewards ∪⁺ refunds } }
+        ; gState = if not (null govSt')
+                     then gState
+                     else record gState { dreps = mapValues sucᵉ (GState.dreps gState) }
       utxoSt' = record utxoSt
         { fees = 0
         ; deposits = deposits ∣ map (proj₁ ∘ proj₂) removedGovActions ᶜ

--- a/src/Ledger/Epoch.agda
+++ b/src/Ledger/Epoch.agda
@@ -44,6 +44,10 @@ record EpochStructure : Set₁ where
   _≤ˢ?_ : (s s' : Slot) → Dec (s ≤ˢ s')
   s ≤ˢ? s' = ¬? (s' <ˢ? s)
 
+  ℕtoEpoch : ℕ → Epoch
+  ℕtoEpoch zero    = epoch (Semiring.0# Slotʳ)
+  ℕtoEpoch (suc n) = sucᵉ (ℕtoEpoch n)
+
   _+ᵉ_ : ℕ → Epoch → Epoch
   zero +ᵉ e = e
   suc n +ᵉ e = sucᵉ (n +ᵉ e)

--- a/src/Ledger/Gov.lagda
+++ b/src/Ledger/Gov.lagda
@@ -74,8 +74,9 @@ addAction s e aid addr a prev = s ∷ʳ (aid , record
 
 -- x is the anchor in those two cases, which we don't do anything with
 data _⊢_⇀⦇_,GOV'⦈_ : GovEnv × ℕ → GovState → GovVote ⊎ GovProposal → GovState → Set where
-  GOV-Vote : ∀ {x k} → let open GovEnv Γ in
-    aid ∈ setFromList (L.map proj₁ s)
+  GOV-Vote : ∀ {x k ast} → let open GovEnv Γ in
+    (aid , ast) ∈ setFromList s
+    → canVote pparams (action ast) role
     ────────────────────────────────
     (Γ , k) ⊢ s ⇀⦇ inj₁ record { gid = aid ; role = role ; credential = cred ; vote = v ; anchor = x } ,GOV'⦈
               addVote s aid role cred v

--- a/src/Ledger/PParams.lagda
+++ b/src/Ledger/PParams.lagda
@@ -81,7 +81,8 @@ record PParams : Set where
 paramsWellFormed : PParams → Bool
 paramsWellFormed pp = ⌊ ¬? (0 ∈? setFromList
   (maxBlockSize ∷ maxTxSize ∷ maxHeaderSize ∷ maxValSize ∷ minUTxOValue ∷ poolDeposit
-  ∷ collateralPercent ∷ ccTermLimit ∷ govExpiration ∷ govDeposit ∷ drepDeposit ∷ [])) ⌋
+  ∷ collateralPercent ∷ ccTermLimit ∷ govExpiration ∷ govDeposit ∷ drepDeposit ∷ [])) ⌋ ∧
+  ⌊ (ℕtoEpoch govExpiration) ≤ᵉ? drepActivity ⌋
   where open PParams pp
 \end{code}
 \end{AgdaAlign}

--- a/src/Ledger/Ratify.lagda
+++ b/src/Ledger/Ratify.lagda
@@ -371,7 +371,7 @@ accepted' Γ es@record { cc = cc , _    ; pparams = pparams , _ }
     meetsMinAVS = activeVotingStake cc' redStakeDistr votes ≥ minimumAVS
 
     acceptedBy : GovRole → Set
-    acceptedBy role = let t = threshold pparams (Data.Maybe.map proj₂ cc) action role in
+    acceptedBy role = let t = maybe id R.0ℚ (threshold pparams (Data.Maybe.map proj₂ cc) action role) in
       case totalStake role cc' redStakeDistr votes of λ where
         0          → t ≡ R.0ℚ -- if there's no stake, accept only if threshold is zero
         x@(suc _)  → Z.+ acceptedStake role cc' redStakeDistr votes R./ x R.≥ t

--- a/src/Ledger/Ratify.lagda
+++ b/src/Ledger/Ratify.lagda
@@ -119,10 +119,9 @@ record RatifyEnv : Set where
         ccHotKeys     : Credential ⇀ Maybe Credential
 
 record RatifyState : Set where
-  constructor ⟦_,_,_,_⟧ʳ
+  constructor ⟦_,_,_⟧ʳ
   field es              : EnactState
-        future          : List (GovActionID × GovActionState)
-        removed         : List (GovActionID × GovActionState)
+        removed         : ℙ (GovActionID × GovActionState)
         delay           : Bool
 
 CCData : Set
@@ -434,11 +433,9 @@ The code in Figure~\ref{fig:defs:ratify-iv} defines still more types required fo
 \begin{code}[hide]
 private variable
   Γ : RatifyEnv
-  s s' : RatifyState
   es es' : EnactState
-  upd : PParamsUpdate
   a : GovActionID × GovActionState
-  f f' l removed : List (GovActionID × GovActionState)
+  removed : ℙ (GovActionID × GovActionState)
   d : Bool
 
 -- having `accepted` abstract speeds up type checking of RATIFY' a lot
@@ -457,7 +454,7 @@ data _⊢_⇀⦇_,RATIFY'⦈_ : RatifyEnv → RatifyState → GovActionID × Gov
     → ¬ delayed action prevAction es d
     → ⟦ proj₁ a ⟧ᵉ ⊢ es ⇀⦇ action ,ENACT⦈ es'
     ────────────────────────────────
-    Γ ⊢ ⟦ es , f , removed , d ⟧ʳ ⇀⦇ a ,RATIFY'⦈ ⟦ es' , f , a ∷ removed , delayingAction action ⟧ʳ
+    Γ ⊢ ⟦ es , removed , d ⟧ʳ ⇀⦇ a ,RATIFY'⦈ ⟦ es' , ❴ a ❵ ∪ removed , delayingAction action ⟧ʳ
 
   -- remove expired actions
   -- NOTE:  We don't have to remove actions that can never be accpted because of
@@ -467,14 +464,14 @@ data _⊢_⇀⦇_,RATIFY'⦈_ : RatifyEnv → RatifyState → GovActionID × Gov
     ¬ accepted Γ es st
     → expired currentEpoch st
     ────────────────────────────────
-    Γ ⊢ ⟦ es , f , removed , d ⟧ʳ ⇀⦇ a ,RATIFY'⦈ ⟦ es , f , a ∷ removed , d ⟧ʳ
+    Γ ⊢ ⟦ es , removed , d ⟧ʳ ⇀⦇ a ,RATIFY'⦈ ⟦ es , ❴ a ❵ ∪ removed , d ⟧ʳ
 
   -- Continue voting in the next epoch
 
   RATIFY-Continue : let open RatifyEnv Γ; st = proj₂ a; open GovActionState st in
     ¬ accepted Γ es st × ¬ expired currentEpoch st ⊎ delayed action prevAction es d
     ────────────────────────────────
-    Γ ⊢ ⟦ es , f , removed , d ⟧ʳ ⇀⦇ a ,RATIFY'⦈ ⟦ es , a ∷ f , removed , d ⟧ʳ
+    Γ ⊢ ⟦ es , removed , d ⟧ʳ ⇀⦇ a ,RATIFY'⦈ ⟦ es , removed , d ⟧ʳ
 
 _⊢_⇀⦇_,RATIFY⦈_ :  RatifyEnv → RatifyState → List (GovActionID × GovActionState)
                    → RatifyState → Set


### PR DESCRIPTION
# Description

They are removed at the same epoch where they come into effect (via rollover of `EnactState`). Fixes #180.

<!-- Add your description here, if it fixes a particular issue please provide a
[link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=)
to the issue. -->

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] Code is formatted according to [CONTRIBUTING.md](https://github.com/input-output-hk/formal-ledger-specifications/blob/master/CONTRIBUTING.md)
- [x] Self-reviewed the diff
