### PR TITLE
Type classes for common structures: preorders, partial orders, and strict total orders

### DIFF
--- a/src/Data/Nat/Properties/Ext.agda
+++ b/src/Data/Nat/Properties/Ext.agda
@@ -2,7 +2,6 @@
 
 module Data.Nat.Properties.Ext where
 
-open import Data.Nat as ℕ using (ℕ ; _<_)
 open import Data.Nat.Properties
 open import Ledger.Prelude
 open import Relation.Nullary.Decidable
@@ -21,6 +20,6 @@ negInduction {P = P} P? P0 (N , ¬PN) with anyUpTo? (λ x → P? x ×-dec ¬? (P
     k<N⇒P'k {zero}  k<N = helper k<N P0
     k<N⇒P'k {suc k} k<N = helper k<N (proj₂ $ k<N⇒P'k {k} (<⇒≤ k<N))
 
-    k≤N⇒Pk : ∀ {k} → k ℕ.≤ N → P k
+    k≤N⇒Pk : ∀ {k} → k ≤ N → P k
     k≤N⇒Pk {zero}  k≤N = P0
     k≤N⇒Pk {suc k} k≤N = proj₂ $ k<N⇒P'k k≤N

--- a/src/Data/Nat/Properties/Ext.agda
+++ b/src/Data/Nat/Properties/Ext.agda
@@ -2,10 +2,11 @@
 
 module Data.Nat.Properties.Ext where
 
-open import Data.Nat
+open import Data.Nat as ℕ using (ℕ ; _<_)
 open import Data.Nat.Properties
 open import Ledger.Prelude
 open import Relation.Nullary.Decidable
+open import Interface.HasOrder.Instance
 
 -- if P holds for 0 but not for some N, then there exists a k where the induction step fails
 negInduction : {P : ℕ → Set} → Dec₁ P → P 0 → ∃[ N ] ¬ P N → ∃[ k ] P k × ¬ P (suc k)
@@ -20,6 +21,6 @@ negInduction {P = P} P? P0 (N , ¬PN) with anyUpTo? (λ x → P? x ×-dec ¬? (P
     k<N⇒P'k {zero}  k<N = helper k<N P0
     k<N⇒P'k {suc k} k<N = helper k<N (proj₂ $ k<N⇒P'k {k} (<⇒≤ k<N))
 
-    k≤N⇒Pk : ∀ {k} → k ≤ N → P k
+    k≤N⇒Pk : ∀ {k} → k ℕ.≤ N → P k
     k≤N⇒Pk {zero}  k≤N = P0
     k≤N⇒Pk {suc k} k≤N = proj₂ $ k<N⇒P'k k≤N

--- a/src/Interface/Decidable/Instance.agda
+++ b/src/Interface/Decidable/Instance.agda
@@ -47,7 +47,5 @@ instance
   DecEq⇒Dec : ⦃ DecEq X ⦄ → {x y : X} → Dec (x ≡ y)
   DecEq⇒Dec ⦃ record { _≟_ = _≟_ } ⦄ {x} {y} = x ≟ y
 
-  Dec-⊎ : ∀ {a b} {A : Set a} {B : Set b} → ⦃ Dec A ⦄ → ⦃ Dec B ⦄ → Dec (A ⊎ B)
-  Dec-⊎ ⦃ yes p ⦄ ⦃ _     ⦄ = yes (inj₁ p)
-  Dec-⊎ ⦃ no _  ⦄ ⦃ yes q ⦄ = yes (inj₂ q)
-  Dec-⊎ ⦃ no ¬p ⦄ ⦃ no ¬q ⦄ = no λ { (inj₁ p) → ¬p p; (inj₂ q) → ¬q q }
+  -- Moved `Dec-⊎` to where it is used (in `Deleg` module); otherwise it conflicts with
+  -- one of the `_≤_` instances that we want Agda to use in the `PPUp.Properties` module.

--- a/src/Interface/HasOrder.agda
+++ b/src/Interface/HasOrder.agda
@@ -1,0 +1,24 @@
+{-# OPTIONS --safe #-}
+
+module Interface.HasOrder where
+
+open import Level using (_⊔_ ; suc)
+open import Relation.Binary using (Rel)
+open import Relation.Binary.Structures using (IsPreorder ; IsPartialOrder)
+
+record HasPreorder {a ℓ ℓ₂} (A : Set a) (_≈_ : Rel A ℓ) : Set (a ⊔ ℓ ⊔ suc ℓ₂) where
+  infix 4 _≤_
+  field
+    _≤_ : Rel A ℓ₂
+    isPreorder : IsPreorder {A = A} _≈_ _≤_
+
+-- Remove the following; otherwise, we can't resolve _≤_ for ℕ type in GovernanceActions.
+-- open HasPreorder ⦃ ... ⦄ public
+
+record HasPartialOrder {a ℓ ℓ₂} (A : Set a) (_≈_ : Rel A ℓ) : Set (a ⊔ ℓ ⊔ suc ℓ₂) where
+  infix 4 _≤_
+  field
+    _≤_ : Rel A ℓ₂
+    isPartialOrder  : IsPartialOrder {A = A} _≈_ _≤_
+
+open HasPartialOrder ⦃ ... ⦄ public

--- a/src/Interface/HasOrder.agda
+++ b/src/Interface/HasOrder.agda
@@ -2,9 +2,10 @@
 
 module Interface.HasOrder where
 
-open import Level using (_⊔_ ; suc)
+open import Level using (_⊔_; suc)
 open import Relation.Binary using (Rel)
-open import Relation.Binary.Structures using (IsPreorder ; IsPartialOrder)
+open import Relation.Binary.Definitions using (Decidable)
+open import Relation.Binary.Structures using (IsPreorder; IsPartialOrder; IsStrictTotalOrder)
 
 record HasPreorder {a ℓ ℓ₂} (A : Set a) (_≈_ : Rel A ℓ) : Set (a ⊔ ℓ ⊔ suc ℓ₂) where
   infix 4 _≤_
@@ -12,8 +13,7 @@ record HasPreorder {a ℓ ℓ₂} (A : Set a) (_≈_ : Rel A ℓ) : Set (a ⊔ �
     _≤_ : Rel A ℓ₂
     isPreorder : IsPreorder {A = A} _≈_ _≤_
 
--- Remove the following; otherwise, we can't resolve _≤_ for ℕ type in GovernanceActions.
--- open HasPreorder ⦃ ... ⦄ public
+-- open HasPreorder ⦃ ... ⦄ public -- (removed; otherwise can't resolve _≤_ for ℕ in GovernanceActions)
 
 record HasPartialOrder {a ℓ ℓ₂} (A : Set a) (_≈_ : Rel A ℓ) : Set (a ⊔ ℓ ⊔ suc ℓ₂) where
   infix 4 _≤_
@@ -22,3 +22,19 @@ record HasPartialOrder {a ℓ ℓ₂} (A : Set a) (_≈_ : Rel A ℓ) : Set (a �
     isPartialOrder  : IsPartialOrder {A = A} _≈_ _≤_
 
 open HasPartialOrder ⦃ ... ⦄ public
+
+record HasStrictTotalOrder {a ℓ ℓ₂} (A : Set a) (_≈_ : Rel A ℓ)  : Set (a ⊔ ℓ ⊔ suc ℓ₂) where
+  infix 4 _<_
+  field
+    _<_ : Rel A ℓ₂
+    isStrictTotalOrder : IsStrictTotalOrder {A = A} _≈_ _<_
+
+open HasStrictTotalOrder ⦃ ... ⦄ public
+
+record HasDecPartialOrder {a ℓ ℓ₂} (A : Set a) (_≈_ : Rel A ℓ) : Set (a ⊔ ℓ ⊔ suc ℓ₂) where
+  infix 4 _≤?_
+  field
+    _≤_   : Rel A ℓ₂
+    _≤?_  : Decidable _≤_
+
+-- open HasDecPartialOrder ⦃ ... ⦄ public

--- a/src/Interface/HasOrder/Instance.agda
+++ b/src/Interface/HasOrder/Instance.agda
@@ -1,0 +1,37 @@
+{-# OPTIONS --safe #-}
+
+module Interface.HasOrder.Instance where
+
+open import Prelude                  using (_≡_)
+open import Interface.HasOrder       using (HasPartialOrder)
+open import Data.Integer             using (ℤ) renaming (_≤_ to _≤ℤ_)
+open import Data.Integer.Properties  using ( ) renaming (≤-isPartialOrder to ≤ℤ-isPartialOrder)
+open import Data.Nat                 using (ℕ) renaming (_≤_ to _≤ℕ_)
+open import Data.Nat.Properties      using ( ) renaming (≤-isPartialOrder to ≤ℕ-isPartialOrder)
+
+instance
+  leqInt : HasPartialOrder ℤ _≡_
+  leqInt = record { _≤_ = _≤ℤ_ ; isPartialOrder = ≤ℤ-isPartialOrder }
+
+  leqNat : HasPartialOrder ℕ _≡_
+  leqNat = record { _≤_ = _≤ℕ_ ; isPartialOrder = ≤ℕ-isPartialOrder }
+
+-- (The following no longer works since we've switched the type class from "raw"
+-- partial orders to partial orders with properties.)
+--
+-- open import Prelude                  using (refl)
+-- open import Ledger.Prelude           using (isEquivalence)
+-- open import Ledger.TokenAlgebra
+-- open import Relation.Binary.Structures using (IsPartialOrder)
+
+-- module leqTokenAlgebra (PolicyId : Set)(ta : TokenAlgebra PolicyId)  where
+--   open TokenAlgebra ta
+--   instance
+--     leqTokenAlgebra : HasPartialOrder Value _≡_
+--     leqTokenAlgebra = record { _≤_ = _≤ᵗ_ ; isPartialOrder = poTA }
+--       where
+--       poTA : IsPartialOrder _≡_ _≤ᵗ_
+--       Relation.Binary.Structures.IsPreorder.isEquivalence (IsPartialOrder.isPreorder poTA) = isEquivalence
+--       Relation.Binary.Structures.IsPreorder.reflexive (IsPartialOrder.isPreorder poTA) refl = {!!}
+--       Relation.Binary.Structures.IsPreorder.trans (IsPartialOrder.isPreorder poTA) = {!!}
+--       IsPartialOrder.antisym poTA = {!!}

--- a/src/Interface/HasOrder/Instance.agda
+++ b/src/Interface/HasOrder/Instance.agda
@@ -3,35 +3,24 @@
 module Interface.HasOrder.Instance where
 
 open import Prelude                  using (_≡_)
-open import Interface.HasOrder       using (HasPartialOrder)
-open import Data.Integer             using (ℤ) renaming (_≤_ to _≤ℤ_)
-open import Data.Integer.Properties  using ( ) renaming (≤-isPartialOrder to ≤ℤ-isPartialOrder)
-open import Data.Nat                 using (ℕ) renaming (_≤_ to _≤ℕ_)
-open import Data.Nat.Properties      using ( ) renaming (≤-isPartialOrder to ≤ℕ-isPartialOrder)
+open import Interface.HasOrder       using (HasPartialOrder; HasStrictTotalOrder)
+open import Data.Integer             using (ℤ) renaming  (_≤_ to _≤ℤ_; _<_ to _<ℤ_)
+open import Data.Integer.Properties  using ( ) renaming  (≤-isPartialOrder to ≤ℤ-isPartialOrder)
+open import Data.Integer.Properties  using ( ) renaming  (<-isStrictTotalOrder to <ℤ-isStrictTotalOrder)
+open import Data.Nat                 using (ℕ) renaming  (_≤_ to _≤ℕ_; _<_ to _<ℕ_)
+open import Data.Nat.Properties      using ( ) renaming  (≤-isPartialOrder to ≤ℕ-isPartialOrder)
+open import Data.Nat.Properties      using ( ) renaming  (<-isStrictTotalOrder to <ℕ-isStrictTotalOrder)
+
 
 instance
   leqInt : HasPartialOrder ℤ _≡_
   leqInt = record { _≤_ = _≤ℤ_ ; isPartialOrder = ≤ℤ-isPartialOrder }
 
+  ltInt : HasStrictTotalOrder ℤ _≡_
+  ltInt = record { _<_ = _<ℤ_ ; isStrictTotalOrder = <ℤ-isStrictTotalOrder }
+
   leqNat : HasPartialOrder ℕ _≡_
   leqNat = record { _≤_ = _≤ℕ_ ; isPartialOrder = ≤ℕ-isPartialOrder }
 
--- (The following no longer works since we've switched the type class from "raw"
--- partial orders to partial orders with properties.)
---
--- open import Prelude                  using (refl)
--- open import Ledger.Prelude           using (isEquivalence)
--- open import Ledger.TokenAlgebra
--- open import Relation.Binary.Structures using (IsPartialOrder)
-
--- module leqTokenAlgebra (PolicyId : Set)(ta : TokenAlgebra PolicyId)  where
---   open TokenAlgebra ta
---   instance
---     leqTokenAlgebra : HasPartialOrder Value _≡_
---     leqTokenAlgebra = record { _≤_ = _≤ᵗ_ ; isPartialOrder = poTA }
---       where
---       poTA : IsPartialOrder _≡_ _≤ᵗ_
---       Relation.Binary.Structures.IsPreorder.isEquivalence (IsPartialOrder.isPreorder poTA) = isEquivalence
---       Relation.Binary.Structures.IsPreorder.reflexive (IsPartialOrder.isPreorder poTA) refl = {!!}
---       Relation.Binary.Structures.IsPreorder.trans (IsPartialOrder.isPreorder poTA) = {!!}
---       IsPartialOrder.antisym poTA = {!!}
+  ltNat : HasStrictTotalOrder ℕ _≡_
+  ltNat = record { _<_ = _<ℕ_ ; isStrictTotalOrder = <ℕ-isStrictTotalOrder }

--- a/src/Ledger/Deleg.lagda
+++ b/src/Ledger/Deleg.lagda
@@ -239,6 +239,11 @@ instance
   Computational-POOL = fromComputational' Computational'-POOL
 
 instance
+  Dec-⊎ : ∀ {a b} {A : Set a} {B : Set b} → ⦃ Dec A ⦄ → ⦃ Dec B ⦄ → Dec (A ⊎ B)
+  Dec-⊎ ⦃ yes p ⦄ ⦃ _     ⦄ = yes (inj₁ p)
+  Dec-⊎ ⦃ no _  ⦄ ⦃ yes q ⦄ = yes (inj₂ q)
+  Dec-⊎ ⦃ no ¬p ⦄ ⦃ no ¬q ⦄ = no λ { (inj₁ p) → ¬p p; (inj₂ q) → ¬q q }
+
   Computational'-GOVCERT : Computational' _⊢_⇀⦇_,GOVCERT⦈_
   Computational'-GOVCERT .computeProof ⟦ e , pp , vs ⟧ᶜ ⟦ dReps , ccKeys ⟧ᵛ (regdrep c d an) =
     let open PParams pp in

--- a/src/Ledger/Epoch.agda
+++ b/src/Ledger/Epoch.agda
@@ -2,14 +2,15 @@
 
 module Ledger.Epoch where
 
-open import Ledger.Prelude hiding (compare)
+open import Ledger.Prelude
 
-open import Data.Nat using (_<_)
+open import Data.Nat using () renaming (_<_ to _<ℕ_)
 open import Data.Nat.Properties using (+-*-semiring; <-isStrictTotalOrder)
 
-open import Algebra
+open import Algebra using (Semiring)
 open import Relation.Binary
-open import Relation.Nullary.Negation
+
+import Relation.Binary.Construct.StrictToNonStrict as StrictToNonStrict
 
 record GlobalConstants : Set₁ where
   field Network : Set
@@ -33,16 +34,51 @@ record EpochStructure : Set₁ where
         sucᵉ : Epoch → Epoch
         instance DecEq-Epoch : DecEq Epoch
 
+  _>ˢ_ : Slot → Slot → Set
+  _>ˢ_ = flip _<ˢ_
+
   _≥ˢ_ : Slot → Slot → Set
-  _≥ˢ_ = ¬_ ∘₂ _<ˢ_
+  x ≥ˢ y = (x >ˢ y) ⊎ (x ≡ y)
 
   _≤ˢ_ : Slot → Slot → Set
-  _≤ˢ_ = flip _≥ˢ_
+  x ≤ˢ y = (x <ˢ y) ⊎ (x ≡ y)
+
+  tri : Trichotomous _≡_ _<ˢ_
+  tri = IsStrictTotalOrder.compare Slot-STO
+
+  ≤ˢ⇒¬>ˢ-mp : {x y : Slot} → x ≤ˢ y → Tri (x <ˢ y) (x ≡ y) (x >ˢ y) → ¬ (x >ˢ y)
+  ≤ˢ⇒¬>ˢ-mp _           (tri< _     _     ¬x>y)  x>y  = ¬x>y x>y
+  ≤ˢ⇒¬>ˢ-mp _           (tri≈ _     _     ¬x>y)  x>y  = ¬x>y x>y
+  ≤ˢ⇒¬>ˢ-mp (inj₁ x<y)  (tri> ¬x<y  _     _)     _    = ¬x<y x<y
+  ≤ˢ⇒¬>ˢ-mp (inj₂ x≡y)  (tri> _     ¬x≡y  _)     _    = ¬x≡y x≡y
+
+  ≤ˢ⇒¬>ˢ : {x y : Slot} → x ≤ˢ y → ¬ (x >ˢ y)
+  ≤ˢ⇒¬>ˢ x≤y x>y = ≤ˢ⇒¬>ˢ-mp x≤y (tri _ _) x>y
 
   open IsStrictTotalOrder Slot-STO using () renaming (_<?_ to _<ˢ?_) public
 
+  open StrictToNonStrict _≡_ _<ˢ_
+
+  ≤ˢ-isDecTotalOrder : IsDecTotalOrder _≡_ _≤ˢ_
+  ≤ˢ-isDecTotalOrder = isDecTotalOrder Slot-STO
+
+  ≤ˢ-isTotalOrder : IsTotalOrder _≡_ _≤ˢ_
+  ≤ˢ-isTotalOrder = isTotalOrder Slot-STO
+
+  ≤ˢ-isPartialOrder : IsPartialOrder _≡_ _≤ˢ_
+  ≤ˢ-isPartialOrder = IsTotalOrder.isPartialOrder ≤ˢ-isTotalOrder
+
+  ≤ˢ-isPreorder : IsPreorder _≡_ _≤ˢ_
+  ≤ˢ-isPreorder = IsPartialOrder.isPreorder ≤ˢ-isPartialOrder
+
+  ≤ˢ-isTransitive : Transitive _≤ˢ_
+  ≤ˢ-isTransitive = IsPreorder.trans ≤ˢ-isPreorder
+
+  ≤ˢ-isAntisymmetric : Antisymmetric _≡_ _≤ˢ_
+  ≤ˢ-isAntisymmetric = IsPartialOrder.antisym ≤ˢ-isPartialOrder
+
   _≤ˢ?_ : (s s' : Slot) → Dec (s ≤ˢ s')
-  s ≤ˢ? s' = ¬? (s' <ˢ? s)
+  _≤ˢ?_ = IsDecTotalOrder._≤?_ ≤ˢ-isDecTotalOrder
 
   ℕtoEpoch : ℕ → Epoch
   ℕtoEpoch zero    = epoch (Semiring.0# Slotʳ)
@@ -65,12 +101,23 @@ record EpochStructure : Set₁ where
   _≤ᵉ?_ : (e e' : Epoch) → Dec (e ≤ᵉ e')
   e ≤ᵉ? e' = firstSlot e ≤ˢ? firstSlot e'
 
+  ≤ᵉ-isPreorder : IsPreorder _≡_ _≤ᵉ_
+  ≤ᵉ-isPreorder .IsPreorder.isEquivalence     = Ledger.Prelude.isEquivalence
+  ≤ᵉ-isPreorder .IsPreorder.reflexive refl    = inj₂ Ledger.Prelude.refl
+  ≤ᵉ-isPreorder .IsPreorder.trans ij jk       = ≤ˢ-isTransitive ij jk
+
   instance
     addSlot : HasAdd Slot
     addSlot = record { _+_ = _+ˢ_ }
 
     addEpoch : HasAdd Epoch
     addEpoch = record { _+_ = _+ᵉ'_ }
+
+    poSlot : HasPartialOrder Slot _≡_
+    poSlot = record { _≤_ = _≤ˢ_ ; isPartialOrder = ≤ˢ-isPartialOrder }
+
+    preoEpoch : HasPreorder Epoch _≡_
+    preoEpoch = record { _≤_ = _≤ᵉ_ ; isPreorder = ≤ᵉ-isPreorder }
 
 module _ (gc : GlobalConstants) where
   open GlobalConstants gc
@@ -81,7 +128,7 @@ module _ (gc : GlobalConstants) where
   ℕEpochStructure .Epoch           = ℕ
   ℕEpochStructure .epoch     slot  = slot / SlotsPerEpochᶜ
   ℕEpochStructure .firstSlot e     = e * SlotsPerEpochᶜ
-  ℕEpochStructure ._<ˢ_            = _<_
+  ℕEpochStructure ._<ˢ_            = _<ℕ_
   ℕEpochStructure .Slot-STO        = <-isStrictTotalOrder
   ℕEpochStructure .StabilityWindow = StabilityWindowᶜ
   ℕEpochStructure .sucᵉ            = suc

--- a/src/Ledger/Foreign/HSLedger.agda
+++ b/src/Ledger/Foreign/HSLedger.agda
@@ -9,9 +9,9 @@ import Data.Rational as ℚ
 
 open import Algebra              using (CommutativeMonoid)
 open import Algebra.Morphism     using (module MonoidMorphisms)
-open import Data.Nat.Properties  using (+-0-monoid)
-open import Data.Nat using (_≤_; _≤ᵇ_)
-open import Data.Nat.Properties using (+-*-semiring; <-isStrictTotalOrder)
+open import Data.Nat.Properties  using (+-0-commutativeMonoid) renaming (_≟_ to _≟ℕ_)
+import Data.Nat as ℕ
+open import Data.Nat.Properties  using (+-*-semiring; <-isStrictTotalOrder)
 open import Relation.Binary.Morphism.Structures
 
 open import Foreign.Convertible
@@ -21,6 +21,8 @@ import Ledger.Foreign.LedgerTypes as F
 
 open import Ledger.Crypto
 open import Ledger.Epoch
+
+open import Interface.HasOrder.Instance
 
 open GlobalConstants
 HSGlobalConstants : GlobalConstants
@@ -98,8 +100,6 @@ HSScriptStructure = record { p1s = HSP1ScriptStructure ; ps = HSP2ScriptStructur
 
 open import Ledger.Transaction
 import Ledger.TokenAlgebra as TA
-open import Data.Nat.Properties using (+-0-commutativeMonoid; _≟_)
-open import Data.Nat
 
 module _ where
 
@@ -114,7 +114,7 @@ module _ where
   coinTokenAlgebra  .inject                    = id
   coinTokenAlgebra  .policies                  = λ _ → ∅
   coinTokenAlgebra  .size                      = λ x → 1 -- there is only ada in this token algebra
-  coinTokenAlgebra  ._≤ᵗ_                      = _≤_
+  coinTokenAlgebra  ._≤ᵗ_                      = ℕ._≤_
   coinTokenAlgebra  .AssetName                 = String
   coinTokenAlgebra  .specialAsset              = "Ada"
   coinTokenAlgebra  .property                  = λ _ → refl
@@ -127,7 +127,7 @@ module _ where
                     .homo                      = λ _ _ → refl
   coinTokenAlgebra  .coinIsMonoidHomomorphism
                     .ε-homo                    = refl
-  coinTokenAlgebra  .DecEq-Value               = record { _≟_ = Data.Nat._≟_ }
+  coinTokenAlgebra  .DecEq-Value               = record { _≟_ = _≟ℕ_ }
 
 module _ where
   open TransactionStructure

--- a/src/Ledger/GovernanceActions.lagda
+++ b/src/Ledger/GovernanceActions.lagda
@@ -17,8 +17,7 @@ open import Ledger.Prelude hiding (yes; no)
 open import Ledger.Epoch
 
 import Ledger.PParams as PP
-
-open import Data.Nat using (_≤_)
+import Data.Nat as ℕ
 open import Data.Nat.Properties using (+-0-commutativeMonoid; +-0-monoid)
 open import Data.Rational using (ℚ; 0ℚ; 1ℚ)
 
@@ -334,7 +333,7 @@ It represents how the \agdaboundEnactState changes when a specific governance ac
     record s { pparams = applyUpdate (proj₁ (s .pparams)) up , gid }
   Enact-Wdrl      :
     let newWdrls = Σᵐᵛ[ x ← wdrl ᶠᵐ ] x
-    in newWdrls ≤ s .treasury
+    in newWdrls ℕ.≤ s .treasury
     ────────────────────────────────
     ⟦ gid ⟧ᵉ ⊢ s ⇀⦇ TreasuryWdrl wdrl  ,ENACT⦈
       record s { withdrawals  = s .withdrawals  ∪⁺ wdrl

--- a/src/Ledger/PPUp.lagda
+++ b/src/Ledger/PPUp.lagda
@@ -92,6 +92,8 @@ data _⊢_⇀⦇_,PPUP⦈_ : PPUpdateEnv → PPUpdateState → Maybe Update → 
   PPUpdateCurrent : let open PPUpdateEnv Γ in
     dom (pup ˢ) ⊆ dom (genDelegs ˢ)
     → All (isViableUpdate pparams) (range (pup ˢ))
+    -- I would like to remove the `ˢ` decoration from `<ˢ`, but I believe we need a *strict*
+    -- order type class for that and including such a type class was voted down.
     → (slot + (2 * StabilityWindow)) <ˢ firstSlot (sucᵉ (epoch slot))
     → epoch slot ≡ e
     ────────────────────────────────
@@ -101,7 +103,7 @@ data _⊢_⇀⦇_,PPUP⦈_ : PPUpdateEnv → PPUpdateState → Maybe Update → 
   PPUpdateFuture : let open PPUpdateEnv Γ in
     dom (pup ˢ) ⊆ dom (genDelegs ˢ)
     → All (isViableUpdate pparams) (range (pup ˢ))
-    → firstSlot (sucᵉ (epoch slot)) ≤ˢ (slot + (2 * StabilityWindow))
+    → firstSlot (sucᵉ (epoch slot)) ≤ (slot + (2 * StabilityWindow))
     → sucᵉ (epoch slot) ≡ e
     ────────────────────────────────
     Γ ⊢ record { pup = pupˢ ; fpup = fpupˢ } ⇀⦇ just (pup , e) ,PPUP⦈

--- a/src/Ledger/PPUp.lagda
+++ b/src/Ledger/PPUp.lagda
@@ -92,9 +92,7 @@ data _⊢_⇀⦇_,PPUP⦈_ : PPUpdateEnv → PPUpdateState → Maybe Update → 
   PPUpdateCurrent : let open PPUpdateEnv Γ in
     dom (pup ˢ) ⊆ dom (genDelegs ˢ)
     → All (isViableUpdate pparams) (range (pup ˢ))
-    -- I would like to remove the `ˢ` decoration from `<ˢ`, but I believe we need a *strict*
-    -- order type class for that and including such a type class was voted down.
-    → (slot + (2 * StabilityWindow)) <ˢ firstSlot (sucᵉ (epoch slot))
+    → (slot + (2 * StabilityWindow)) < firstSlot (sucᵉ (epoch slot))
     → epoch slot ≡ e
     ────────────────────────────────
     Γ ⊢ record { pup = pupˢ ; fpup = fpupˢ } ⇀⦇ just (pup , e) ,PPUP⦈

--- a/src/Ledger/PPUp/Properties.agda
+++ b/src/Ledger/PPUp/Properties.agda
@@ -30,7 +30,7 @@ private
   Current-Property Γ (pup , e) = let open PPUpdateEnv Γ in
       dom (pup ˢ) ⊆ dom (genDelegs ˢ)
       × All (isViableUpdate pparams) (range (pup ˢ))
-      × (slot + (2 * StabilityWindow)) <ˢ firstSlot (sucᵉ (epoch slot))
+      × (slot + (2 * StabilityWindow)) < firstSlot (sucᵉ (epoch slot))
       × epoch slot ≡ e
 
   Future-Property : PPUpdateEnv → Update → Set

--- a/src/Ledger/PPUp/Properties.agda
+++ b/src/Ledger/PPUp/Properties.agda
@@ -4,7 +4,7 @@ open import Ledger.Transaction
 
 module Ledger.PPUp.Properties (txs : TransactionStructure) where
 
-open TransactionStructure txs
+open TransactionStructure txs hiding (Dec-⊎)
 open import Ledger.Prelude hiding (_+_; _*_; Dec₁)
 
 open import Ledger.PPUp txs
@@ -37,7 +37,7 @@ private
   Future-Property Γ (pup , e) = let open PPUpdateEnv Γ in
       dom (pup ˢ) ⊆ dom (genDelegs ˢ)
       × All (isViableUpdate pparams) (range (pup ˢ))
-      × firstSlot (sucᵉ (epoch slot)) ≤ˢ (slot + (2 * StabilityWindow))
+      × firstSlot (sucᵉ (epoch slot)) ≤ (slot + (2 * StabilityWindow))
       × sucᵉ (epoch slot) ≡ e
 
 instance
@@ -55,15 +55,18 @@ instance
   Dec-Current-Property : ∀ {Γ u} → Dec (Current-Property Γ u)
   Dec-Current-Property {Γ} = ¿ _ ¿ ×-dec all?' ⦃ Dec₁-isViableUpdate {Γ} ⦄ ×-dec ¿ _ ¿ ×-dec _ ≟ _
 
+  _ = Decidable²⇒Dec _≤ˢ?_
+
   Dec-Future-Property : ∀ {Γ u} → Dec (Future-Property Γ u)
   Dec-Future-Property {Γ} = ¿ _ ¿ ×-dec all?' ⦃ Dec₁-isViableUpdate {Γ} ⦄ ×-dec ¿ _ ¿ ×-dec _ ≟ _
 
 private
   helper : ∀ {Γ u} → Dec (Current-Property Γ u) × Dec (Future-Property Γ u) → PPUpdateState → Maybe PPUpdateState
-  helper (no _  , no  _) record { pup = pupˢ ; fpup = fpupˢ } = nothing
-  helper {u = (pup , _)} (no _  , yes _) record { pup = pupˢ ; fpup = fpupˢ } = just record { pup = pupˢ ; fpup = pup ∪ᵐˡ fpupˢ }
-  helper {u = (pup , _)} (yes _ , no  _) record { pup = pupˢ ; fpup = fpupˢ } = just record { pup = pup ∪ᵐˡ pupˢ ; fpup = fpupˢ }
-  helper (yes (_ , _ , p , _) , yes (_ , _ , p' , _)) _       = case p' p of λ ()
+  helper                  (no _                 , no _                  ) _                                     = nothing
+  helper {u = (pup , _)}  (no _                 , yes _                 ) record { pup = pupˢ ; fpup = fpupˢ }  = just record { pup = pupˢ ; fpup = pup ∪ᵐˡ fpupˢ }
+  helper {u = (pup , _)}  (yes _                , no _                  ) record { pup = pupˢ ; fpup = fpupˢ }  = just record { pup = pup ∪ᵐˡ pupˢ ; fpup = fpupˢ }
+  helper                  (yes (_ , _ , p , _)  , yes (_ , _ , p' , _)  ) _                                     = contradiction p (≤ˢ⇒¬>ˢ p')
+
 
 Computational-PPUP : Computational _⊢_⇀⦇_,PPUP⦈_
 Computational-PPUP .compute Γ s (just x@(pup , _)) =
@@ -74,20 +77,20 @@ Computational-PPUP .≡-just⇔STS {Γ} {s} {e} {s'} = mk⇔
     nothing  refl → PPUpdateEmpty
     (just e)      → case (Dec-Current-Property {Γ} {e} ,′ Dec-Future-Property {Γ} {e})
       return (λ x → helper {Γ} {e} x s ≡ just s' → Γ ⊢ s ⇀⦇ just e ,PPUP⦈ s')
-      of λ where (no _                   , yes (x , x₁ , x₂ , x₃)) refl → PPUpdateFuture x x₁ x₂ x₃
-                 (yes (x , x₁ , x₂ , x₃) , no                   _) refl → PPUpdateCurrent x x₁ x₂ x₃
-                 (yes (_ , _ , p , _)    , yes (_ , _ , ¬p , _))        → contradiction p ¬p)
+      of λ where (no _                    , yes (x , x₁ , x₂ , x₃)  ) refl  → PPUpdateFuture x x₁ x₂ x₃
+                 (yes (x , x₁ , x₂ , x₃)  , no _                    ) refl  → PPUpdateCurrent x x₁ x₂ x₃
+                 (yes (_ , _ , p , _)     , yes (_ , _ , ¬p , _)    )       → contradiction p (≤ˢ⇒¬>ˢ ¬p))
   (λ where
     PPUpdateEmpty → refl
     (PPUpdateCurrent {pup = pup} {e} {pupˢ} {fpupˢ} x x₁ x₂ x₃) → subst
       (λ a → helper {Γ} {pup , e} a record { pup = pupˢ ; fpup = fpupˢ } ≡
                just record { pup = pup ∪ᵐˡ pupˢ ; fpup = fpupˢ })
       (sym $ (×-≡,≡→≡ ((proj₂ $ dec-yes (Dec-Current-Property {Γ} {pup , e}) (x , x₁ , x₂ , x₃)) ,′
-                       (dec-no (Dec-Future-Property {Γ} {pup , e}) λ where (_ , _ , p , _) → contradiction x₂ p))))
+                       (dec-no (Dec-Future-Property {Γ} {pup , e}) λ where (_ , _ , p , _) → contradiction x₂ (≤ˢ⇒¬>ˢ p)))))
       refl
     (PPUpdateFuture {pup = pup} {e} {pupˢ} {fpupˢ} x x₁ x₂ x₃) → subst
       (λ a → helper {Γ} {pup , e} a record { pup = pupˢ ; fpup = fpupˢ } ≡
                just record { pup = pupˢ ; fpup = pup ∪ᵐˡ fpupˢ })
-      (sym $ (×-≡,≡→≡ ((dec-no (Dec-Current-Property {Γ} {pup , e}) λ where (_ , _ , p , _) → contradiction p x₂) ,′
+      (sym $ (×-≡,≡→≡ ((dec-no (Dec-Current-Property {Γ} {pup , e}) λ where (_ , _ , p , _) → contradiction p (≤ˢ⇒¬>ˢ x₂)) ,′
                        (proj₂ $ dec-yes (Dec-Future-Property {Γ} {pup , e}) (x , x₁ , x₂ , x₃)))))
       refl)

--- a/src/Ledger/Prelude.agda
+++ b/src/Ledger/Prelude.agda
@@ -22,6 +22,8 @@ open import Interface.HasAdd public
 open import Interface.HasAdd.Instance public
 open import Interface.HasSubtract public
 open import Interface.HasSubtract.Instance public
+open import Interface.HasOrder public
+open import Interface.HasOrder.Instance public
 open import Relation.Nullary public
 open import Relation.Unary using () renaming (Decidable to Dec₁) public
 open Computational public

--- a/src/Ledger/Ratify.lagda
+++ b/src/Ledger/Ratify.lagda
@@ -92,7 +92,6 @@ open import Ledger.PParams epochStructure
 import Data.Integer as Z
 import Data.Maybe
 import Data.Rational as R
-open import Data.Nat hiding (_≟_)
 open import Data.Nat.Properties hiding (_≟_)
 open import Data.Nat.Properties.Ext
 open import Data.Product using (map₂)

--- a/src/Ledger/TokenAlgebra/ValueSet.lagda
+++ b/src/Ledger/TokenAlgebra/ValueSet.lagda
@@ -13,15 +13,17 @@ open import Ledger.TokenAlgebra PolicyId           using (TokenAlgebra)
 
 open import Algebra                                using (CommutativeMonoid ; Op₂ ; IsSemigroup ; IsMonoid ; IsMagma ; IsCommutativeMonoid)
 open import Algebra.Morphism                       using (IsMonoidHomomorphism ; IsMagmaHomomorphism)
-open import Data.Nat                               using (_≤_)
+import Data.Nat as ℕ
 open import Data.Nat.Properties                    using (+-comm ; +-assoc ; +-identityʳ ; +-0-commutativeMonoid)
 open import Function.Related.TypeIsomorphisms      using (Σ-≡,≡→≡)
 open import Relation.Binary                        using (IsEquivalence)
 open import Relation.Binary.Morphism               using (IsRelHomomorphism)
 open import Relation.Binary.PropositionalEquality  using (module ≡-Reasoning)
+-- open import Interface.HasOrder.Instance
 
 import Relation.Binary.PropositionalEquality as ≡
 import Relation.Binary.Core  as stdlib
+
 \end{code}
 
 \subsubsection{Derived types}
@@ -195,7 +197,7 @@ We are now in a position to define the commutative monoid.
     policies tm = dom (dom (rel tm))
 
     leq : AssetId ⇒ Quantity → AssetId ⇒ Quantity → Type
-    leq = λ u v → ∀ {a}{p}{q} → lookup u (a , p) ≤ lookup v (a , q)
+    leq u v = ∀ {a}{p}{q} → lookup u (a , p) ℕ.≤ lookup v (a , q)
 
     compose-to-id : totalMap↠coin ∘ coin↪totalMap ≗ id
     compose-to-id _ = lookup-update-id ι

--- a/src/Ledger/Utxo.lagda
+++ b/src/Ledger/Utxo.lagda
@@ -15,7 +15,7 @@ open import Ledger.Prelude hiding (Dec₁)
 
 open import Algebra                        using (CommutativeMonoid)
 open import Data.Integer.Ext               using (posPart; negPart)
-open import Data.Nat as ℕ                  using (_≤?_)
+import Data.Nat as ℕ     --              using (_≤?_)
 open import Data.Nat.Properties            using (+-0-monoid; +-0-commutativeMonoid)
 open import Interface.Decidable.Instance   using (Decidable²⇒Dec; Dec₁; ¿_¿)
 
@@ -29,8 +29,9 @@ open import MyDebugOptions
 open import Tactic.DeriveComp
 open import Tactic.Derive.DecEq
 
+
 instance
-  _ = Decidable²⇒Dec _≤?_
+  _ = Decidable²⇒Dec ℕ._≤?_
   _ = TokenAlgebra.Value-CommutativeMonoid tokenAlgebra
   _ = +-0-monoid
   _ = +-0-commutativeMonoid
@@ -157,6 +158,7 @@ record UTxOState : Set where
 ⟦_⟧ : {A : Set} → A → A
 ⟦_⟧ = id
 
+open HasDecPartialOrder ⦃ ... ⦄
 instance
   _ = ≟-∅
 
@@ -170,14 +172,14 @@ instance
   netId? {_} {networkId} {f} .Dec₁.P? a = f a ≟ networkId
 
   Dec-inInterval : {slot : Slot} {I : Maybe Slot × Maybe Slot} → Dec (inInterval slot I)
-  Dec-inInterval {slot} {just x  , just y } with x ≤ˢ? slot | slot ≤ˢ? y
+  Dec-inInterval {slot} {just x  , just y } with x ≤? slot | slot ≤? y
   ... | no ¬p₁ | _      = no λ where (both (h₁ , h₂)) → ¬p₁ h₁
   ... | yes p₁ | no ¬p₂ = no λ where (both (h₁ , h₂)) → ¬p₂ h₂
   ... | yes p₁ | yes p₂ = yes (both (p₁ , p₂))
-  Dec-inInterval {slot} {just x  , nothing} with x ≤ˢ? slot
+  Dec-inInterval {slot} {just x  , nothing} with x ≤? slot
   ... | no ¬p = no  (λ where (lower h) → ¬p h)
   ... | yes p = yes (lower p)
-  Dec-inInterval {slot} {nothing , just x } with slot ≤ˢ? x
+  Dec-inInterval {slot} {nothing , just x } with slot ≤? x
   ... | no ¬p = no  (λ where (upper h) → ¬p h)
   ... | yes p = yes (upper p)
   Dec-inInterval {slot} {nothing , nothing} = yes none
@@ -253,9 +255,9 @@ data _⊢_⇀⦇_,UTXO⦈_ where
           donations     = UTxOState.donations s
       in
     txins tx ≢ ∅                           → txins tx ⊆ dom (utxo ˢ)
-    → inInterval slot (txvldt tx)          → minfee pp tx ≤ txfee tx
+    → inInterval slot (txvldt tx)          → minfee pp tx ℕ.≤ txfee tx
     → consumed pp s tx ≡ produced pp s tx  → coin (mint tx) ≡ 0
-    → txsize tx ≤ maxTxSize pp
+    → txsize tx ℕ.≤ maxTxSize pp
     ────────────────────────────────
     Γ ⊢ s ⇀⦇ tx ,UTXO⦈  ⟦ (utxo ∣ txins tx ᶜ) ∪ᵐˡ outs tx
                         , fees + txfee tx
@@ -281,10 +283,10 @@ instance
     with  ¿ txins tx ≢ ∅
           × txins tx ⊆ dom (UTxOState.utxo s ˢ)
           × inInterval (UTxOEnv.slot Γ) (txvldt tx)
-          × minfee (UTxOEnv.pparams Γ) tx ≤ txfee tx
+          × minfee (UTxOEnv.pparams Γ) tx ℕ.≤ txfee tx
           × consumed (UTxOEnv.pparams Γ) s tx ≡ produced (UTxOEnv.pparams Γ) s tx
           × coin (mint tx) ≡ 0
-          × txsize tx ≤ maxTxSize (UTxOEnv.pparams Γ) ¿
+          × txsize tx ℕ.≤ maxTxSize (UTxOEnv.pparams Γ) ¿
        | "work around mysterious Agda bug"
   ... | yes (p₀ , p₁ , p₂ , p₃ , p₄ , p₅ , p₆) | _ = refl
   ... | no q | _ = ⊥-elim (q (q₀ , q₁ , q₂ , q₃ , q₄ , q₅ , q₆))

--- a/src/Ledger/Utxo.lagda
+++ b/src/Ledger/Utxo.lagda
@@ -15,7 +15,7 @@ open import Ledger.Prelude hiding (Dec₁)
 
 open import Algebra                        using (CommutativeMonoid)
 open import Data.Integer.Ext               using (posPart; negPart)
-open import Data.Nat                       using (_≤?_; _≤_)
+open import Data.Nat as ℕ                  using (_≤?_)
 open import Data.Nat.Properties            using (+-0-monoid; +-0-commutativeMonoid)
 open import Interface.Decidable.Instance   using (Decidable²⇒Dec; Dec₁; ¿_¿)
 
@@ -111,10 +111,10 @@ propDepositᵐ pp gaid record { returnAddr = record { stake = c } }
 
 -- this has to be a type definition for inference to work
 data inInterval (slot : Slot) : (Maybe Slot × Maybe Slot) → Set where
-  both  : ∀ {l r} → l ≤ˢ slot × slot ≤ˢ r  →  inInterval slot (just l  , just r)
-  lower : ∀ {l}   → l ≤ˢ slot              →  inInterval slot (just l  , nothing)
-  upper : ∀ {r}   → slot ≤ˢ r              →  inInterval slot (nothing , just r)
-  none  :                                     inInterval slot (nothing , nothing)
+  both  : ∀ {l r}  → l ≤ slot × slot ≤ r  →  inInterval slot (just l   , just r)
+  lower : ∀ {l}    → l ≤ slot             →  inInterval slot (just l   , nothing)
+  upper : ∀ {r}    → slot ≤ r             →  inInterval slot (nothing  , just r)
+  none  :                                    inInterval slot (nothing  , nothing)
 
 \end{code}
 \begin{code}[hide]
@@ -271,10 +271,10 @@ instance
     case ¿ txins tx ≢ ∅
          × txins tx ⊆ dom (UTxOState.utxo s ˢ)
          × inInterval (UTxOEnv.slot Γ) (txvldt tx)
-         × minfee (UTxOEnv.pparams Γ) tx ≤ txfee tx
+         × minfee (UTxOEnv.pparams Γ) tx ℕ.≤ txfee tx
          × consumed (UTxOEnv.pparams Γ) s tx ≡ produced (UTxOEnv.pparams Γ) s tx
          × coin (mint tx) ≡ 0
-         × txsize tx ≤ maxTxSize (UTxOEnv.pparams Γ) ¿ of λ where
+         × txsize tx ℕ.≤ maxTxSize (UTxOEnv.pparams Γ) ¿ of λ where
       (yes (p₀ , p₁ , p₂ , p₃ , p₄ , p₅ , p₆)) → just (_ , UTXO-inductive p₀ p₁ p₂ p₃ p₄ p₅ p₆)
       (no _) → nothing
   Computational'-UTXO .Computational'.completeness Γ s tx s' h@(UTXO-inductive q₀ q₁ q₂ q₃ q₄ q₅ q₆)

--- a/src/Ledger/Utxo/Properties.lagda
+++ b/src/Ledger/Utxo/Properties.lagda
@@ -36,6 +36,8 @@ open Properties
 
 open Tactic.EquationalReasoning.≡-Reasoning {A = ℕ} (solve-macro (quoteTerm +-0-monoid))
 
+open import Interface.HasOrder.Instance
+
 instance
   _ = TokenAlgebra.Value-CommutativeMonoid tokenAlgebra
   _ = +-0-monoid
@@ -86,11 +88,11 @@ consumedCoinEquality {tx} {utxoState} {pp} h = let utxo = UTxOState.utxo utxoSta
     ≡⟨ ∙-homo-Coin _ _ ⟩
   coin (balance (utxo ∣ txins tx) + mint tx) + coin (inject $ depositRefunds pp utxoState tx)
     ≡⟨ cong (coin (balance (utxo ∣ txins tx) + mint tx) +_) (property _) ⟩
-  coin (balance (utxo ∣ txins tx) +ᵛ mint tx) ℕ.+ depositRefunds pp utxoState tx
+  coin (balance (utxo ∣ txins tx) + mint tx) ℕ.+ depositRefunds pp utxoState tx
     ≡⟨ cong! (∙-homo-Coin _ _) ⟩
-  coin (balance (utxo ∣ txins tx)) ℕ.+ coin (mint tx) ℕ.+ depositRefunds pp utxoState tx
+  coin (balance (utxo ∣ txins tx)) + coin (mint tx) ℕ.+ depositRefunds pp utxoState tx
     ≡⟨ cong (λ x → cbalance (utxo ∣ txins tx) + x + depositRefunds pp utxoState tx) h ⟩
-  cbalance (utxo ∣ txins tx) ℕ.+ 0 ℕ.+ depositRefunds pp utxoState tx
+  cbalance (utxo ∣ txins tx) + 0 ℕ.+ depositRefunds pp utxoState tx
     ≡⟨ cong! (+-identityʳ (cbalance (utxo ∣ txins tx))) ⟩
   cbalance (utxo ∣ txins tx) ℕ.+ depositRefunds pp utxoState tx                        ∎
 
@@ -107,7 +109,7 @@ producedCoinEquality {utxoState} {tx} {pp} = begin
         ≡⟨ cong! (property _) ⟩
       coin (balance (outs tx) +ᵛ inject (txfee tx)) ℕ.+ newDeposits pp utxoState tx
         ≡⟨ cong! (∙-homo-Coin _ _) ⟩
-      coin (balance (outs tx)) ℕ.+ coin (inject (txfee tx)) ℕ.+ newDeposits pp utxoState tx
+      coin (balance (outs tx)) + coin (inject (txfee tx)) ℕ.+ newDeposits pp utxoState tx
         ≡⟨ cong (λ x → cbalance (outs tx) + x + newDeposits pp utxoState tx) (property (txfee tx)) ⟩
       cbalance (outs tx) + (txfee tx) + newDeposits pp utxoState tx                     ∎
     )⟩

--- a/src/Prelude.agda
+++ b/src/Prelude.agda
@@ -19,4 +19,4 @@ open import Data.Integer as ℤ using (ℤ; _⊖_) renaming (_+_ to _+ℤ_) publ
 open import Data.String using (String; _<+>_) public
 
 open import Relation.Nullary.Negation public
-open import Relation.Binary.PropositionalEquality hiding (preorder; setoid; [_]; module ≡-Reasoning) public
+open import Relation.Binary.PropositionalEquality hiding (preorder; isPreorder; isPartialOrder; setoid; [_]; module ≡-Reasoning) public


### PR DESCRIPTION
# Description

**Update** (15 Sep 2023)

This is an extension of PR #199.  It adds a `HasStrictTotalOrder` type class to the `HasOrder` module.

**Update** (6 Sep 2023) (to reflect some of the changes requested in conversation below)

This addresses issue #34 for the special cases of preorders and partial orders.

The goal of this PR is to allow us to use

+ a single relation symbol `≤`, to denote the "less or equal" relation on each of the types `ℤ`, `ℕ`, and `Slot`---on which `≤` denotes a *partial order*---and on the `Epoch` type, on which ≤` denotes a *preorder*.

+ a single relation symbol `<` to denote the "strictly less than" relation on each of the types `ℤ`, `ℕ`, and `Slot`.

# Checklist

- [X] Commit sequence broadly makes sense and commits have useful messages
- [X] Code is formatted according to [CONTRIBUTING.md](https://github.com/input-output-hk/formal-ledger-specifications/blob/master/CONTRIBUTING.md)
- [X] Self-reviewed the diff
