### PR TITLE
Require `ppdWellFormed` to imply non-empty `updateGroups`

### DIFF
--- a/src/Ledger/Foreign/HSLedger.agda
+++ b/src/Ledger/Foreign/HSLedger.agda
@@ -156,11 +156,12 @@ HsGovParams : GovParams
 HsGovParams = record
   { Implementation
   ; ppUpd = let open PParamsDiff in λ where
-      .UpdateT          → ⊤
-      .updateGroups     → λ _ → ∅
-      .applyUpdate      → λ p _ → p
-      .ppdWellFormed    → λ _ → true
-      .ppdWellFormed⇒WF → λ _ _ x → x
+      .UpdateT                → ⊤
+      .updateGroups           → λ _ → ∅
+      .applyUpdate            → λ p _ → p
+      .ppdWellFormed          → λ _ → false
+      .ppdWellFormed⇒hasGroup → λ ()
+      .ppdWellFormed⇒WF       → λ _ _ x → x
   ; ppHashingScheme = it
   }
 

--- a/src/Ledger/PParams.lagda
+++ b/src/Ledger/PParams.lagda
@@ -135,9 +135,10 @@ record PParamsDiff : Set₁ where
         updateGroups : UpdateT → ℙ PParamGroup
         applyUpdate : PParams → UpdateT → PParams
         ppdWellFormed : UpdateT → Bool
-        ppdWellFormed⇒WF : ∀ {u} → ppdWellFormed u ≡ true → ∀ pp
-                         → paramsWellFormed pp
-                         → paramsWellFormed (applyUpdate pp u)
+        ppdWellFormed⇒hasGroup : ∀ {u} → ppdWellFormed u ≡ true → updateGroups u ≢ ∅
+        ppdWellFormed⇒WF       : ∀ {u} → ppdWellFormed u ≡ true → ∀ pp
+                               → paramsWellFormed pp
+                               → paramsWellFormed (applyUpdate pp u)
 
 record GovParams : Set₁ where
   field ppUpd : PParamsDiff


### PR DESCRIPTION
# Description

Closes #271. We should probably clean this thing up and expose it in the PDF soon (#273)

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] Code is formatted according to [CONTRIBUTING.md](https://github.com/input-output-hk/formal-ledger-specifications/blob/master/CONTRIBUTING.md)
- [x] Self-reviewed the diff
