### PR TITLE
Computational instance for GOV' rule

### DIFF
--- a/src/Foreign/Convertible.agda
+++ b/src/Foreign/Convertible.agda
@@ -30,7 +30,7 @@ instance
 
   Convertible-FinSet : ∀ {A A'} → ⦃ _ : Convertible A A' ⦄ → Convertible (ℙ A) (List A')
   Convertible-FinSet .to   s = Data.List.map to (setToList s)
-  Convertible-FinSet .from l = setFromList (Data.List.map from l)
+  Convertible-FinSet .from l = fromList (Data.List.map from l)
 
   Convertible-Map : ∀ {K K' V V'} ⦃ _ : DecEq K ⦄
                   → ⦃ _ : Convertible K K' ⦄ → ⦃ _ : Convertible V V' ⦄ → Convertible (K ⇀ V) (List (Pair K' V'))

--- a/src/Interface/Decidable/Instance.agda
+++ b/src/Interface/Decidable/Instance.agda
@@ -10,6 +10,8 @@ open import Data.Empty
 open import Data.Product
 open import Data.Unit
 open import Data.Sum
+open import Data.Maybe
+open import Data.Maybe.Relation.Unary.Any
 
 open import Relation.Binary renaming (Decidable to Decidable²)
 open import Relation.Binary.PropositionalEquality
@@ -55,3 +57,7 @@ instance
 
   Dec-≤ : ∀ {n m} → Dec (n ≤ m)
   Dec-≤ = Decidable²⇒Dec _≤?_
+
+  Dec-IsJust : ∀ {a} {A : Set a} {x : Maybe A} → Dec (Is-just x)
+  Dec-IsJust {x = just x} = yes (just _)
+  Dec-IsJust {x = nothing} = no λ ()

--- a/src/Ledger/Chain.lagda
+++ b/src/Ledger/Chain.lagda
@@ -158,7 +158,7 @@ govActionDeposits ls =
         vd ← lookupᵐ? voteDelegs c ⦃ _ ∈? _ ⦄
         dep ← lookupᵐ? deposits (GovActionDeposit gaid) ⦃ _ ∈? _ ⦄
         just ❴ vd , dep ❵ᵐ )
-      (setFromList govSt)
+      (fromList govSt)
 
 calculateStakeDistrs : LState → StakeDistrs
 calculateStakeDistrs ls =

--- a/src/Ledger/Gov.lagda
+++ b/src/Ledger/Gov.lagda
@@ -75,7 +75,7 @@ addAction s e aid addr a prev = s ∷ʳ (aid , record
 -- x is the anchor in those two cases, which we don't do anything with
 data _⊢_⇀⦇_,GOV'⦈_ : GovEnv × ℕ → GovState → GovVote ⊎ GovProposal → GovState → Set where
   GOV-Vote : ∀ {x k ast} → let open GovEnv Γ in
-    (aid , ast) ∈ setFromList s
+    (aid , ast) ∈ fromList s
     → canVote pparams (action ast) role
     ────────────────────────────────
     (Γ , k) ⊢ s ⇀⦇ inj₁ record { gid = aid ; role = role ; credential = cred ; vote = v ; anchor = x } ,GOV'⦈

--- a/src/Ledger/PParams.lagda
+++ b/src/Ledger/PParams.lagda
@@ -79,7 +79,7 @@ record PParams : Set where
         minimumAVS         : Coin
 
 paramsWellFormed : PParams → Bool
-paramsWellFormed pp = ⌊ ¬? (0 ∈? setFromList
+paramsWellFormed pp = ⌊ ¬? (0 ∈? fromList
   (maxBlockSize ∷ maxTxSize ∷ maxHeaderSize ∷ maxValSize ∷ minUTxOValue ∷ poolDeposit
   ∷ collateralPercent ∷ ccTermLimit ∷ govExpiration ∷ govDeposit ∷ drepDeposit ∷ [])) ⌋ ∧
   ⌊ (ℕtoEpoch govExpiration) ≤ᵉ? drepActivity ⌋

--- a/src/Ledger/Prelude.agda
+++ b/src/Ledger/Prelude.agda
@@ -15,6 +15,7 @@ open import Prelude public
 
 open import Ledger.Prelude.Base public
 
+open import Data.List.Membership.Propositional using () renaming (_∈_ to _∈ˡ_)
 open import Interface.ComputationalRelation public
 open import Interface.DecEq public
 open import Ledger.Interface.HasCoin public
@@ -75,9 +76,6 @@ abstract
 
   setToList : {A : Set} → ℙ A → List A
   setToList = id
-
-  setFromList : {A : Set} → List A → ℙ A
-  setFromList = id
 
   ≟-∅ : {A : Set} ⦃ _ : DecEq A ⦄ → {X : ℙ A} → Dec (X ≡ ∅)
   ≟-∅ = Decˡ.≟-∅

--- a/src/Ledger/Utxow.lagda
+++ b/src/Ledger/Utxow.lagda
@@ -33,9 +33,9 @@ getScripts = mapPartial isInj₂
 credsNeeded : Maybe ScriptHash → UTxO → TxBody → ℙ Credential
 credsNeeded ppolicy utxo txb =
     map (payCred ∘ proj₁) ((utxo ˢ) ⟪$⟫ txins txb)
-  ∪ map cwitness (setFromList $ txcerts txb)
-  ∪ map GovVote.credential (setFromList $ txvote txb)
-  ∪ mapPartial (const (M.map inj₂ ppolicy)) (setFromList $ txprop txb)
+  ∪ map cwitness (fromList $ txcerts txb)
+  ∪ map GovVote.credential (fromList $ txvote txb)
+  ∪ mapPartial (const (M.map inj₂ ppolicy)) (fromList $ txprop txb)
 
 witsVKeyNeeded : Maybe ScriptHash → UTxO → TxBody → ℙ KeyHash
 witsVKeyNeeded sh utxo = getVKeys ∘ credsNeeded sh utxo


### PR DESCRIPTION
This doesn't do anything about #212, the existing definition of the rule *is* computational even without enforcing unique GovActionIds.

Question: This defines `any⇔∃` locally with the computational instance, but it feels like something that should either already be in the standard library (where I couldn't find it), or be defined in some more reasonable place in our repo.