### PR TITLE
Remove --overlapping-instances

### DIFF
--- a/src/Axiom/Set/List.agda
+++ b/src/Axiom/Set/List.agda
@@ -55,9 +55,8 @@ module Decˡ {A : Type} ⦃ _ : DecEq A ⦄ where
   _∈?_ : Dec₂ (_∈ˡ_ {A = A})
   _∈?_ a = Any.any? (a ≟_)
 
-  ≟-∅ : {X : Set A} → Dec (X ≡ ∅)
-  ≟-∅ {[]}    = yes refl
-  ≟-∅ {x ∷ X} = no (λ ())
+  DecEq-Set : DecEq (Set A)
+  DecEq-Set = DecEq-List
 
 List-Modelᵈ : Theoryᵈ
 List-Modelᵈ = record

--- a/src/Ledger/Prelude.agda
+++ b/src/Ledger/Prelude.agda
@@ -70,8 +70,9 @@ abstract
   setToList : {A : Set} → ℙ A → List A
   setToList = id
 
-  ≟-∅ : {A : Set} ⦃ _ : DecEq A ⦄ → {X : ℙ A} → Dec (X ≡ ∅)
-  ≟-∅ = L.Decˡ.≟-∅
+  instance
+    DecEq-ℙ : {A : Set} ⦃ _ : DecEq A ⦄ → DecEq (ℙ A)
+    DecEq-ℙ = L.Decˡ.DecEq-Set
 
 open import Axiom.Set.Rel th public
   hiding (_∣'_; _↾'_)
@@ -83,7 +84,7 @@ open import Axiom.Set.TotalMap th public
 open import Axiom.Set.TotalMapOn th
 
 open L.Decˡ public
-  hiding (_∈?_; ≟-∅)
+  hiding (_∈?_; DecEq-Set)
 
 open import Axiom.Set.Sum th public
 open import Axiom.Set.Map.Dec List-Modelᵈ public

--- a/src/Ledger/Utxo.lagda
+++ b/src/Ledger/Utxo.lagda
@@ -5,7 +5,6 @@
 
 \begin{code}[hide]
 {-# OPTIONS --safe #-}
-{-# OPTIONS --overlapping-instances #-}
 
 open import Algebra              using (CommutativeMonoid)
 open import Data.Integer.Ext     using (posPart; negPart)
@@ -153,8 +152,6 @@ record UTxOState : Set where
 
 open HasDecPartialOrder ⦃ ... ⦄
 instance
-  _ = ≟-∅
-
   netId? : ∀ {A : Set} {networkId : Network} {f : A → Network}
     → Dec₁ (λ a → f a ≡ networkId)
   netId? {_} {networkId} {f} .Dec₁.P? a = f a ≟ networkId

--- a/src/MidnightExample/HSLedger.agda
+++ b/src/MidnightExample/HSLedger.agda
@@ -1,4 +1,3 @@
-{-# OPTIONS --overlapping-instances #-}
 module MidnightExample.HSLedger where
 
 open import Prelude hiding (_++_)
@@ -28,7 +27,6 @@ instance
 open import MidnightExample.Ledger Hash
 
 open import Foreign.Convertible
-open import Foreign.Haskell.Coerce
 
 instance
   Convertible-Point : Convertible Point F.Point


### PR DESCRIPTION
- In light of a recent issue with `--overlapping-instances`
  (c.f. https://github.com/agda/agda/issues/6895), I removed
  all uses of overlapping in the codebase, which we actually redundant.

- `Foreign.Convertible` no longer overlaps instances of `Coercible`.

- `Axiom.Set.List` now exports general decidable equality to avoid ambiguity
  when `Interface.DecEq.DecEq⇒Dec` is also in scope.