### PR TITLE
README: fix links to HTML + add links to Haskell tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,11 @@
 name: Formal Ledger Specs
-on: [push, pull_request]
+on:
+  push:
+    branches:
+    - master
+  pull_request:
+    branches:
+    - master
 
 permissions:
   contents: write

--- a/README.md
+++ b/README.md
@@ -4,10 +4,10 @@ This repository contains the formal ledger specifications that are intended to e
 
 This repository currently contains two specifications---the work in progress specification for Cardano (up to and including the Conway era) and a small example that was produced for the Midnight project (but is unrelated to any actual Midnight code/features). Each specification is executable and contains some documentation in the form of a PDF document. They can be built by following the steps below.
 
-Project | Formal Specification | HTML Version |
---------|----------------------|--------------|
-Cardano | [Ledger Spec](https://input-output-hk.github.io/formal-ledger-specifications/pdfs/cardano-ledger.pdf) | [HTML](https://input-output-hk.github.io/formal-ledger-specifications/html/ledger/Ledger.PDF.html) |
-Midnight Example | [Ledger Spec](https://input-output-hk.github.io/formal-ledger-specifications/pdfs/midnight-example.pdf) | [HTML](https://input-output-hk.github.io/formal-ledger-specifications/html/midnight/MidnightExample.PDF.html) |
+Formal Specification | HTML Version | Haskell Tests |
+--------|----------------------|--------------|---------------|
+[Cardano Ledger](https://input-output-hk.github.io/formal-ledger-specifications/pdfs/cardano-ledger.pdf) | [Ledger.PDF](https://input-output-hk.github.io/formal-ledger-specifications/html/Ledger.PDF.html) | [UTXOW test](https://input-output-hk.github.io/formal-ledger-specifications/haskell/Ledger/test/UtxowSpec.hs) |
+[Midnight Example](https://input-output-hk.github.io/formal-ledger-specifications/pdfs/midnight-example.pdf) | [MidnightExample.PDF](https://input-output-hk.github.io/formal-ledger-specifications/html/MidnightExample.PDF.html) | [LEDGER test](https://input-output-hk.github.io/formal-ledger-specifications/haskell/MidnightExample/test/LedgerSpec.hs) |
 
 Note: the HTML versions of the specifications are interactive, but many modules currently contain LaTeX code which is used to generate the PDF. We intend to fix this eventually.
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This repository contains the formal ledger specifications that are intended to e
 This repository currently contains two specifications---the work in progress specification for Cardano (up to and including the Conway era) and a small example that was produced for the Midnight project (but is unrelated to any actual Midnight code/features). Each specification is executable and contains some documentation in the form of a PDF document. They can be built by following the steps below.
 
 Formal Specification | HTML Version | Haskell Tests |
---------|----------------------|--------------|---------------|
+----------------------|--------------|---------------|
 [Cardano Ledger](https://input-output-hk.github.io/formal-ledger-specifications/pdfs/cardano-ledger.pdf) | [Ledger.PDF](https://input-output-hk.github.io/formal-ledger-specifications/html/Ledger.PDF.html) | [UTXOW test](https://input-output-hk.github.io/formal-ledger-specifications/haskell/Ledger/test/UtxowSpec.hs) |
 [Midnight Example](https://input-output-hk.github.io/formal-ledger-specifications/pdfs/midnight-example.pdf) | [MidnightExample.PDF](https://input-output-hk.github.io/formal-ledger-specifications/html/MidnightExample.PDF.html) | [LEDGER test](https://input-output-hk.github.io/formal-ledger-specifications/haskell/MidnightExample/test/LedgerSpec.hs) |
 


### PR DESCRIPTION
- HTML links changed after #255, which this hotfix remedies.
- Also include links to generated Haskell.

