### PR TITLE
Tactic to remove trivial injectivity proofs

### DIFF
--- a/src/Axiom/Set/Map.agda
+++ b/src/Axiom/Set/Map.agda
@@ -28,6 +28,7 @@ open import Tactic.AnyOf
 open import Tactic.Assumption
 open import Tactic.Defaults
 open import Tactic.Helpers
+open import Tactic.ByEq
 
 -- Because of missing macro hygiene, we have to copy&paste this.
 -- c.f. https://github.com/agda/agda/issues/3819
@@ -182,10 +183,11 @@ InjectiveOn X f = ∀ {x y} → x ∈ X → y ∈ X → f x ≡ f y → x ≡ y
 weaken-Injective : ∀ {X : Set A} {f : A → B} → Injective _≡_ _≡_ f → InjectiveOn X f
 weaken-Injective p _ _ = p
 
-mapˡ-uniq : {f : A → A'} → InjectiveOn (dom R) f
+mapˡ-uniq : {f : A → A'}
+  → {@(tactic by-eq) inj : InjectiveOn (dom R) f}
   → left-unique R
   → left-unique (mapˡ f R)
-mapˡ-uniq inj uniq = λ h h' → case ∈⇔P h ,′ ∈⇔P h' of λ where
+mapˡ-uniq {inj = inj} uniq = λ h h' → case ∈⇔P h ,′ ∈⇔P h' of λ where
   (((_ , b) , refl , Ha) , ((_ , b') , eqb , Hb)) → uniq Ha
     $ subst _ ( sym
               $ ×-≡,≡→≡
@@ -197,8 +199,10 @@ mapʳ-uniq : {f : B → B'} → left-unique R → left-unique (mapʳ f R)
 mapʳ-uniq uniq = λ h h' → case ∈⇔P h ,′ ∈⇔P h' of λ where
   ((_ , refl , Ha) , (_ , refl , Hb)) → cong _ $ uniq Ha Hb
 
-mapKeys : (f : A → A') → (m : Map A B) → InjectiveOn (dom (m ˢ)) f → Map A' B
-mapKeys f (R , uniq) inj = mapˡ f R , mapˡ-uniq inj uniq
+mapKeys : (f : A → A') → (m : Map A B)
+  → {@(tactic by-eq) _ : InjectiveOn (dom (m ˢ)) f}
+  → Map A' B
+mapKeys f (R , uniq) {inj} = mapˡ f R , mapˡ-uniq {inj = inj} uniq
 
 mapValues : (B → B') → Map A B → Map A B'
 mapValues f (R , uniq) = mapʳ f R , mapʳ-uniq uniq

--- a/src/Ledger/Chain.lagda
+++ b/src/Ledger/Chain.lagda
@@ -134,10 +134,10 @@ maybePurpose-prop {prps = prps} {x} {y} _ xy∈dom with to dom∈ xy∈dom
 ... | yes refl | _ = refl
 
 filterPurpose : DepositPurpose → (DepositPurpose × Credential) ⇀ Coin → Credential ⇀ Coin
-filterPurpose prps m = mapKeys proj₂ (mapMaybeWithKeyᵐ (maybePurpose prps) m) λ where
-  x∈dom y∈dom refl → cong (_, _) $
-    trans (maybePurpose-prop {prps = prps} m x∈dom)
-    (sym $ maybePurpose-prop {prps = prps} m y∈dom)
+filterPurpose prps m = mapKeys proj₂ (mapMaybeWithKeyᵐ (maybePurpose prps) m)
+  {λ where x∈dom y∈dom refl → cong (_, _)
+                            $ trans (maybePurpose-prop {prps = prps} m x∈dom)
+                            $ sym   (maybePurpose-prop {prps = prps} m y∈dom)}
 
 govActionDeposits : LState → VDeleg ⇀ Coin
 govActionDeposits ls =

--- a/src/Ledger/Ratify.lagda
+++ b/src/Ledger/Ratify.lagda
@@ -258,7 +258,6 @@ module _
 \begin{code}
   roleVotes : GovRole → VDeleg ⇀ Vote
   roleVotes r = mapKeys (uncurry credVoter) (filterᵐ (to-sp ((r ≟_) ∘ proj₁ ∘ proj₁)) votes)
-                        (λ where _ _ refl → refl)
 
   actualCCVote : Credential → Epoch → Vote
   actualCCVote c e =
@@ -309,7 +308,7 @@ module _
         _             → false
 
   actualVotes
-    =    mapKeys (credVoter CC) actualCCVotes (λ where _ _ refl → refl)
+    =    mapKeys (credVoter CC) actualCCVotes
     ∪ᵐˡ  actualPDRepVotes ∪ᵐˡ actualDRepVotes
     ∪ᵐˡ  actualSPOVotes
 \end{code}

--- a/src/Ledger/Utxo.lagda
+++ b/src/Ledger/Utxo.lagda
@@ -62,7 +62,7 @@ module _ (open TxBody) where
 \end{code}
 \begin{code}
   outs : TxBody → UTxO
-  outs tx = mapKeys (tx .txid ,_) (tx .txouts) λ where _ _ refl → refl
+  outs tx = mapKeys (tx .txid ,_) (tx .txouts)
 
   balance : UTxO → Value
   balance utxo = Σᵐᵛ[ x ← utxo ᶠᵐ ] getValue x

--- a/src/Tactic/ByEq.agda
+++ b/src/Tactic/ByEq.agda
@@ -1,0 +1,58 @@
+{-# OPTIONS --safe --without-K #-}
+module Tactic.ByEq where
+
+open import Prelude
+open import Interface.Functor using (map; _<&>_)
+
+open import Agda.Builtin.Reflection using (clause; dot)
+open import Reflection
+open import Generics
+
+-- Introduce as many arguments as possible and then:
+--   1. for those of type `_ ≡ _`, unify with  `refl`
+--   2. ignore the rest of the arguments (unify with `_`)
+--   3. unify the hole with `refl`
+by-eq : Hole → TC ⊤
+by-eq hole = do
+  ty ← withNormalisation true $ inferType hole
+  let ps : Args Pattern
+      ps = argTys ty <&> map λ {(def (quote _≡_) _) → quote refl ◇; _ → dot unknown}
+  unify hole $ pat-lam [ clause [] ps (quote refl ◆) ] []
+
+macro $by-eq = by-eq
+
+private
+  -- test that macro works
+  _ : ∀ {n m k : ℕ} → n ≡ m → m ≡ k → n ≡ k
+  _ = $by-eq
+
+  _ : ∀ {n m k x y : ℕ} → n ≡ m → x ≡ y → m ≡ n
+  _ = $by-eq
+
+  -- test that tactic arguments work
+  f : {@(tactic by-eq) _ : ∀ {n m : ℕ} → n ≡ m → m ≡ n} → Bool → Bool
+  f = id
+
+  _ : f {λ where refl → refl} true ≡ true
+  _ = refl
+
+  _ : f {$by-eq} true ≡ true
+  _ = refl
+
+  _ : f true ≡ true
+  _ = refl
+
+  -- test that normalisation works
+  Sym = ∀ {n m : ℕ} → n ≡ m → m ≡ n
+
+  g : {@(tactic by-eq) _ : Sym} → Bool → Bool
+  g = id
+
+  _ : g {λ where refl → refl} true ≡ true
+  _ = refl
+
+  _ : g {$by-eq} true ≡ true
+  _ = refl
+
+  _ : g true ≡ true
+  _ = refl


### PR DESCRIPTION
- Introduce the `by-eq` tactic that automates proofs of the form:

    `λ where _ refl _ refl → refl`

- Use on injectivity proofs for `Axiom.Set.Map:mapKeys`, replacing the explicit argument of an injectivity proof with a tactic argument that invokes `by-eq`.
