### PR TITLE
PDF cleanup: fix spacing in Figures 4 and 6

### DIFF
--- a/src/Ledger/Address.lagda
+++ b/src/Ledger/Address.lagda
@@ -54,6 +54,7 @@ record RwdAddr : Set where
 open BaseAddr; open BootstrapAddr; open BaseAddr; open BootstrapAddr
 \end{code}
 \begin{code}
+
 VKeyBaseAddr         = Σ[ addr ∈ BaseAddr       ] isVKey    (addr .pay)
 VKeyBootstrapAddr    = Σ[ addr ∈ BootstrapAddr  ] isVKey    (addr .pay)
 ScriptBaseAddr       = Σ[ addr ∈ BaseAddr       ] isScript  (addr .pay)

--- a/src/Ledger/GovernanceActions.lagda
+++ b/src/Ledger/GovernanceActions.lagda
@@ -40,26 +40,26 @@ data GovRole : Set where
   CC DRep SPO : GovRole
 
 data VDeleg : Set where
-  credVoter        : GovRole → Credential → VDeleg
-  abstainRep       : VDeleg
-  noConfidenceRep  : VDeleg
+  credVoter        : GovRole → Credential →  VDeleg
+  abstainRep       :                         VDeleg
+  noConfidenceRep  :                         VDeleg
 
 record Anchor : Set where
   field  url   : String
          hash  : DocHash
 
 data GovAction : Set where
-  NoConfidence     :                                          GovAction
-  NewCommittee     : Credential ⇀ Epoch → ℙ Credential → ℚ  → GovAction
-  NewConstitution  : DocHash → Maybe ScriptHash             → GovAction
-  TriggerHF        : ProtVer                                → GovAction
-  ChangePParams    : PParamsUpdate                          → GovAction
-  TreasuryWdrl     : (RwdAddr ⇀ Coin)                       → GovAction
-  Info             :                                          GovAction
+  NoConfidence     :                                           GovAction
+  NewCommittee     : Credential ⇀ Epoch → ℙ Credential → ℚ  →  GovAction
+  NewConstitution  : DocHash → Maybe ScriptHash             →  GovAction
+  TriggerHF        : ProtVer                                →  GovAction
+  ChangePParams    : PParamsUpdate                          →  GovAction
+  TreasuryWdrl     : (RwdAddr ⇀ Coin)                       →  GovAction
+  Info             :                                           GovAction
 
 actionWellFormed : GovAction → Bool
-actionWellFormed (ChangePParams x) = ppdWellFormed x
-actionWellFormed _                 = true
+actionWellFormed (ChangePParams x)  = ppdWellFormed x
+actionWellFormed _                  = true
 \end{code}
 } %% end small
 \caption{Governance actions}


### PR DESCRIPTION
# Description

Fix spacing/alignment in Figures 4 and 6 as suggested in two items of issue #146.

# Checklist

- [X] Commit sequence broadly makes sense and commits have useful messages
- [X] Code is formatted according to [CONTRIBUTING.md](https://github.com/input-output-hk/formal-ledger-specifications/blob/master/CONTRIBUTING.md)
- [X] Self-reviewed the diff
