### PR TITLE
Remove the old Computational in favour of the new representation

### DIFF
--- a/src/Interface/ComputationalRelation.agda
+++ b/src/Interface/ComputationalRelation.agda
@@ -22,22 +22,12 @@ private variable
 
 module _ (STS : C → S → Sig → S → Set) where
 
-  record Computational : Set where
-    constructor MkComputational
-    field
-      compute : C → S → Sig → Maybe S
-      ≡-just⇔STS : compute c s sig ≡ just s' ⇔ STS c s sig s'
-
-    nothing⇒∀¬STS : compute c s sig ≡ nothing → ∀ s' → ¬ STS c s sig s'
-    nothing⇒∀¬STS comp≡nothing s' h rewrite ≡-just⇔STS .Equivalence.from h =
-      case comp≡nothing of λ ()
-
   ExtendedRel : C → S → Sig → Maybe S → Set
   ExtendedRel c s sig (just s') = STS c s sig s'
   ExtendedRel c s sig nothing   = ∀ s' → ¬ STS c s sig s'
 
-  record Computational' : Set where
-    constructor MkComputational'
+  record Computational : Set where
+    constructor MkComputational
     field
       computeProof : (c : C) (s : S) (sig : Sig) → Maybe (∃[ s' ] STS c s sig s')
 
@@ -48,23 +38,20 @@ module _ (STS : C → S → Sig → S → Set) where
       completeness : (c : C) (s : S) (sig : Sig) (s' : S)
         → STS c s sig s' → compute c s sig ≡ just s'
 
-module _ {STS : C → S → Sig → S → Set} (comp' : Computational' STS) where
+    open ≡-Reasoning
 
-  open Computational' comp'
-  open ≡-Reasoning
+    ≡-just⇔STS : compute c s sig ≡ just s' ⇔ STS c s sig s'
+    ≡-just⇔STS {c} {s} {sig} {s'} with computeProof c s sig in eq
+    ... | just (s'' , h) = mk⇔ (λ where refl → h) λ h' → begin just s''       ≡˘⟨ completeness _ _ _ _ h ⟩
+                                                              compute c s sig ≡⟨ completeness _ _ _ _ h' ⟩
+                                                              just s' ∎
+    ... | nothing        = mk⇔ (λ ()) λ h → begin nothing         ≡˘⟨ map-nothing eq ⟩
+                                                  compute c s sig ≡⟨ completeness _ _ _ _ h ⟩
+                                                  just s' ∎
 
-  fromComputational' : Computational STS
-  fromComputational' .Computational.compute = compute
-  fromComputational' .Computational.≡-just⇔STS {c} {s} {sig} {s'}
-    with computeProof c s sig in eq
-  ... | just (s'' , h) = mk⇔ (λ where refl → h) λ h' →
-    begin just s''        ≡˘⟨ completeness _ _ _ _ h ⟩
-          compute c s sig ≡⟨ completeness _ _ _ _ h' ⟩
-          just s'         ∎
-  ... | nothing = mk⇔ (λ ()) λ h →
-    begin nothing         ≡˘⟨ map-nothing eq ⟩
-          compute c s sig ≡⟨ completeness _ _ _ _ h ⟩
-          just s'         ∎
+    nothing⇒∀¬STS : compute c s sig ≡ nothing → ∀ s' → ¬ STS c s sig s'
+    nothing⇒∀¬STS comp≡nothing s' h rewrite ≡-just⇔STS .Equivalence.from h =
+      case comp≡nothing of λ ()
 
 module _ {STS : C → S → Sig → S → Set} (comp : Computational STS) where
 
@@ -110,39 +97,56 @@ Computational⇒Dec' :
   → Dec (STS c s sig s')
 Computational⇒Dec' ⦃ comp = comp ⦄ = Computational⇒Dec comp
 
-module _ {BSTS : C → S → ⊤ → S → Set} {STS : C → S → Sig → S → Set}
-         ⦃ bcomp : Computational' BSTS ⦄ ⦃ comp : Computational' STS ⦄ where
+open Computational ⦃...⦄
 
-  open Computational' ⦃...⦄
+instance
+  Computational-Id : {C S : Set} → Computational (IdSTS {C} {S})
+  Computational-Id .computeProof _ s _ = just (s , Id-nop)
+  Computational-Id .completeness _ _ _ _ Id-nop = refl
+
+module _ {BSTS : C → S → ⊤ → S → Set} {STS : C → S → Sig → S → Set}
+         ⦃ bcomp : Computational BSTS ⦄ ⦃ comp : Computational STS ⦄ where
 
   instance
-    Computational'-SS⇒BSᵇ : Computational' (SS⇒BSᵇ (λ Γ s → BSTS Γ s tt) (STS ∘ proj₁))
-    Computational'-SS⇒BSᵇ .computeProof c s [] =
+    Computational-SS⇒BSᵇ : Computational (SS⇒BSᵇ BSTS STS)
+    Computational-SS⇒BSᵇ .computeProof c s [] =
       map (map₂′ BS-base) (computeProof c s tt)
-    Computational'-SS⇒BSᵇ .computeProof c s (sig ∷ sigs) = do
+    Computational-SS⇒BSᵇ .computeProof c s (sig ∷ sigs) = do
       s₁ , h  ← computeProof c s sig
       s₂ , hs ← computeProof c s₁ sigs
       just (s₂ , BS-ind h hs)
       where open import Data.Maybe
-    Computational'-SS⇒BSᵇ .completeness c s [] s' (BS-base p)
-      with computeProof c s tt | completeness _ _ _ _ p
+    Computational-SS⇒BSᵇ .completeness c s [] s' (BS-base p)
+      with computeProof {STS = BSTS} c s tt | completeness _ _ _ _ p
     ... | just x | p' = p'
-    Computational'-SS⇒BSᵇ .completeness c s (sig ∷ sigs) s' (BS-ind h hs)
+    Computational-SS⇒BSᵇ .completeness c s (sig ∷ sigs) s' (BS-ind h hs)
       with computeProof c s sig | completeness _ _ _ _ h
     ... | just (s₁ , _) | refl
-      with computeProof ⦃ Computational'-SS⇒BSᵇ ⦄ c s₁ sigs | completeness _ _ _ _ hs
+      with computeProof ⦃ Computational-SS⇒BSᵇ ⦄ c s₁ sigs | completeness _ _ _ _ hs
     ... | just (s₂ , _) | p = p
 
-    Computational-SS⇒BSᵇ = fromComputational' Computational'-SS⇒BSᵇ
-
-module _ {STS : C → S → Sig → S → Set} ⦃ comp : Computational' STS ⦄ where
-
-  open Computational' ⦃...⦄
+module _ {BSTS : C → S → ⊤ → S → Set} {STS : C × ℕ → S → Sig → S → Set}
+         ⦃ bcomp : Computational BSTS ⦄ ⦃ comp : Computational STS ⦄ where
 
   instance
-    Computational'-SS⇒BS : Computational' (SS⇒BS (STS ∘ proj₁))
-    Computational'-SS⇒BS = Computational'-SS⇒BSᵇ ⦃ bcomp = λ where
-      .computeProof → λ c s _ → just (-, refl)
-      .completeness → λ where c s _ _ refl → refl ⦄
+    Computational-SS⇒BSᵢᵇ : Computational (SS⇒BSᵢᵇ BSTS STS)
+    Computational-SS⇒BSᵢᵇ .computeProof c s [] =
+      map (map₂′ BS-base) (computeProof c s tt)
+    Computational-SS⇒BSᵢᵇ .computeProof c s (sig ∷ sigs) = do
+      s₁ , h  ← computeProof (c , length sigs) s sig
+      s₂ , hs ← computeProof c s₁ sigs
+      just (s₂ , BS-ind h hs)
+      where open import Data.Maybe
+    Computational-SS⇒BSᵢᵇ .completeness c s [] s' (BS-base p) with computeProof {STS = BSTS} c s tt | completeness _ _ _ _ p
+    ... | just x | p' = p'
+    Computational-SS⇒BSᵢᵇ .completeness c s (sig ∷ sigs) s' (BS-ind h hs)
+      with computeProof {STS = STS} (c , length sigs) s sig | completeness _ _ _ _ h
+    ... | just (s₁ , _) | refl
+      with computeProof ⦃ Computational-SS⇒BSᵢᵇ ⦄ c s₁ sigs | completeness _ _ _ _ hs
+    ...   | just (s₂ , _) | p = p
 
-    Computational-SS⇒BS = fromComputational' Computational'-SS⇒BS
+Computational-SS⇒BS : {STS : C → S → Sig → S → Set} → ⦃ Computational STS ⦄ → Computational (SS⇒BS STS)
+Computational-SS⇒BS = it
+
+Computational-SS⇒BSᵢ : {STS : C × ℕ → S → Sig → S → Set} ⦃ comp : Computational STS ⦄ → Computational (SS⇒BSᵢ STS)
+Computational-SS⇒BSᵢ = it

--- a/src/Interface/ComputationalRelation.agda
+++ b/src/Interface/ComputationalRelation.agda
@@ -42,12 +42,14 @@ module _ (STS : C → S → Sig → S → Set) where
 
     ≡-just⇔STS : compute c s sig ≡ just s' ⇔ STS c s sig s'
     ≡-just⇔STS {c} {s} {sig} {s'} with computeProof c s sig in eq
-    ... | just (s'' , h) = mk⇔ (λ where refl → h) λ h' → begin just s''       ≡˘⟨ completeness _ _ _ _ h ⟩
-                                                              compute c s sig ≡⟨ completeness _ _ _ _ h' ⟩
-                                                              just s' ∎
-    ... | nothing        = mk⇔ (λ ()) λ h → begin nothing         ≡˘⟨ map-nothing eq ⟩
-                                                  compute c s sig ≡⟨ completeness _ _ _ _ h ⟩
-                                                  just s' ∎
+    ... | just (s'' , h) = mk⇔ (λ where refl → h) λ h' →
+      begin just s''        ≡˘⟨ completeness _ _ _ _ h ⟩
+            compute c s sig ≡⟨ completeness _ _ _ _ h' ⟩
+            just s'         ∎
+    ... | nothing = mk⇔ (λ ()) λ h →
+      begin nothing         ≡˘⟨ map-nothing eq ⟩
+            compute c s sig ≡⟨ completeness _ _ _ _ h ⟩
+            just s'         ∎
 
     nothing⇒∀¬STS : compute c s sig ≡ nothing → ∀ s' → ¬ STS c s sig s'
     nothing⇒∀¬STS comp≡nothing s' h rewrite ≡-just⇔STS .Equivalence.from h =
@@ -104,10 +106,8 @@ instance
   Computational-Id .computeProof _ s _ = just (s , Id-nop)
   Computational-Id .completeness _ _ _ _ Id-nop = refl
 
-module _ {BSTS : C → S → ⊤ → S → Set} {STS : C → S → Sig → S → Set}
-         ⦃ bcomp : Computational BSTS ⦄ ⦃ comp : Computational STS ⦄ where
-
-  instance
+module _ {BSTS : C → S → ⊤ → S → Set} ⦃ _ : Computational BSTS ⦄ where
+  module _ {STS : C → S → Sig → S → Set} ⦃ _ : Computational STS ⦄ where instance
     Computational-SS⇒BSᵇ : Computational (SS⇒BSᵇ BSTS STS)
     Computational-SS⇒BSᵇ .computeProof c s [] =
       map (map₂′ BS-base) (computeProof c s tt)
@@ -125,10 +125,7 @@ module _ {BSTS : C → S → ⊤ → S → Set} {STS : C → S → Sig → S →
       with computeProof ⦃ Computational-SS⇒BSᵇ ⦄ c s₁ sigs | completeness _ _ _ _ hs
     ... | just (s₂ , _) | p = p
 
-module _ {BSTS : C → S → ⊤ → S → Set} {STS : C × ℕ → S → Sig → S → Set}
-         ⦃ bcomp : Computational BSTS ⦄ ⦃ comp : Computational STS ⦄ where
-
-  instance
+  module _ {STS : C × ℕ → S → Sig → S → Set} ⦃ _ : Computational STS ⦄ where instance
     Computational-SS⇒BSᵢᵇ : Computational (SS⇒BSᵢᵇ BSTS STS)
     Computational-SS⇒BSᵢᵇ .computeProof c s [] =
       map (map₂′ BS-base) (computeProof c s tt)
@@ -137,7 +134,8 @@ module _ {BSTS : C → S → ⊤ → S → Set} {STS : C × ℕ → S → Sig �
       s₂ , hs ← computeProof c s₁ sigs
       just (s₂ , BS-ind h hs)
       where open import Data.Maybe
-    Computational-SS⇒BSᵢᵇ .completeness c s [] s' (BS-base p) with computeProof {STS = BSTS} c s tt | completeness _ _ _ _ p
+    Computational-SS⇒BSᵢᵇ .completeness c s [] s' (BS-base p)
+      with computeProof {STS = BSTS} c s tt | completeness _ _ _ _ p
     ... | just x | p' = p'
     Computational-SS⇒BSᵢᵇ .completeness c s (sig ∷ sigs) s' (BS-ind h hs)
       with computeProof {STS = STS} (c , length sigs) s sig | completeness _ _ _ _ h
@@ -145,8 +143,10 @@ module _ {BSTS : C → S → ⊤ → S → Set} {STS : C × ℕ → S → Sig �
       with computeProof ⦃ Computational-SS⇒BSᵢᵇ ⦄ c s₁ sigs | completeness _ _ _ _ hs
     ...   | just (s₂ , _) | p = p
 
-Computational-SS⇒BS : {STS : C → S → Sig → S → Set} → ⦃ Computational STS ⦄ → Computational (SS⇒BS STS)
+Computational-SS⇒BS : {STS : C → S → Sig → S → Set} → ⦃ Computational STS ⦄
+  → Computational (SS⇒BS STS)
 Computational-SS⇒BS = it
 
-Computational-SS⇒BSᵢ : {STS : C × ℕ → S → Sig → S → Set} ⦃ comp : Computational STS ⦄ → Computational (SS⇒BSᵢ STS)
+Computational-SS⇒BSᵢ : {STS : C × ℕ → S → Sig → S → Set} → ⦃ Computational STS ⦄
+  → Computational (SS⇒BSᵢ STS)
 Computational-SS⇒BSᵢ = it

--- a/src/Interface/STS.agda
+++ b/src/Interface/STS.agda
@@ -32,31 +32,60 @@ private
 
 -- small-step to big-step transformer
 
-module _ (_⊢_⇀_ : C → S → S → Set) (_⊢_⇀⟦_⟧_ : C × ℕ → S → Sig → S → Set) where
+module _ (_⊢_⇀⟦_⟧ᵇ_ : C → S → ⊤ → S → Set) (_⊢_⇀⟦_⟧_ : C → S → Sig → S → Set) where
   data _⊢_⇀⟦_⟧*_ : C → S → List Sig → S → Set where
 
     BS-base :
-      ∙ Γ ⊢ s ⇀ s'
+      ∙ Γ ⊢ s ⇀⟦ _ ⟧ᵇ s'
       ───────────────────────────────────────
       Γ ⊢ s ⇀⟦ [] ⟧* s'
 
     BS-ind :
-      ∙ (Γ , length sigs) ⊢ s  ⇀⟦ sig  ⟧  s'
-      ∙  Γ                ⊢ s' ⇀⟦ sigs ⟧* s''
+      ∙ Γ ⊢ s  ⇀⟦ sig  ⟧  s'
+      ∙ Γ ⊢ s' ⇀⟦ sigs ⟧* s''
       ───────────────────────────────────────
       Γ ⊢ s ⇀⟦ sig ∷ sigs ⟧* s''
 
--- with a trivial base case
-SS⇒BS : (C × ℕ → S → Sig → S → Set) → C → S → List Sig → S → Set
-SS⇒BS {C} {S} {Sig} = _⊢_⇀⟦_⟧*_ {C} {S} {Sig} (λ _ → _≡_)
+module _ (_⊢_⇀⟦_⟧ᵇ_ : C → S → ⊤ → S → Set) (_⊢_⇀⟦_⟧_ : C × ℕ → S → Sig → S → Set) where
+  data _⊢_⇀⟦_⟧ᵢ*_ : C → S → List Sig → S → Set where
 
-SS-total⇒BS-total : {_⊢_⇀⟦_⟧_ : C × ℕ → S → Sig → S → Set}
-                  → (∀ {Γ s sig} → ∃[ s' ] Γ ⊢ s ⇀⟦ sig ⟧ s')
-                  → (∀ {Γ s sig} → ∃[ s' ] SS⇒BS _⊢_⇀⟦_⟧_ Γ s sig s')
-SS-total⇒BS-total SS-total {Γ} {s} {[]} = s , BS-base refl
-SS-total⇒BS-total SS-total {Γ} {s} {x ∷ sig} =
+    BS-base :
+      ∙ Γ ⊢ s ⇀⟦ _ ⟧ᵇ s'
+      ───────────────────────────────────────
+      Γ ⊢ s ⇀⟦ [] ⟧ᵢ* s'
+
+    BS-ind :
+      ∙ (Γ , length sigs) ⊢ s  ⇀⟦ sig  ⟧  s'
+      ∙  Γ                ⊢ s' ⇀⟦ sigs ⟧ᵢ* s''
+      ───────────────────────────────────────
+      Γ ⊢ s ⇀⟦ sig ∷ sigs ⟧ᵢ* s''
+
+data IdSTS {C S} : C → S → ⊤ → S → Set where
+  Id-nop : IdSTS Γ s _ s
+
+-- with a trivial base case
+SS⇒BS : (C → S → Sig → S → Set) → C → S → List Sig → S → Set
+SS⇒BS {C} {S} {Sig} = _⊢_⇀⟦_⟧*_ {C} {S} {Sig} IdSTS
+
+SS⇒BS-total : {_⊢_⇀⟦_⟧_ : C → S → Sig → S → Set}
+            → (∀ {Γ s sig} → ∃[ s' ] Γ ⊢ s ⇀⟦ sig ⟧ s')
+            → (∀ {Γ s sig} → ∃[ s' ] SS⇒BS _⊢_⇀⟦_⟧_ Γ s sig s')
+SS⇒BS-total SS-total {Γ} {s} {[]} = s , BS-base Id-nop
+SS⇒BS-total SS-total {Γ} {s} {x ∷ sig} =
+  case SS-total {Γ} {s} {x} of λ where
+    (s' , Ps') → map₂′ (BS-ind Ps') $ SS⇒BS-total SS-total {Γ} {s'} {sig}
+
+SS⇒BSᵢ : (C × ℕ → S → Sig → S → Set) → C → S → List Sig → S → Set
+SS⇒BSᵢ {C} {S} {Sig} = _⊢_⇀⟦_⟧ᵢ*_ {C} {S} {Sig} IdSTS
+
+SS⇒BSᵢ-total : {_⊢_⇀⟦_⟧_ : C × ℕ → S → Sig → S → Set}
+             → (∀ {Γ s sig} → ∃[ s' ] Γ ⊢ s ⇀⟦ sig ⟧ s')
+             → (∀ {Γ s sig} → ∃[ s' ] SS⇒BSᵢ _⊢_⇀⟦_⟧_ Γ s sig s')
+SS⇒BSᵢ-total SS-total {Γ} {s} {[]} = s , BS-base Id-nop
+SS⇒BSᵢ-total SS-total {Γ} {s} {x ∷ sig} =
   case SS-total {Γ , length sig} {s} {x} of λ where
-    (s' , Ps') → map₂′ (BS-ind Ps') $ SS-total⇒BS-total SS-total {Γ} {s'} {sig}
+    (s' , Ps') → map₂′ (BS-ind Ps') $ SS⇒BSᵢ-total SS-total {Γ} {s'} {sig}
 
 -- with a given base case
-SS⇒BSᵇ = _⊢_⇀⟦_⟧*_
+SS⇒BSᵢᵇ = _⊢_⇀⟦_⟧ᵢ*_
+SS⇒BSᵇ  = _⊢_⇀⟦_⟧*_

--- a/src/Ledger/Deleg.lagda
+++ b/src/Ledger/Deleg.lagda
@@ -185,7 +185,7 @@ data _⊢_⇀⦇_,CERTBASE⦈_ : CertEnv → CertState → ⊤ → CertState →
         { dreps = mapValueRestricted (const (e + drepActivity)) dreps refresh } }
 
 _⊢_⇀⦇_,CERTS⦈_ : CertEnv → CertState → List DCert → CertState → Set
-_⊢_⇀⦇_,CERTS⦈_ = SS⇒BSᵇ _⊢_⇀⦇ tt ,CERTBASE⦈_ λ (Γ , _) → Γ ⊢_⇀⦇_,CERT⦈_
+_⊢_⇀⦇_,CERTS⦈_ = SS⇒BSᵇ _⊢_⇀⦇_,CERTBASE⦈_ _⊢_⇀⦇_,CERT⦈_
 \end{code}
 \caption{CERTS rules}
 \end{figure*}
@@ -196,108 +196,97 @@ open import Relation.Nullary.Decidable
 
 open import Tactic.ReduceDec
 
-open Computational' ⦃...⦄
+open Computational ⦃...⦄
 
 instance
-  Computational'-DELEG : Computational' _⊢_⇀⦇_,DELEG⦈_
-  Computational'-DELEG .computeProof pp _ = λ where
+  Computational-DELEG : Computational _⊢_⇀⦇_,DELEG⦈_
+  Computational-DELEG .computeProof pp _ = λ where
     (delegate c mv mc d) →
       case d ≟ requiredDeposit pp mv ⊔ requiredDeposit pp mc of λ where
         (yes p) → just (-, DELEG-delegate p)
         (no _)  → nothing
     _ → nothing
-  Computational'-DELEG .completeness pp s (delegate c mv mc d) s' (DELEG-delegate p)
+  Computational-DELEG .completeness pp s (delegate c mv mc d) s' (DELEG-delegate p)
     rewrite dec-yes (d ≟ requiredDeposit pp mv ⊔ requiredDeposit pp mc) p .proj₂ = refl
 
-  Computational-DELEG = fromComputational' Computational'-DELEG
-
 instance
-  Computational'-POOL : Computational' _⊢_⇀⦇_,POOL⦈_
-  Computational'-POOL .computeProof _ ⟦ pools , _ ⟧ᵖ (regpool c _) =
+  Computational-POOL : Computational _⊢_⇀⦇_,POOL⦈_
+  Computational-POOL .computeProof _ ⟦ pools , _ ⟧ᵖ (regpool c _) =
     case c ∈? dom (pools ˢ) of λ where
       (yes _) → nothing
       (no p)  →  just (-, POOL-regpool p)
-  Computational'-POOL .computeProof _ _ (retirepool c e) = just (-, POOL-retirepool)
-  Computational'-POOL .computeProof _ _ _ = nothing
-  Computational'-POOL .completeness _ ⟦ pools , _ ⟧ᵖ (regpool c _) _ (POOL-regpool ¬p)
+  Computational-POOL .computeProof _ _ (retirepool c e) = just (-, POOL-retirepool)
+  Computational-POOL .computeProof _ _ _ = nothing
+  Computational-POOL .completeness _ ⟦ pools , _ ⟧ᵖ (regpool c _) _ (POOL-regpool ¬p)
     rewrite dec-no (c ∈? dom (pools ˢ)) ¬p = refl
-  Computational'-POOL .completeness _ _ (retirepool _ _) _ POOL-retirepool = refl
+  Computational-POOL .completeness _ _ (retirepool _ _) _ POOL-retirepool = refl
 
-  Computational-POOL = fromComputational' Computational'-POOL
-
-  Computational'-GOVCERT : Computational' _⊢_⇀⦇_,GOVCERT⦈_
-  Computational'-GOVCERT .computeProof ⟦ _ , pp , _ ⟧ᶜ ⟦ dReps , _ ⟧ᵛ (regdrep c d _) =
+  Computational-GOVCERT : Computational _⊢_⇀⦇_,GOVCERT⦈_
+  Computational-GOVCERT .computeProof ⟦ _ , pp , _ ⟧ᶜ ⟦ dReps , _ ⟧ᵛ (regdrep c d _) =
     let open PParams pp in
     case ¿ (d ≡ drepDeposit × c ∉ dom (dReps ˢ))
          ⊎ (d ≡ 0 × c ∈ dom (dReps ˢ)) ¿ of λ where
       (yes p) → just (-, GOVCERT-regdrep p)
       (no _)  → nothing
-  Computational'-GOVCERT .computeProof _ ⟦ dReps , _ ⟧ᵛ (deregdrep c) =
+  Computational-GOVCERT .computeProof _ ⟦ dReps , _ ⟧ᵛ (deregdrep c) =
     case c ∈? dom (dReps ˢ) of λ where
       (yes p) → just (-, GOVCERT-deregdrep p)
       (no _)  → nothing
-  Computational'-GOVCERT .computeProof _ ⟦ _ , ccKeys ⟧ᵛ (ccreghot c _) =
+  Computational-GOVCERT .computeProof _ ⟦ _ , ccKeys ⟧ᵛ (ccreghot c _) =
     case (c , nothing) ∈? (ccKeys ˢ) of λ where
       (yes _) → nothing
       (no p)  → just (-, GOVCERT-ccreghot p)
-  Computational'-GOVCERT .computeProof _ _ _ = nothing
-  Computational'-GOVCERT .completeness ⟦ _ , pp , _ ⟧ᶜ ⟦ dReps , _ ⟧ᵛ
+  Computational-GOVCERT .computeProof _ _ _ = nothing
+  Computational-GOVCERT .completeness ⟦ _ , pp , _ ⟧ᶜ ⟦ dReps , _ ⟧ᵛ
     (regdrep c d _) _ (GOVCERT-regdrep p)
     rewrite dec-yes
       ¿ (let open PParams pp in
         (d ≡ drepDeposit × c ∉ dom (dReps ˢ)) ⊎ (d ≡ 0 × c ∈ dom (dReps ˢ)))
       ¿ p .proj₂ = refl
-  Computational'-GOVCERT .completeness _ ⟦ dReps , _ ⟧ᵛ
+  Computational-GOVCERT .completeness _ ⟦ dReps , _ ⟧ᵛ
     (deregdrep c) _ (GOVCERT-deregdrep p)
     rewrite dec-yes (c ∈? dom (dReps ˢ)) p .proj₂ = refl
-  Computational'-GOVCERT .completeness _ ⟦ _ , ccKeys ⟧ᵛ
+  Computational-GOVCERT .completeness _ ⟦ _ , ccKeys ⟧ᵛ
     (ccreghot c _) _ (GOVCERT-ccreghot ¬p)
     rewrite dec-no ((c , nothing) ∈? (ccKeys ˢ)) ¬p = refl
 
-  Computational-GOVCERT = fromComputational' Computational'-GOVCERT
-
 instance
-  Computational'-CERT : Computational' _⊢_⇀⦇_,CERT⦈_
-  Computational'-CERT .computeProof Γ@(⟦ e , pp , vs ⟧ᶜ) ⟦ stᵈ , stᵖ , stᵍ ⟧ᶜ dCert
+  Computational-CERT : Computational _⊢_⇀⦇_,CERT⦈_
+  Computational-CERT .computeProof Γ@(⟦ e , pp , vs ⟧ᶜ) ⟦ stᵈ , stᵖ , stᵍ ⟧ᶜ dCert
     with computeProof pp stᵈ dCert | computeProof pp stᵖ dCert | computeProof Γ stᵍ dCert
   ... | just (_ , h) | _            | _            = just (-, CERT-deleg h)
   ... | nothing      | just (_ , h) | _            = just (-, CERT-pool h)
   ... | nothing      | nothing      | just (_ , h) = just (-, CERT-vdel h)
   ... | nothing      | nothing      | nothing      = nothing
-  Computational'-CERT .completeness ⟦ _ , pp , _ ⟧ᶜ ⟦ stᵈ , stᵖ , stᵍ ⟧ᶜ
+  Computational-CERT .completeness ⟦ _ , pp , _ ⟧ᶜ ⟦ stᵈ , stᵖ , stᵍ ⟧ᶜ
     dCert@(delegate c mv mc d) ⟦ stᵈ' , stᵖ , stᵍ ⟧ᶜ (CERT-deleg h)
     with computeProof pp stᵈ dCert | completeness _ _ _ _ h
   ... | just _ | refl = refl
-  Computational'-CERT .completeness ⟦ _ , pp , _ ⟧ᶜ ⟦ stᵈ , stᵖ , stᵍ ⟧ᶜ
+  Computational-CERT .completeness ⟦ _ , pp , _ ⟧ᶜ ⟦ stᵈ , stᵖ , stᵍ ⟧ᶜ
     dCert@(regpool c poolParams) ⟦ stᵈ , stᵖ' , stᵍ ⟧ᶜ (CERT-pool h)
     with computeProof pp stᵖ dCert | completeness _ _ _ _ h
   ... | just _ | refl = refl
-  Computational'-CERT .completeness ⟦ _ , pp , _ ⟧ᶜ ⟦ stᵈ , stᵖ , stᵍ ⟧ᶜ
+  Computational-CERT .completeness ⟦ _ , pp , _ ⟧ᶜ ⟦ stᵈ , stᵖ , stᵍ ⟧ᶜ
     dCert@(retirepool c e) ⟦ stᵈ , stᵖ' , stᵍ ⟧ᶜ (CERT-pool h)
     with completeness _ _ _ _ h
   ... | refl = refl
-  Computational'-CERT .completeness Γ ⟦ stᵈ , stᵖ , stᵍ ⟧ᶜ
+  Computational-CERT .completeness Γ ⟦ stᵈ , stᵖ , stᵍ ⟧ᶜ
     dCert@(regdrep c d an)
     ⟦ stᵈ , stᵖ , stᵍ' ⟧ᶜ (CERT-vdel h)
     with computeProof Γ stᵍ dCert | completeness _ _ _ _ h
   ... | just _ | refl = refl
-  Computational'-CERT .completeness Γ ⟦ stᵈ , stᵖ , stᵍ ⟧ᶜ
+  Computational-CERT .completeness Γ ⟦ stᵈ , stᵖ , stᵍ ⟧ᶜ
     dCert@(deregdrep c) ⟦ stᵈ , stᵖ , stᵍ' ⟧ᶜ (CERT-vdel h)
     with computeProof Γ stᵍ dCert | completeness _ _ _ _ h
   ... | just _ | refl = refl
-  Computational'-CERT .completeness Γ ⟦ stᵈ , stᵖ , stᵍ ⟧ᶜ
+  Computational-CERT .completeness Γ ⟦ stᵈ , stᵖ , stᵍ ⟧ᶜ
     dCert@(ccreghot c mkh) ⟦ stᵈ , stᵖ , stᵍ' ⟧ᶜ (CERT-vdel h)
     with computeProof Γ stᵍ dCert | completeness _ _ _ _ h
   ... | just _ | refl = refl
 
-  Computational-CERT = fromComputational' Computational'-CERT
-
-  Computational'-CERTBASE : Computational' _⊢_⇀⦇_,CERTBASE⦈_
-  Computational'-CERTBASE .computeProof ⟦ e , pp , vs ⟧ᶜ st _ = just (-, CERT-base _)
-  Computational'-CERTBASE .completeness ⟦ e , pp , vs ⟧ᶜ st _ st' (CERT-base _) = refl
-
-Computational'-CERTS : Computational' _⊢_⇀⦇_,CERTS⦈_
-Computational'-CERTS = it
+  Computational-CERTBASE : Computational _⊢_⇀⦇_,CERTBASE⦈_
+  Computational-CERTBASE .computeProof ⟦ e , pp , vs ⟧ᶜ st _ = just (-, CERT-base _)
+  Computational-CERTBASE .completeness ⟦ e , pp , vs ⟧ᶜ st _ st' (CERT-base _) = refl
 
 Computational-CERTS : Computational _⊢_⇀⦇_,CERTS⦈_
 Computational-CERTS = it

--- a/src/Ledger/GovernanceActions.lagda
+++ b/src/Ledger/GovernanceActions.lagda
@@ -349,11 +349,11 @@ data _⊢_⇀⦇_,ENACT⦈_ : EnactEnv → EnactState → GovAction → EnactSta
 \end{figure*}
 
 \begin{code}[hide]
-open Computational' ⦃...⦄
+open Computational ⦃...⦄
 
 instance
-  Computational'-ENACT : Computational' _⊢_⇀⦇_,ENACT⦈_
-  Computational'-ENACT .computeProof ⟦ _ , t , e ⟧ᵉ s = λ where
+  Computational-ENACT : Computational _⊢_⇀⦇_,ENACT⦈_
+  Computational-ENACT .computeProof ⟦ _ , t , e ⟧ᵉ s = λ where
     NoConfidence             → just (_ , Enact-NoConf)
     (NewCommittee new rem q) →
       case ¿ ∀[ term ∈ range (new ˢ) ]
@@ -368,7 +368,7 @@ instance
       case ¿ Σᵐᵛ[ x ← (s .withdrawals ∪⁺ wdrl) ᶠᵐ ] x ≤ t ¿ of λ where
         (yesᵈ p)             → just (-, Enact-Wdrl p)
         (noᵈ _)              → nothing
-  Computational'-ENACT .completeness ⟦ _ , t , e ⟧ᵉ s action _ p
+  Computational-ENACT .completeness ⟦ _ , t , e ⟧ᵉ s action _ p
     with action | p
   ... | .NoConfidence           | Enact-NoConf   = refl
   ... | .NewCommittee new rem q | Enact-NewComm p
@@ -383,6 +383,4 @@ instance
   ... | .TreasuryWdrl wdrl      | Enact-Wdrl p
     rewrite dec-yes (¿ (Σᵐᵛ[ x ← (s .withdrawals ∪⁺ wdrl) ᶠᵐ ] x) ≤ t ¿) p .proj₂
     = refl
-
-  Computational-ENACT = fromComputational' Computational'-ENACT
 \end{code}

--- a/src/Ledger/Ledger.lagda
+++ b/src/Ledger/Ledger.lagda
@@ -82,7 +82,7 @@ data
 \begin{figure*}[h]
 \begin{code}
 _⊢_⇀⦇_,LEDGERS⦈_ : LEnv → LState → List Tx → LState → Set
-_⊢_⇀⦇_,LEDGERS⦈_ = SS⇒BS λ (Γ , _) → Γ ⊢_⇀⦇_,LEDGER⦈_
+_⊢_⇀⦇_,LEDGERS⦈_ = SS⇒BS _⊢_⇀⦇_,LEDGER⦈_
 \end{code}
 \caption{LEDGERS transition system}
 \end{figure*}

--- a/src/Ledger/Ledger/Properties.agda
+++ b/src/Ledger/Ledger/Properties.agda
@@ -6,7 +6,7 @@ import Relation.Binary.PropositionalEquality as Eq
 
 open import Tactic.ReduceDec using (fromWitness')
 
-open import Ledger.Prelude; open Equivalence; open Computational
+open import Ledger.Prelude; open Equivalence; open Computational ⦃...⦄
 open import Ledger.Transaction
 
 module Ledger.Ledger.Properties (txs : _) (open TransactionStructure txs) where
@@ -30,108 +30,56 @@ private variable
   s s' : LState
   l : List Tx
 
-module _ (Computational-TALLY : Computational _⊢_⇀⦇_,GOV⦈_)
-         (Computational-CERTS : Computational _⊢_⇀⦇_,CERTS⦈_) where
-
-  instance
-    HasCoin-LState : HasCoin LState
-    HasCoin-LState .getCoin s = getCoin (s .LState.utxoSt)
-
-  private
-    helper : Maybe UTxOState × Maybe GovState × Maybe CertState × Bool → Maybe LState
-    helper (just utxoSt' , just tally' , just certState' , true) =
-      just ⟦ utxoSt' , tally' , certState' ⟧ˡ
-    helper _                                                     = nothing
-
-    -- This massively speeds up type-checking
-    abstract
-      Computational-UTXOW : Computational _⊢_⇀⦇_,UTXOW⦈_
-      Computational-UTXOW = PW.Computational-UTXOW
-
-    Computational-Match :
-      LEnv → LState → Tx → Maybe UTxOState × Maybe GovState × Maybe CertState × Bool
-    Computational-Match Γ s tx = let open LState s in
-         compute Computational-UTXOW record { LEnv Γ } utxoSt tx
-      ,′ compute Computational-TALLY
-           record { epoch = epoch (Γ .LEnv.slot) ; LEnv Γ ; TxBody (tx .body) }
-           govSt (txgov (tx .body))
-      ,′ maybe
-           (λ certState' → just certState' ,′
-             ⌊ ¿ mapˢ RwdAddr.stake (dom (tx .body .txwdrls ˢ))
-               ⊆ dom (DState.voteDelegs (CertState.dState certState') ˢ) ¿ ⌋)
-           (nothing ,′ false)
-           (compute Computational-CERTS
-             ⟦ epoch (LEnv.slot Γ) , LEnv.pparams Γ , tx .body .txvote ⟧ᶜ
-             certState (tx .body .txcerts))
-
-    helper₁ : ∀ {X Z : Set} {x : Z → X} {y : X} {z : Maybe Z} →
-      maybe′ (λ w → just w ,′ x w) (nothing ,′ y) z .proj₁ ≡ z
-    helper₁ {z = just x}  = refl
-    helper₁ {z = nothing} = refl
-
-    Computational-Match-helper : helper (Computational-Match Γ s tx) ≡ just s' →
-      let open LState
-          us , gs , cs , _ = Computational-Match Γ s tx
-      in us ≡ just (s' .utxoSt)
-       × gs ≡ just (s' .govSt)
-       × cs ≡ just (s' .certState)
-       × mapˢ RwdAddr.stake (dom (tx .body .txwdrls ˢ)) ⊆
-         dom (DState.voteDelegs (CertState.dState $ certState s') ˢ)
-    Computational-Match-helper {Γ} {s} {tx} {⟦ utxoSt , tally , certState ⟧ˡ} h
-      with Computational-Match Γ s tx | inspect (Computational-Match Γ s) tx | h
-    ... | just x , just x₁ , just x₂ , true | Eq.[ eq ] | refl = let
-      eq₁ , eqs = ×-≡,≡←≡ eq
-      eq₂ , eqs' = ×-≡,≡←≡ eqs
-      eq₃ , eq₄ = ×-≡,≡←≡ eqs'
-      comp = compute Computational-CERTS
-               ⟦ epoch (LEnv.slot Γ) , LEnv.pparams Γ , tx .body .txvote ⟧ᶜ
-               (LState.certState s)
-               (tx .body .txcerts)
-      prop = λ s → ¿ mapˢ RwdAddr.stake (dom (txwdrls (tx .body) ˢ))
-                   ⊆ dom (DState.voteDelegs (CertState.dState s) ˢ) ¿
-      p = (case comp return (λ x → comp ≡ x → x ≡ just certState) of
-             λ x h → trans (trans (sym h) (sym (helper₁))) eq₃) refl
-      q = subst
-        (λ x → proj₂ (maybe′ (λ certState' → _ ,′ ⌊ prop certState' ⌋) _ x) ≡ _)
-        p eq₄
-      in eq₁ , eq₂ , eq₃ , toWitness (subst T (sym q) _)
-
-  open UTxOState
-  open LState
-
+instance
   Computational-LEDGER : Computational _⊢_⇀⦇_,LEDGER⦈_
-  Computational-LEDGER .compute Γ s tx = helper (Computational-Match Γ s tx)
-  Computational-LEDGER .≡-just⇔STS {Γ} {s} {tx} {s'} = mk⇔
-    (λ h → let h₁ , h₂ , h₃ , h₄ = Computational-Match-helper {Γ = Γ} {s = s} {tx = tx} h in
-      LEDGER (Computational-UTXOW .≡-just⇔STS .to h₁)
-             (Computational-CERTS .≡-just⇔STS .to (trans (sym helper₁) h₃))
-             (Computational-TALLY .≡-just⇔STS .to h₂)
-             h₄)
-    (λ where
-      (LEDGER x x₁ x₂ x₃) → cong helper
-        ( ×-≡,≡→≡
-          ( Computational-UTXOW .≡-just⇔STS .from x
-          , ×-≡,≡→≡
-            ( Computational-TALLY .≡-just⇔STS .from x₂
-            , subst (λ x → maybe _ _ x ≡ _)
-                    (sym $ Computational-CERTS .≡-just⇔STS  .from x₁)
-                    (×-≡,≡→≡ (refl , fromWitness' _ x₃))))))
+  Computational-LEDGER .computeProof Γ@(⟦ slot , ppolicy , pparams ⟧ˡᵉ) ⟦ utxoSt , govSt , certSt ⟧ˡ tx = do
+    let txb = body tx
+    (utxoSt' , utxoStep) ← computeProof record{ LEnv Γ } utxoSt tx
+    (certSt' , certStep) ← computeProof ⟦ epoch slot , pparams , txvote txb ⟧ᶜ certSt (txcerts txb)
+    (govSt'  , govStep)  ← computeProof ⟦ txid txb , epoch slot , pparams ⟧ᵗ govSt (txgov txb)
+    case ¿ mapˢ RwdAddr.stake (dom (txwdrls txb ˢ)) ⊆ dom (DState.voteDelegs (CertState.dState certSt') ˢ) ¿ of λ where
+      (yes h) → just (_ , LEDGER utxoStep certStep govStep h)
+      (no _)  → nothing
+    where
+      open import Data.Maybe hiding (map)
+  Computational-LEDGER .completeness Γ@(⟦ slot , ppolicy , pparams ⟧ˡᵉ)
+                                     ⟦ utxoSt , govSt , certSt ⟧ˡ
+                                     tx
+                                     ⟦ utxoSt' , govSt' , certState' ⟧ˡ
+                                     (LEDGER utxoStep certStep govStep h)
+    with computeProof record{ LEnv Γ } utxoSt tx | completeness _ _ _ _ utxoStep
+  ... | just (utxoSt' , _) | refl
+    with computeProof {STS = _⊢_⇀⦇_,CERTS⦈_} ⟦ epoch slot , pparams , txvote (body tx) ⟧ᶜ certSt (txcerts (body tx))
+       | completeness _ _ _ _ certStep
+  ... | just (certSt' , _) | refl
+    with computeProof {STS = _⊢_⇀⦇_,GOV⦈_} ⟦ txid (body tx) , epoch slot , pparams ⟧ᵗ govSt (txgov (body tx))
+       | completeness _ _ _ _ govStep
+  ... | just (govSt' , _) | refl
+    rewrite dec-yes ¿ mapˢ RwdAddr.stake (dom (txwdrls (body tx) ˢ)) ⊆
+                      dom (DState.voteDelegs (CertState.dState certSt') ˢ) ¿ h .proj₂ = refl
 
-  FreshTx : Tx → LState → Set
-  FreshTx tx ls = tx .body .txid ∉ mapˢ proj₁ (dom (ls .utxoSt .utxo ˢ))
+instance
+  HasCoin-LState : HasCoin LState
+  HasCoin-LState .getCoin s = getCoin (LState.utxoSt s)
 
-  LEDGER-pov : FreshTx tx s → Γ ⊢ s ⇀⦇ tx ,LEDGER⦈ s' → getCoin s ≡ getCoin s'
-  LEDGER-pov h (LEDGER (UTXOW-inductive _ _ _ _ _ st) _ _ _) = P.pov h st
+open UTxOState
+open LState
 
-  data FreshTxs : LEnv → LState → List Tx → Set where
-    []-Fresh : FreshTxs Γ s []
-    ∷-Fresh  : FreshTx tx s → Γ ⊢ s ⇀⦇ tx ,LEDGER⦈ s' → FreshTxs Γ s' l
-             → FreshTxs Γ s (tx ∷ l)
+FreshTx : Tx → LState → Set
+FreshTx tx ls = txid (body tx) ∉ mapˢ proj₁ (dom (utxo (utxoSt ls) ˢ))
 
-  LEDGERS-pov : FreshTxs Γ s l → Γ ⊢ s ⇀⦇ l ,LEDGERS⦈ s' → getCoin s ≡ getCoin s'
-  LEDGERS-pov _ (BS-base refl) = refl
-  LEDGERS-pov {Γ} {_} {_ ∷ l} (∷-Fresh h h₁ h₂) (BS-ind x st) =
-    trans (LEDGER-pov h x) $
-      LEDGERS-pov (subst (λ s → FreshTxs Γ s l)
-                         (sym $ computational⇒rightUnique Computational-LEDGER x h₁)
-                         h₂) st
+LEDGER-pov : FreshTx tx s → Γ ⊢ s ⇀⦇ tx ,LEDGER⦈ s' → getCoin s ≡ getCoin s'
+LEDGER-pov h (LEDGER (UTXOW-inductive _ _ _ _ _ st) _ _ _) = P.pov h st
+
+data FreshTxs : LEnv → LState → List Tx → Set where
+  []-Fresh : FreshTxs Γ s []
+  ∷-Fresh  : FreshTx tx s → Γ ⊢ s ⇀⦇ tx ,LEDGER⦈ s' → FreshTxs Γ s' l
+            → FreshTxs Γ s (tx ∷ l)
+
+LEDGERS-pov : FreshTxs Γ s l → Γ ⊢ s ⇀⦇ l ,LEDGERS⦈ s' → getCoin s ≡ getCoin s'
+LEDGERS-pov _ (BS-base Id-nop) = refl
+LEDGERS-pov {Γ} {_} {_ ∷ l} (∷-Fresh h h₁ h₂) (BS-ind x st) =
+  trans (LEDGER-pov h x) $
+    LEDGERS-pov (subst (λ s → FreshTxs Γ s l)
+                        (sym $ computational⇒rightUnique Computational-LEDGER x h₁)
+                        h₂) st

--- a/src/Ledger/Ledger/Properties.agda
+++ b/src/Ledger/Ledger/Properties.agda
@@ -1,28 +1,69 @@
 {-# OPTIONS --safe #-}
 
-open import Data.Product.Properties
-
-import Relation.Binary.PropositionalEquality as Eq
-
-open import Tactic.ReduceDec using (fromWitness')
-
-open import Ledger.Prelude; open Equivalence; open Computational ⦃...⦄
+open import Ledger.Prelude
 open import Ledger.Transaction
 
 module Ledger.Ledger.Properties (txs : _) (open TransactionStructure txs) where
 
-open TxBody
-open TxWitnesses
-open Tx
-
 open import Ledger.Gov govStructure
 open import Ledger.Utxo txs
-open import Ledger.Ledger txs
-open import Ledger.Utxow txs
-open import Ledger.PPUp txs
-
 import Ledger.Utxo.Properties txs as P
+open import Ledger.Utxow txs
 import Ledger.Utxow.Properties txs as PW
+open import Ledger.Ledger txs
+
+-- ** Proof that LEDGER is computational.
+
+instance
+  Computational-LEDGER : Computational _⊢_⇀⦇_,LEDGER⦈_
+  Computational-LEDGER = record {go}
+    where
+    open Computational ⦃...⦄ renaming (computeProof to comp; completeness to complete)
+    computeUtxow = comp {STS = _⊢_⇀⦇_,UTXOW⦈_}
+    computeCerts = comp {STS = _⊢_⇀⦇_,CERTS⦈_}
+    computeGov   = comp {STS = _⊢_⇀⦇_,GOV⦈_}
+
+    module go
+      (Γ : LEnv)   (let ⟦ slot , ppolicy , pparams ⟧ˡᵉ = Γ)
+      (s : LState) (let ⟦ utxoSt , govSt , certSt ⟧ˡ = s)
+      (tx : Tx)    (let open Tx tx renaming (body to txb); open TxBody txb)
+      where
+      utxoΓ = UTxOEnv ∋ record{ LEnv Γ }
+      certΓ = CertEnv ∋ ⟦ epoch slot , pparams , txvote ⟧ᶜ
+      govΓ  = GovEnv  ∋ ⟦ txid , epoch slot , pparams ⟧ᵗ
+
+      module _ (cs : CertState) where
+        LEDGER-premises : Set
+        LEDGER-premises = mapˢ RwdAddr.stake (dom (txwdrls ˢ))
+                        ⊆ dom (cs .CertState.dState .DState.voteDelegs ˢ)
+
+        LEDGER-premises? = ¿ LEDGER-premises ¿
+
+      computeProof : Maybe (∃[ s' ] Γ ⊢ s ⇀⦇ tx ,LEDGER⦈ s')
+      computeProof = do
+        (utxoSt' , utxoStep) ← computeUtxow utxoΓ utxoSt tx
+        (certSt' , certStep) ← computeCerts certΓ certSt txcerts
+        (govSt'  , govStep)  ← computeGov   govΓ  govSt  (txgov txb)
+        case LEDGER-premises? certSt' of λ where
+          (yes h) → just (_ , LEDGER utxoStep certStep govStep h)
+          (no _)  → nothing
+        where open import Data.Maybe hiding (map)
+
+      completeness : ∀ s' → Γ ⊢ s ⇀⦇ tx ,LEDGER⦈ s' → (proj₁ <$> computeProof) ≡ just s'
+      completeness ⟦ utxoSt' , govSt' , certState' ⟧ˡ (LEDGER utxoStep certStep govStep h)
+        with computeUtxow utxoΓ utxoSt tx | complete _ _ _ _ utxoStep
+      ... | just (utxoSt' , _) | refl
+        with computeCerts certΓ certSt txcerts | complete _ _ _ _ certStep
+      ... | just (certSt' , _) | refl
+        with computeGov govΓ govSt (txgov txb) | complete _ _ _ _ govStep
+      ... | just (govSt' , _) | refl
+        rewrite dec-yes (LEDGER-premises? certSt') h .proj₂ = refl
+
+instance
+  HasCoin-LState : HasCoin LState
+  HasCoin-LState .getCoin s = getCoin (LState.utxoSt s)
+
+-- ** Proof that LEDGER preserves values.
 
 private variable
   tx : Tx
@@ -30,43 +71,9 @@ private variable
   s s' : LState
   l : List Tx
 
-instance
-  Computational-LEDGER : Computational _⊢_⇀⦇_,LEDGER⦈_
-  Computational-LEDGER .computeProof Γ@(⟦ slot , ppolicy , pparams ⟧ˡᵉ) ⟦ utxoSt , govSt , certSt ⟧ˡ tx = do
-    let txb = body tx
-    (utxoSt' , utxoStep) ← computeProof record{ LEnv Γ } utxoSt tx
-    (certSt' , certStep) ← computeProof ⟦ epoch slot , pparams , txvote txb ⟧ᶜ certSt (txcerts txb)
-    (govSt'  , govStep)  ← computeProof ⟦ txid txb , epoch slot , pparams ⟧ᵗ govSt (txgov txb)
-    case ¿ mapˢ RwdAddr.stake (dom (txwdrls txb ˢ)) ⊆ dom (DState.voteDelegs (CertState.dState certSt') ˢ) ¿ of λ where
-      (yes h) → just (_ , LEDGER utxoStep certStep govStep h)
-      (no _)  → nothing
-    where
-      open import Data.Maybe hiding (map)
-  Computational-LEDGER .completeness Γ@(⟦ slot , ppolicy , pparams ⟧ˡᵉ)
-                                     ⟦ utxoSt , govSt , certSt ⟧ˡ
-                                     tx
-                                     ⟦ utxoSt' , govSt' , certState' ⟧ˡ
-                                     (LEDGER utxoStep certStep govStep h)
-    with computeProof record{ LEnv Γ } utxoSt tx | completeness _ _ _ _ utxoStep
-  ... | just (utxoSt' , _) | refl
-    with computeProof {STS = _⊢_⇀⦇_,CERTS⦈_} ⟦ epoch slot , pparams , txvote (body tx) ⟧ᶜ certSt (txcerts (body tx))
-       | completeness _ _ _ _ certStep
-  ... | just (certSt' , _) | refl
-    with computeProof {STS = _⊢_⇀⦇_,GOV⦈_} ⟦ txid (body tx) , epoch slot , pparams ⟧ᵗ govSt (txgov (body tx))
-       | completeness _ _ _ _ govStep
-  ... | just (govSt' , _) | refl
-    rewrite dec-yes ¿ mapˢ RwdAddr.stake (dom (txwdrls (body tx) ˢ)) ⊆
-                      dom (DState.voteDelegs (CertState.dState certSt') ˢ) ¿ h .proj₂ = refl
-
-instance
-  HasCoin-LState : HasCoin LState
-  HasCoin-LState .getCoin s = getCoin (LState.utxoSt s)
-
-open UTxOState
-open LState
-
 FreshTx : Tx → LState → Set
-FreshTx tx ls = txid (body tx) ∉ mapˢ proj₁ (dom (utxo (utxoSt ls) ˢ))
+FreshTx tx ls = tx .body .txid ∉ mapˢ proj₁ (dom (ls .utxoSt .utxo ˢ))
+  where open Tx; open TxBody; open UTxOState; open LState
 
 LEDGER-pov : FreshTx tx s → Γ ⊢ s ⇀⦇ tx ,LEDGER⦈ s' → getCoin s ≡ getCoin s'
 LEDGER-pov h (LEDGER (UTXOW-inductive _ _ _ _ _ st) _ _ _) = P.pov h st

--- a/src/Ledger/PPUp/Properties.agda
+++ b/src/Ledger/PPUp/Properties.agda
@@ -1,6 +1,6 @@
 {-# OPTIONS --safe #-}
 
-open import Ledger.Prelude hiding (_+_; _*_); open Computational' ⦃...⦄; open HasDecPartialOrder ⦃...⦄
+open import Ledger.Prelude hiding (_+_; _*_); open Computational ⦃...⦄; open HasDecPartialOrder ⦃...⦄
 open import Ledger.Transaction
 
 module Ledger.PPUp.Properties (txs : _) (open TransactionStructure txs) where
@@ -29,8 +29,8 @@ private
       × sucᵉ (epoch slot) ≡ e
 
 instance
-  Computational'-PPUP : Computational' _⊢_⇀⦇_,PPUP⦈_
-  Computational'-PPUP .computeProof Γ s = λ where
+  Computational-PPUP : Computational _⊢_⇀⦇_,PPUP⦈_
+  Computational-PPUP .computeProof Γ s = λ where
     (just (pup , e)) →
       case ¿ Current-Property Γ (pup , e) ¿
         ,′ ¿ Future-Property Γ (pup , e) ¿ of λ where
@@ -39,16 +39,12 @@ instance
         (no _ , no _)                 → nothing
     nothing → just (-, PPUpdateEmpty)
 
-  Computational'-PPUP .completeness Γ _ .nothing  _     PPUpdateEmpty = refl
-  Computational'-PPUP .completeness Γ _ (just up) _ p   with p
-  Computational'-PPUP .completeness Γ _ (just up) _ _ | PPUpdateCurrent p₁ p₂ p₃ p₄
-    with ¿ Current-Property Γ up ¿ | "bug"
-  ... | yes p | _ = refl
-  ... | no ¬p | _ = ⊥-elim (¬p (p₁ , p₂ , p₃ , p₄))
-  Computational'-PPUP .completeness Γ _ (just up) _ _ | PPUpdateFuture p₁ p₂ p₃ p₄
-    with ¿ Current-Property Γ up ¿ | ¿ Future-Property Γ up ¿ | "bug"
+  Computational-PPUP .completeness Γ _ .nothing  _     PPUpdateEmpty = refl
+  Computational-PPUP .completeness Γ _ (just up) _ p   with p
+  Computational-PPUP .completeness Γ _ (just up) _ _ | PPUpdateCurrent p₁ p₂ p₃ p₄
+    rewrite dec-yes ¿ Current-Property Γ up ¿ (p₁ , p₂ , p₃ , p₄) .proj₂ = refl
+  Computational-PPUP .completeness Γ _ (just up) _ _ | PPUpdateFuture p₁ p₂ p₃ p₄
+    with ¿ Current-Property Γ up ¿ | ¿ Future-Property Γ up ¿ | "agda#6868"
   ... | yes (_ , _ , (p₃˘ , ≢_ ) , _) | _ | _ = ⊥-elim $ ≢ ≤ˢ-isAntisymmetric p₃˘ p₃
   ... | no _ | yes p | _ = refl
   ... | no _ | no ¬p | _ = ⊥-elim (¬p (p₁ , p₂ , p₃ , p₄))
-
-  Computational-PPUP = fromComputational' Computational'-PPUP

--- a/src/Ledger/Prelude.agda
+++ b/src/Ledger/Prelude.agda
@@ -29,6 +29,7 @@ open import Interface.Decidable.Instance public
 open import Interface.ComputationalRelation public
 open import Ledger.Interface.HasCoin public
 open import MyDebugOptions public
+open import Tactic.DeriveComp public
 
 --------------------------------------------------------------------------------
 -- Set theory

--- a/src/Ledger/Ratify.lagda
+++ b/src/Ledger/Ratify.lagda
@@ -516,7 +516,7 @@ data _⊢_⇀⦇_,RATIFY'⦈_ : RatifyEnv → RatifyState → GovActionID × Gov
 
 _⊢_⇀⦇_,RATIFY⦈_ :  RatifyEnv → RatifyState → List (GovActionID × GovActionState)
                    → RatifyState → Set
-_⊢_⇀⦇_,RATIFY⦈_ = SS⇒BS λ (Γ , _) → Γ ⊢_⇀⦇_,RATIFY'⦈_
+_⊢_⇀⦇_,RATIFY⦈_ = SS⇒BS _⊢_⇀⦇_,RATIFY'⦈_
 \end{code}
 } %% end small
 \caption{The RATIFY transition system}

--- a/src/Ledger/Ratify/Properties.agda
+++ b/src/Ledger/Ratify/Properties.agda
@@ -35,4 +35,4 @@ module _ (accepted? : ∀ Γ es st → Dec (accepted Γ es st))
         (yes q) → -, RATIFY-Continue (inj₂ (inj₁ q))
 
   RATIFY-total : ∀ {Γ s sig} → ∃[ s' ] Γ ⊢ s ⇀⦇ sig ,RATIFY⦈ s'
-  RATIFY-total = SS-total⇒BS-total RATIFY'-total
+  RATIFY-total = SS⇒BS-total RATIFY'-total

--- a/src/Ledger/Utxo.lagda
+++ b/src/Ledger/Utxo.lagda
@@ -11,7 +11,6 @@ open import Algebra              using (CommutativeMonoid)
 open import Data.Integer.Ext     using (posPart; negPart)
 open import Data.Nat.Properties  using (+-0-monoid; +-0-commutativeMonoid)
 
-open import Tactic.DeriveComp
 open import Tactic.Derive.DecEq
 
 open import Ledger.Prelude

--- a/src/Ledger/Utxo.lagda
+++ b/src/Ledger/Utxo.lagda
@@ -262,8 +262,8 @@ data _⊢_⇀⦇_,UTXO⦈_ where
 \end{code}
 \begin{code}[hide]
 instance
-  Computational'-UTXO : Computational' _⊢_⇀⦇_,UTXO⦈_
-  Computational'-UTXO = record {go} where module go Γ s tx where
+  Computational-UTXO : Computational _⊢_⇀⦇_,UTXO⦈_
+  Computational-UTXO = record {go} where module go Γ s tx where
     open TxBody tx
     open UTxOEnv Γ renaming (pparams to pp)
     open UTxOState s
@@ -294,8 +294,6 @@ instance
       QED with UTXO-premises?
       ... | yes (p₀ , p₁ , p₂ , p₃ , p₄ , p₅ , p₆) = refl
       ... | no q = ⊥-elim (q (q₀ , q₁ , q₂ , q₃ , q₄ , q₅ , q₆))
-
-  Computational-UTXO = fromComputational' Computational'-UTXO
 \end{code}
 \caption{UTXO inference rules}
 \label{fig:rules:utxo-shelley}

--- a/src/Ledger/Utxow/Properties.agda
+++ b/src/Ledger/Utxow/Properties.agda
@@ -1,6 +1,6 @@
 {-# OPTIONS --safe #-}
 
-open import Ledger.Prelude; open Computational' ⦃...⦄
+open import Ledger.Prelude; open Computational ⦃...⦄
 open import Ledger.Crypto
 open import Ledger.Transaction
 
@@ -25,17 +25,13 @@ private
 
 open Tx
 instance
-  Computational'-UTXOW : Computational' _⊢_⇀⦇_,UTXOW⦈_
-  Computational'-UTXOW .computeProof Γ s tx@(record {body = txb}) =
+  Computational-UTXOW : Computational _⊢_⇀⦇_,UTXOW⦈_
+  Computational-UTXOW .computeProof Γ s tx@(record {body = txb}) =
     case ¿ UTXOW-premise Γ s tx ¿ of λ where
       (yes (p₁ , p₂ , p₃ , p₄ , p₅)) →
         map₂′ (UTXOW-inductive p₁ p₂ p₃ p₄ p₅) <$> computeProof Γ s (tx .body)
       (no _) → nothing
-  Computational'-UTXOW .completeness Γ s tx s' (UTXOW-inductive p₁ p₂ p₃ p₄ p₅ h)
-    with ¿ UTXOW-premise Γ s tx ¿ | "dumb Agda bug"
-  ... | no ¬p | _ = ⊥-elim (¬p (p₁ , p₂ , p₃ , p₄ , p₅))
-  ... | yes _ | _
+  Computational-UTXOW .completeness Γ s tx s' (UTXOW-inductive p₁ p₂ p₃ p₄ p₅ h)
+    rewrite dec-yes ¿ UTXOW-premise Γ s tx ¿ (p₁ , p₂ , p₃ , p₄ , p₅) .proj₂
     with computeProof Γ s (tx .body) | completeness _ _ _ _ h
   ...   | just h | refl = refl
-
-  Computational-UTXOW = fromComputational' Computational'-UTXOW

--- a/src/MidnightExample/Ledger.lagda
+++ b/src/MidnightExample/Ledger.lagda
@@ -175,20 +175,27 @@ data _⊢_⇀⦇_,LEDGER⦈_ : ⊤ → LedgerState → Block → LedgerState →
 \caption{The LEDGER transition system}
 \end{figure*}
 
-We also have automation that generates a step function for this
-relation. As an example, we also provide a function that does the same
-computation explicitly.
+We can prove that this relation is a partial function and the proof gives us a step function.
+As an example we also provide a function that does the same computation explicitly.
 
 \begin{code}[hide]
-unquoteDecl Computational-LEDGER =
-  deriveComputational (quote _⊢_⇀⦇_,LEDGER⦈_) Computational-LEDGER
-
-open Computational
+open Computational ⦃...⦄
+instance
+  Computational-LEDGER : Computational _⊢_⇀⦇_,LEDGER⦈_
+  Computational-LEDGER .computeProof Γ s b =
+    let open Block b
+        acc = Σˡ[ x ← body ] txDelta x
+    in case ¿ acc ≢ 0ℤ ∧ computeBlockHash b ≡ blockHash ¿ of λ where
+      (yes (p , p₁)) → just (_ , LEDGER-inductive p p₁)
+      (no _) → nothing
+  Computational-LEDGER .completeness Γ s b s' (LEDGER-inductive p p₁)
+    rewrite (let open Block b; acc = Σˡ[ x ← body ] txDelta x
+             in dec-yes ¿ acc ≢ 0ℤ ∧ computeBlockHash b ≡ blockHash ¿ (p , p₁) .proj₂) = refl
 \end{code}
 \begin{figure*}[h]
 \begin{code}
 LEDGER-step : ⊤ → LedgerState → Block → Maybe LedgerState
-LEDGER-step = compute Computational-LEDGER
+LEDGER-step = compute
 
 applyBlockTo : Block → LedgerState → Maybe LedgerState
 applyBlockTo b st = let acc = Σˡ[ x ← Block.body b ] txDelta x in
@@ -233,7 +240,7 @@ LEDGER-property₁ (LEDGER-inductive acc≢0 _) = lemma acc≢0
 LEDGER-property₂ : LEDGER-step _ s b ≡ just s' → count s ≢ count s'
 LEDGER-property₂ {s} {b} eq
   = LEDGER-property₁
-  $ Equivalence.to (≡-just⇔STS Computational-LEDGER {s = s} {sig = b}) eq
+  $ Equivalence.to (≡-just⇔STS {s = s} {sig = b}) eq
 
 LEDGER-property₃ : applyBlockTo b s ≡ just s' → count s ≢ count s'
 LEDGER-property₃ {b = b} h with

--- a/src/MidnightExample/Ledger.lagda
+++ b/src/MidnightExample/Ledger.lagda
@@ -21,8 +21,6 @@ module MidnightExample.Ledger
 open import Data.Integer.Properties using (+-0-commutativeMonoid; +-0-abelianGroup)
 open import Relation.Nullary
 
-open import Tactic.DeriveComp
-
 instance
   _ = +-0-commutativeMonoid
 

--- a/src/Tactic/DeriveComp.agda
+++ b/src/Tactic/DeriveComp.agda
@@ -230,39 +230,39 @@ module _ ⦃ _ : DebugOptions ⦄ where
       defineFun compName [ nonBindingClause definition ]
       extendRawContext isoCxt $ λ _ → derive⇔ n stsConstrs iso
 
-private module _ {A B : Set} ⦃ _ : DecEq A ⦄ ⦃ _ : DecEq B ⦄ where
-  open import MyDebugOptions
+-- private module _ {A B : Set} ⦃ _ : DecEq A ⦄ ⦃ _ : DecEq B ⦄ where
+--   open import MyDebugOptions
 
-  variable
-    c : A × B
-    s s' : A
-    sig : B
+--   variable
+--     c : A × B
+--     s s' : A
+--     sig : B
 
-  data Test : A × B → A → B → A → Set where
-    test : proj₁ c ≡ s
-         → proj₂ c ≡ sig
-         ------------------------
-         → Test c s sig (proj₁ c)
+--   data Test : A × B → A → B → A → Set where
+--     test : proj₁ c ≡ s
+--          → proj₂ c ≡ sig
+--          ------------------------
+--          → Test c s sig (proj₁ c)
 
-  unquoteDecl Computational-Test = deriveComputational (quote Test) Computational-Test
+--   unquoteDecl Computational-Test = deriveComputational (quote Test) Computational-Test
 
-  -- Sanity checks
-  testFun : A × B → A → B → Maybe A
-  testFun c s sig =
-    if ⌊ ¿ proj₁ c ≡ s × proj₂ c ≡ sig ¿ ⌋ then just (proj₁ c) else nothing
+--   -- Sanity checks
+--   testFun : A × B → A → B → Maybe A
+--   testFun c s sig =
+--     if ⌊ ¿ proj₁ c ≡ s × proj₂ c ≡ sig ¿ ⌋ then just (proj₁ c) else nothing
 
-  testFunPf⇒ : testFun c s sig ≡ just s' → Test c s sig s'
-  testFunPf⇒ {c} {s} {sig} h = case ¿ proj₁ c ≡ s × proj₂ c ≡ sig ¿ of λ where
-    (no ¬p) → case by-reduceDec h of λ ()
-    (yes p) → subst (Test c s sig) (just-injective $ by-reduceDec h)
-            $ test (proj₁ p) (proj₂ p)
+--   testFunPf⇒ : testFun c s sig ≡ just s' → Test c s sig s'
+--   testFunPf⇒ {c} {s} {sig} h = case ¿ proj₁ c ≡ s × proj₂ c ≡ sig ¿ of λ where
+--     (no ¬p) → case by-reduceDec h of λ ()
+--     (yes p) → subst (Test c s sig) (just-injective $ by-reduceDec h)
+--             $ test (proj₁ p) (proj₂ p)
 
-  testFunPf⇐ : Test c s sig s' → testFun c s sig ≡ just s'
-  testFunPf⇐ {s = s} (test x x₁) = by-reduceDecInGoal (refl {x = just s})
+--   testFunPf⇐ : Test c s sig s' → testFun c s sig ≡ just s'
+--   testFunPf⇐ {s = s} (test x x₁) = by-reduceDecInGoal (refl {x = just s})
 
-  Computational-Test-Manual : Computational Test
-  Computational-Test-Manual = record
-    { compute = testFun ; ≡-just⇔STS = mk⇔ testFunPf⇒ testFunPf⇐ }
+--   Computational-Test-Manual : Computational Test
+--   Computational-Test-Manual = record
+--     { compute = testFun ; ≡-just⇔STS = mk⇔ testFunPf⇒ testFunPf⇐ }
 
-  _ : ∀ {c s sig} → testFun c s sig ≡ Computational.compute Computational-Test c s sig
-  _ = refl
+--   _ : ∀ {c s sig} → testFun c s sig ≡ Computational.compute Computational-Test c s sig
+--   _ = refl


### PR DESCRIPTION
Also
- make SS⇒BS more amenable to instance search
- cleaned up Computational instance for LEDGER

Fixes #211 