### PR TITLE
Respect the exit status of `nix` commands

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,35 +56,43 @@ jobs:
       - name: Build agda
         id: agda
         run: |
-          v=$(nix-build -A agdaWithStdLibMeta)
-          closure=$(nix-store --query --requisites --include-outputs $v | tr '\n' ' ')
-          echo "derivation=$v" >> $GITHUB_OUTPUT
-          echo "closure=$closure" >> $GITHUB_OUTPUT
+          d=$(nix-build -A agdaWithStdLibMeta)
+          dRet=$(echo "$d" | tr '\n' ' ')
+          closure=$(nix-store --query --requisites --include-outputs $dRet)
+          cRet=$(echo "$closure" | tr '\n' ' ')
+          echo "derivation=$dRet" >> $GITHUB_OUTPUT
+          echo "closure=$cRet" >> $GITHUB_OUTPUT
 
       - name: Build formalLedger
         id: formalLedger
         run: |
-          v=$(nix-build -A formalLedger)
-          closure=$(nix-store --query --requisites --include-outputs $v | tr '\n' ' ')
-          echo "derivation=$v" >> $GITHUB_OUTPUT
-          echo "closure=$closure" >> $GITHUB_OUTPUT
+          d=$(nix-build -A formalLedger)
+          dRet=$(echo "$d" | tr '\n' ' ')
+          closure=$(nix-store --query --requisites --include-outputs $dRet)
+          cRet=$(echo "$closure" | tr '\n' ' ')
+          echo "derivation=$dRet" >> $GITHUB_OUTPUT
+          echo "closure=$cRet" >> $GITHUB_OUTPUT
 
       - name: Build ledger
         id: ledger
         run: |
           mkdir -p outputs
-          v=$(nix-build -A ledger -j1 -o outputs/ledger| tr '\n' ' ')
-          closure=$(nix-store --query --requisites --include-outputs $v | tr '\n' ' ')
-          echo "derivation=$v" >> $GITHUB_OUTPUT
-          echo "closure=$closure" >> $GITHUB_OUTPUT
+          d=$(nix-build -A ledger -j1 -o outputs/ledger)
+          dRet=$(echo "$d" | tr '\n' ' ')
+          closure=$(nix-store --query --requisites --include-outputs $dRet)
+          cRet=$(echo "$closure" | tr '\n' ' ')
+          echo "derivation=$dRet" >> $GITHUB_OUTPUT
+          echo "closure=$cRet" >> $GITHUB_OUTPUT
 
       - name: Build midnight
         id: midnight
         run: |
-          v=$(nix-build -A midnight -j1 -o outputs/midnight | tr '\n' ' ')
-          closure=$(nix-store --query --requisites --include-outputs $v | tr '\n' ' ')
-          echo "derivation=$v" >> $GITHUB_OUTPUT
-          echo "closure=$closure" >> $GITHUB_OUTPUT
+          d=$(nix-build -A midnight -j1 -o outputs/midnight)
+          dRet=$(echo "$d"| tr '\n' ' ')
+          closure=$(nix-store --query --requisites --include-outputs $dRet)
+          cRet=$(echo "$closure" | tr '\n' ' ')
+          echo "derivation=$dRet" >> $GITHUB_OUTPUT
+          echo "closure=$cRet" >> $GITHUB_OUTPUT
 
       - name: Export all derivations
         id: export-derivations


### PR DESCRIPTION
to prevent fake successful builds: the build succeeding after the nix-command failed.

# Description

<!-- Add your description here, if it fixes a particular issue please provide a
[link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=)
to the issue. -->

The processing of the nix-build command is causing the exit code of the nix command to be ignored. 
In this PR we are processing the result in a new step, so that if "nix-build" or "nix-store" fails, the build is also failing. 

For example, this is a PR reverting to a commit that caused a Haskell compilation error (and hence a nix-build failure) when building ledger: https://github.com/teodanciu/formal-ledger-specifications/pull/2
This build was "fake" succeeding. 
With the change in this commit, it is failing: https://github.com/teodanciu/formal-ledger-specifications/actions/runs/6456348932/job/17525659662?pr=2#step:10:5606

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] Code is formatted according to [CONTRIBUTING.md](https://github.com/input-output-hk/formal-ledger-specifications/blob/master/CONTRIBUTING.md)
- [ ] Self-reviewed the diff
