### PR TITLE
Various cleanup items: Fig 13 -- hide Acnt

### DIFF
--- a/src/Ledger/Chain.lagda
+++ b/src/Ledger/Chain.lagda
@@ -44,6 +44,9 @@ record Block : Set where
         slot  : Slot
 \end{code}
 \caption{Definitions for the NEWEPOCH and CHAIN transition systems}
+The \AgdaRecord{Acnt} record has two fields, \AgdaField{treasury} and \AgdaField{reserves}, so
+the \AgdaBound{acnt} field in \AgdaRecord{NewEpochState} keeps track of the total assets that
+remain in treasury and reserves.
 \end{figure*}
 \begin{code}[hide]
 private variable

--- a/src/Ledger/PParams.lagda
+++ b/src/Ledger/PParams.lagda
@@ -21,15 +21,15 @@ module Ledger.PParams
   (es     : _) (open EpochStructure es)
   (ss     : ScriptStructure crypto es) (open ScriptStructure ss)
   where
+
+record Acnt : Set where
+  field treasury reserves : Coin
 \end{code}
 \begin{figure*}[h!]
 \begin{AgdaAlign}
 \begin{code}
 ProtVer : Set
 ProtVer = ℕ × ℕ
-
-record Acnt : Set where
-  field treasury reserves : Coin
 
 data PParamGroup : Set where
   NetworkGroup EconomicGroup TechnicalGroup GovernanceGroup : PParamGroup


### PR DESCRIPTION
# Description

This addresses an item of issue #288.

After it is defined, `Acnt` doesn't show up again until the "Blockchain Layer" section (currently Sec 15 on page 45), by which point readers will have long forgotten how it was defined.  This PR hides the definition of the `Acnt` record and then explains what it's for in prose near where it first appears in the pdf (in the "Blockchain Layer" section).

# Checklist

- [X] Commit sequence broadly makes sense and commits have useful messages
- [X] Code is formatted according to [CONTRIBUTING.md](https://github.com/input-output-hk/formal-ledger-specifications/blob/master/CONTRIBUTING.md)
- [X] Self-reviewed the diff
