### PR TITLE
Make `RATIFY` total

### DIFF
--- a/src/Interface/ComputationalRelation.agda
+++ b/src/Interface/ComputationalRelation.agda
@@ -79,6 +79,9 @@ module _ {STS : C → S → Sig → S → Set} (comp : Computational STS) where
   computational⇒rightUnique h h' with ExtendedRel-rightUnique h h'
   ... | refl = refl
 
+  nothing⇒∀¬STS : compute c s sig ≡ nothing → ∀ s' → ¬ STS c s sig s'
+  nothing⇒∀¬STS comp≡nothing s' h rewrite Equivalence.from ≡-just⇔STS h = case comp≡nothing of λ ()
+
   Computational⇒Dec : ⦃ _ : DecEq S ⦄ → Dec (STS c s sig s')
   Computational⇒Dec {c} {s} {sig} {s'} with compute c s sig | ExtendedRel-compute {c} {s} {sig}
   ... | nothing | ExSTS = no (ExSTS s')

--- a/src/Interface/STS.agda
+++ b/src/Interface/STS.agda
@@ -4,6 +4,8 @@ module Interface.STS where
 
 open import Prelude
 
+open import Data.Product using (map₂)
+
 infix -150 ∙_
 infixr -100 _∙_
 
@@ -47,6 +49,14 @@ module _ (_⊢_⇀_ : C → S → S → Set) (_⊢_⇀⟦_⟧_ : C × ℕ → S 
 -- with a trivial base case
 SS⇒BS : (C × ℕ → S → Sig → S → Set) → C → S → List Sig → S → Set
 SS⇒BS {C} {S} {Sig} = _⊢_⇀⟦_⟧*_ {C} {S} {Sig} (λ _ → _≡_)
+
+SS-total⇒BS-total : {_⊢_⇀⟦_⟧_ : C × ℕ → S → Sig → S → Set}
+                  → (∀ {Γ s sig} → ∃[ s' ] Γ ⊢ s ⇀⟦ sig ⟧ s')
+                  → (∀ {Γ s sig} → ∃[ s' ] SS⇒BS _⊢_⇀⟦_⟧_ Γ s sig s')
+SS-total⇒BS-total SS-total {Γ} {s} {[]} = s , BS-base refl
+SS-total⇒BS-total SS-total {Γ} {s} {x ∷ sig} =
+  case SS-total {Γ , length sig} {s} {x} of λ where
+    (s' , Ps') → map₂ (BS-ind Ps') $ SS-total⇒BS-total SS-total {Γ} {s'} {sig}
 
 -- with a given base case
 SS⇒BSᵇ = _⊢_⇀⟦_⟧*_

--- a/src/Ledger/Chain.lagda
+++ b/src/Ledger/Chain.lagda
@@ -96,10 +96,10 @@ data _⊢_⇀⦇_,NEWEPOCH⦈_ : NewEpochEnv → NewEpochState → Epoch → New
 
       certState' = record certState
         { pState = record pState { pools = pools ∣ retired ᶜ ; retiring = retiring ∣ retired ᶜ }
-        ; dState = record dState { rewards = rewards ∪⁺ refunds } }
+        ; dState = record dState { rewards = rewards ∪⁺ refunds }
         ; gState = if not (null govSt')
                      then gState
-                     else record gState { dreps = mapValues sucᵉ (GState.dreps gState) }
+                     else record gState { dreps = mapValues sucᵉ (GState.dreps gState) } }
       utxoSt' = record utxoSt
         { fees = 0
         ; deposits = deposits ∣ map (proj₁ ∘ proj₂) removedGovActions ᶜ

--- a/src/Ledger/Chain.lagda
+++ b/src/Ledger/Chain.lagda
@@ -109,7 +109,7 @@ data _⊢_⇀⦇_,NEWEPOCH⦈_ : NewEpochEnv → NewEpochState → Epoch → New
       acnt' = record acnt { treasury = Acnt.treasury acnt + UTxOState.fees utxoSt + getCoin unclaimed + donations }
     in
     e ≡ sucᵉ lastEpoch
-    → record { currentEpoch = e ; GState gState ; NewEpochEnv Γ }
+    → record { currentEpoch = e ; treasury = Acnt.treasury acnt ; GState gState ; NewEpochEnv Γ }
         ⊢ ⟦ es , ∅ , false ⟧ʳ ⇀⦇ govSt' ,RATIFY⦈ fut'
     -- TODO: remove keys that aren't in the CC from the hot key map
     ────────────────────────────────

--- a/src/Ledger/Chain/Properties.agda
+++ b/src/Ledger/Chain/Properties.agda
@@ -1,0 +1,50 @@
+{-# OPTIONS --safe #-}
+
+open import Ledger.Transaction
+
+module Ledger.Chain.Properties (txs : TransactionStructure) where
+
+open import Ledger.Prelude
+
+open TransactionStructure txs
+open import Ledger.Gov TxId Network ADHash epochStructure ppUpd ppHashingScheme crypto
+open import Ledger.Ratify txs
+open import Ledger.Chain txs
+open import Ledger.PParams epochStructure
+open import Ledger.Ledger txs
+
+open import Ledger.Ratify.Properties txs
+
+open import Data.Nat.Properties hiding (_≟_)
+
+open Computational
+
+instance
+  _ = +-0-monoid
+  _ = +-0-commutativeMonoid
+
+-- TODO: get rid of all of those arguments once we have them globally
+
+module _ (accepted? : ∀ Γ es st → Dec (accepted Γ es st))
+         (expired? : ∀ e st → Dec (expired e st))
+         (delayed? : ∀ a p es d → Dec (delayed a p es d))
+         (Computational-ENACT : Computational _⊢_⇀⦇_,ENACT⦈_) where
+
+  NEWEPOCH-total : ∀ {Γ s sig}
+                 → ∃[ s' ] Γ ⊢ s ⇀⦇ sig ,NEWEPOCH⦈ s'
+  NEWEPOCH-total {Γ} {nes} {e} =
+    let open NewEpochState nes hiding (es)
+        open RatifyState fut using (es; removed)
+        open LState ls
+        open CertState certState
+        open Acnt acnt
+
+        govSt' = filter (¬? ∘ (_∈? map proj₁ removed) ∘ proj₁) govSt
+
+        (fut' , pFut) = RATIFY-total accepted? expired? delayed? Computational-ENACT
+          {record { currentEpoch = e ; treasury = treasury ; GState gState ; NewEpochEnv Γ }}
+          {⟦ es , ∅ , false ⟧ʳ} {govSt'}
+    in
+    case e ≟ sucᵉ lastEpoch of λ where
+      (no ¬p) → -, NEWEPOCH-Not-New ¬p
+      (yes p) → -, NEWEPOCH-New p pFut

--- a/src/Ledger/PDF.lagda
+++ b/src/Ledger/PDF.lagda
@@ -85,6 +85,7 @@ open import Ledger.PPUp
 open import Ledger.PPUp.Properties
 
 open import Ledger.Ledger.Properties
+open import Ledger.Ratify.Properties
 
 open import Ledger.TokenAlgebra.ValueSet
 \end{code}

--- a/src/Ledger/PDF.lagda
+++ b/src/Ledger/PDF.lagda
@@ -86,6 +86,7 @@ open import Ledger.PPUp.Properties
 
 open import Ledger.Ledger.Properties
 open import Ledger.Ratify.Properties
+open import Ledger.Chain.Properties
 
 open import Ledger.TokenAlgebra.ValueSet
 \end{code}

--- a/src/Ledger/Ratify.lagda
+++ b/src/Ledger/Ratify.lagda
@@ -117,6 +117,7 @@ record RatifyEnv : Set where
         currentEpoch  : Epoch
         dreps         : Credential ⇀ Epoch
         ccHotKeys     : Credential ⇀ Maybe Credential
+        treasury      : Coin
 
 record RatifyState : Set where
   constructor ⟦_,_,_⟧ʳ
@@ -449,10 +450,10 @@ data _⊢_⇀⦇_,RATIFY'⦈_ : RatifyEnv → RatifyState → GovActionID × Gov
 \begin{figure*}[h!]
 {\small
 \begin{code}
-  RATIFY-Accept : let st = proj₂ a; open GovActionState st in
+  RATIFY-Accept : let open RatifyEnv Γ; st = proj₂ a; open GovActionState st in
     accepted Γ es st
     → ¬ delayed action prevAction es d
-    → ⟦ proj₁ a ⟧ᵉ ⊢ es ⇀⦇ action ,ENACT⦈ es'
+    → ⟦ proj₁ a , treasury ⟧ᵉ ⊢ es ⇀⦇ action ,ENACT⦈ es'
     ────────────────────────────────
     Γ ⊢ ⟦ es , removed , d ⟧ʳ ⇀⦇ a ,RATIFY'⦈ ⟦ es' , ❴ a ❵ ∪ removed , delayingAction action ⟧ʳ
 
@@ -469,7 +470,10 @@ data _⊢_⇀⦇_,RATIFY'⦈_ : RatifyEnv → RatifyState → GovActionID × Gov
   -- Continue voting in the next epoch
 
   RATIFY-Continue : let open RatifyEnv Γ; st = proj₂ a; open GovActionState st in
-    ¬ accepted Γ es st × ¬ expired currentEpoch st ⊎ delayed action prevAction es d
+    ¬ accepted Γ es st × ¬ expired currentEpoch st
+    ⊎ delayed action prevAction es d
+    ⊎ accepted Γ es st × ¬ delayed action prevAction es d
+      × (∀ es' → ¬ ⟦ proj₁ a , treasury ⟧ᵉ ⊢ es ⇀⦇ action ,ENACT⦈ es')
     ────────────────────────────────
     Γ ⊢ ⟦ es , removed , d ⟧ʳ ⇀⦇ a ,RATIFY'⦈ ⟦ es , removed , d ⟧ʳ
 

--- a/src/Ledger/Ratify/Properties.agda
+++ b/src/Ledger/Ratify/Properties.agda
@@ -1,0 +1,34 @@
+{-# OPTIONS --safe #-}
+
+open import Ledger.Transaction
+
+module Ledger.Ratify.Properties (txs : TransactionStructure) where
+
+open import Ledger.Prelude
+
+open TransactionStructure txs
+open import Ledger.Gov TxId Network ADHash epochStructure ppUpd ppHashingScheme crypto
+open import Ledger.Ratify txs
+
+open Computational
+
+caseEq_of_ : ∀ {a b} {A : Set a} {B : Set b} → (a : A) → ((a' : A) → a ≡ a' → B) → B
+caseEq a of f = f a refl
+
+-- TODO: get rid of all of those arguments once we have them globally
+
+RATIFY-total : ∀ {Γ s sig}
+             → (∀ es st → Dec (accepted Γ es st))
+             → (∀ e st → Dec (expired e st))
+             → (∀ a p es d → Dec (delayed a p es d))
+             → Computational _⊢_⇀⦇_,ENACT⦈_
+             → ∃[ s' ] Γ ⊢ s ⇀⦇ sig ,RATIFY'⦈ s'
+RATIFY-total {Γ} {⟦ es , removed , d ⟧ʳ} {sig} accepted? expired? delayed? Computational-ENACT =
+  let open RatifyEnv Γ; st = proj₂ sig; open GovActionState st in
+  case accepted? es st , expired? currentEpoch st , delayed? action prevAction es d of λ where
+    (no ¬p , no ¬p₁ , _) → -, RATIFY-Continue (inj₁ (¬p , ¬p₁))
+    (no ¬p , yes p , _) → -, RATIFY-Reject ¬p p
+    (yes p , _ , no ¬p₁) → caseEq (compute Computational-ENACT ⟦ proj₁ sig , treasury ⟧ᵉ es action) of λ where
+      (just x) eq → -, RATIFY-Accept p ¬p₁ (Equivalence.to (≡-just⇔STS Computational-ENACT) eq)
+      nothing eq  → -, RATIFY-Continue (inj₂ (inj₂ (p , ¬p₁ , nothing⇒∀¬STS Computational-ENACT eq)))
+    (yes p , _ , yes p₁) → -, RATIFY-Continue (inj₂ (inj₁ p₁))

--- a/src/Ledger/Ratify/Properties.agda
+++ b/src/Ledger/Ratify/Properties.agda
@@ -17,18 +17,21 @@ caseEq a of f = f a refl
 
 -- TODO: get rid of all of those arguments once we have them globally
 
-RATIFY-total : ∀ {Γ s sig}
-             → (∀ es st → Dec (accepted Γ es st))
-             → (∀ e st → Dec (expired e st))
-             → (∀ a p es d → Dec (delayed a p es d))
-             → Computational _⊢_⇀⦇_,ENACT⦈_
-             → ∃[ s' ] Γ ⊢ s ⇀⦇ sig ,RATIFY'⦈ s'
-RATIFY-total {Γ} {⟦ es , removed , d ⟧ʳ} {sig} accepted? expired? delayed? Computational-ENACT =
-  let open RatifyEnv Γ; st = proj₂ sig; open GovActionState st in
-  case accepted? es st , expired? currentEpoch st , delayed? action prevAction es d of λ where
-    (no ¬p , no ¬p₁ , _) → -, RATIFY-Continue (inj₁ (¬p , ¬p₁))
-    (no ¬p , yes p , _) → -, RATIFY-Reject ¬p p
-    (yes p , _ , no ¬p₁) → caseEq (compute Computational-ENACT ⟦ proj₁ sig , treasury ⟧ᵉ es action) of λ where
-      (just x) eq → -, RATIFY-Accept p ¬p₁ (Equivalence.to (≡-just⇔STS Computational-ENACT) eq)
-      nothing eq  → -, RATIFY-Continue (inj₂ (inj₂ (p , ¬p₁ , nothing⇒∀¬STS Computational-ENACT eq)))
-    (yes p , _ , yes p₁) → -, RATIFY-Continue (inj₂ (inj₁ p₁))
+module _ (accepted? : ∀ Γ es st → Dec (accepted Γ es st))
+         (expired? : ∀ e st → Dec (expired e st))
+         (delayed? : ∀ a p es d → Dec (delayed a p es d))
+         (Computational-ENACT : Computational _⊢_⇀⦇_,ENACT⦈_) where
+
+  RATIFY'-total : ∀ {Γ s sig} → ∃[ s' ] Γ ⊢ s ⇀⦇ sig ,RATIFY'⦈ s'
+  RATIFY'-total {Γ} {⟦ es , removed , d ⟧ʳ} {sig} =
+    let open RatifyEnv Γ; st = proj₂ sig; open GovActionState st in
+    case accepted? Γ es st , expired? currentEpoch st , delayed? action prevAction es d of λ where
+      (no ¬p , no ¬p₁ , _) → -, RATIFY-Continue (inj₁ (¬p , ¬p₁))
+      (no ¬p , yes p , _) → -, RATIFY-Reject ¬p p
+      (yes p , _ , no ¬p₁) → caseEq (compute Computational-ENACT ⟦ proj₁ sig , treasury ⟧ᵉ es action) of λ where
+        (just x) eq → -, RATIFY-Accept p ¬p₁ (Equivalence.to (≡-just⇔STS Computational-ENACT) eq)
+        nothing eq  → -, RATIFY-Continue (inj₂ (inj₂ (p , ¬p₁ , nothing⇒∀¬STS Computational-ENACT eq)))
+      (yes p , _ , yes p₁) → -, RATIFY-Continue (inj₂ (inj₁ p₁))
+
+  RATIFY-total : ∀ {Γ s sig} → ∃[ s' ] Γ ⊢ s ⇀⦇ sig ,RATIFY⦈ s'
+  RATIFY-total = SS-total⇒BS-total RATIFY'-total


### PR DESCRIPTION
# Description

This is important since we can get stuck on an epoch boundary otherwise. This also moves the treasury from `EnactState` into `EnactEnv`, which is equivalent but cleaner.

Closes #194.

<!-- Add your description here, if it fixes a particular issue please provide a
[link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=)
to the issue. -->

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] Code is formatted according to [CONTRIBUTING.md](https://github.com/input-output-hk/formal-ledger-specifications/blob/master/CONTRIBUTING.md)
- [x] Self-reviewed the diff
