### PR TITLE
Renamed the cabal project of the executable spec

### DIFF
--- a/src/Ledger/hs-src/cardano-ledger-executable-spec.cabal
+++ b/src/Ledger/hs-src/cardano-ledger-executable-spec.cabal
@@ -1,5 +1,5 @@
 cabal-version:      2.4
-name:               cardano-ledger
+name:               cardano-ledger-executable-spec
 version:            0.1.0.0
 synopsis:
 
@@ -35,7 +35,7 @@ test-suite test
     other-modules:
         UtxowSpec
     build-depends:
-        cardano-ledger,
+        cardano-ledger-executable-spec,
         hspec,
         HUnit
     build-tool-depends: hspec-discover:hspec-discover

--- a/src/Makefile
+++ b/src/Makefile
@@ -58,7 +58,7 @@ endef
 HS_LEDGER=$(HS_DIR)/$(LEDGER)/$(MALONZO_DIR)/$(LEDGER)/Foreign/HSLedger.hs
 HS_MIDNIGHT=$(HS_DIR)/$(MIDNIGHT)/$(MALONZO_DIR)/$(MIDNIGHT)/HSLedger.hs
 $(HS_LEDGER): $(LEDGER)/Foreign/HSLedger.agda
-	$(call agdaToHs,cardano-ledger)
+	$(call agdaToHs,cardano-ledger-executable-spec)
 $(HS_MIDNIGHT): $(MIDNIGHT)/HSLedger.agda
 	$(call agdaToHs,midnight-example)
 


### PR DESCRIPTION
# Description

This PR renames the package of the Haskell executable spec to `cardano-ledger-executable-spec` to avoid name collision with the other `cardano-ledger` package.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] Code is formatted according to [CONTRIBUTING.md](https://github.com/input-output-hk/formal-ledger-specifications/blob/master/CONTRIBUTING.md)
- [x] Self-reviewed the diff
