### PR TITLE
[fix #36, #281] consistent use of decision procedures

### DIFF
--- a/src/Data/List/Relation/Binary/Sublist/Ext.agda
+++ b/src/Data/List/Relation/Binary/Sublist/Ext.agda
@@ -1,0 +1,10 @@
+{-# OPTIONS --safe #-}
+module Data.List.Relation.Binary.Sublist.Ext where
+
+open import Data.List.Relation.Binary.Sublist.Propositional public
+  using (_⊆_; []; _∷_; _∷ʳ_)
+open import Data.List using (List; []; _∷_)
+
+[]⊆ : ∀ {ℓ}{A : Set ℓ} {xs : List A} → [] ⊆ xs
+[]⊆ {xs = []} = []
+[]⊆ {xs = _ ∷ _} = _ ∷ʳ []⊆

--- a/src/Data/List/Relation/Unary/MOf.agda
+++ b/src/Data/List/Relation/Unary/MOf.agda
@@ -1,0 +1,49 @@
+{-# OPTIONS --safe #-}
+module Data.List.Relation.Unary.MOf where
+
+open import Level using (Level; _⊔_) renaming (suc to lsuc)
+open import Function using (_$_)
+
+open import Data.Empty using (⊥-elim)
+open import Data.List using (List; []; _∷_; length)
+open import Data.List.Relation.Unary.All using (All; []; _∷_)
+open import Data.Nat using (ℕ; zero; suc)
+open import Data.Nat.Properties using (suc-injective)
+
+open import Relation.Nullary using (Dec; yes; no)
+open import Relation.Nullary.Decidable using () renaming (map′ to mapDec)
+open import Relation.Unary using (Decidable; Pred)
+open import Relation.Binary.PropositionalEquality using (_≡_; refl; cong)
+
+open import Data.List.Relation.Binary.Sublist.Ext
+
+-- States that "m-of-n" elements of a n-element list satisfy a given predicate.
+data MOf {ℓ ℓ′}{A : Set ℓ} (m : ℕ) (P : Pred A ℓ′) (xs : List A) : Set (ℓ ⊔ ℓ′) where
+  mOf : ∀ ys
+    → m ≡ length ys
+    → ys ⊆ xs
+    → All P ys
+    → MOf m P xs
+
+module _ {ℓ ℓ′} {A : Set ℓ} {P : Pred A ℓ′} (P? : Decidable P) where
+  MOf? : ∀ m xs → Dec (MOf m P xs)
+  MOf? zero        _        = yes (mOf [] refl []⊆ [])
+  MOf? (suc _)     []       = no λ where (mOf (_ ∷ _) len≡ () _)
+  MOf? m@(suc m-1) (x ∷ xs)
+    with MOf? m xs
+  ... | yes (mOf _ len≡ ⊆xs        Pxs')
+      = yes (mOf _ len≡ (x ∷ʳ ⊆xs) Pxs')
+  ... | no ¬p
+    with P? x
+  ... | no ¬Px
+      = no λ where (mOf _ _    (refl ∷ _) (Px ∷ _)) → ¬Px Px
+                   (mOf _ len≡ (_ ∷ʳ ⊆xs) Pxs')     → ¬p (mOf _  len≡ ⊆xs Pxs')
+  ... | yes Px
+      = mapDec
+        (λ where (mOf _ len≡ ⊆xs Pxs')
+                  → mOf _ (cong suc len≡) (refl ∷ ⊆xs) (Px ∷ Pxs'))
+        (λ where (mOf _ len≡ (_ ∷  ⊆xs) (_ ∷ Pxs'))
+                  → mOf _ (suc-injective len≡) ⊆xs Pxs'
+                 (mOf _ len≡ (_ ∷ʳ ⊆xs) Pxs)
+                  → ⊥-elim $ ¬p (mOf _ len≡ ⊆xs Pxs))
+        (MOf? m-1 xs)

--- a/src/Interface/ToBool.agda
+++ b/src/Interface/ToBool.agda
@@ -1,0 +1,43 @@
+{-# OPTIONS --safe #-}
+module Interface.ToBool where
+
+open import Prelude
+
+private variable
+  ℓ ℓ′ : Level
+  X : Set ℓ; P : X → Set ℓ
+
+record ToBool′ (A : Set ℓ) (P 𝕋 𝔽 : A → Set ℓ′) : Set (ℓ ⊔ˡ ℓ′) where
+  field decide : (a : A) → ⦃ P a ⦄ → 𝕋 a ⊎ 𝔽 a
+
+  infix -10 _？_∶_
+  _？_∶_ : (a : A) ⦃ _ : P a ⦄ → ({𝕋 a} → X) → ({𝔽 a} → X) → X
+  (a ？ t ∶ f) with decide a
+  ... | inj₁ 𝕥 = t {𝕥}
+  ... | inj₂ 𝕗 = f {𝕗}
+
+  toBool : (a : A) ⦃ _ : P a ⦄ → Bool
+  toBool a = a ？ true ∶ false
+open ToBool′ ⦃...⦄ public
+
+ToBool : (A : Set ℓ) (𝕋 𝔽 : A → Set ℓ′) → Set (ℓ ⊔ˡ ℓ′)
+ToBool {ℓ} A = ToBool′ A (λ _ → ⊤↑)
+
+instance
+  ToBool-Bool : ToBool Bool (_≡ true) (_≡ false)
+  ToBool-Bool .decide = λ where
+    true  → inj₁ refl
+    false → inj₂ refl
+
+  ToBool-Dec : ToBool (Dec X) (const X) (const $ ¬ X)
+  ToBool-Dec .decide = λ where
+    (yes x) → inj₁ x
+    (no ¬x) → inj₂ ¬x
+
+  ToBool-Maybe : ToBool (Maybe X) (const X) (const ⊤↑)
+  ToBool-Maybe .decide = λ where
+    (just x) → inj₁ x
+    nothing  → inj₂ tt↑
+
+  ToBool-⁇ : ToBool′ (Set ℓ) _⁇ id ¬_
+  ToBool-⁇ .decide _ = decide dec

--- a/src/Interface/ToBool.agda
+++ b/src/Interface/ToBool.agda
@@ -10,14 +10,15 @@ private variable
 record ToBool′ (A : Set ℓ) (P 𝕋 𝔽 : A → Set ℓ′) : Set (ℓ ⊔ˡ ℓ′) where
   field decide : (a : A) → ⦃ P a ⦄ → 𝕋 a ⊎ 𝔽 a
 
-  infix -10 _？_∶_
-  _？_∶_ : (a : A) ⦃ _ : P a ⦄ → ({𝕋 a} → X) → ({𝔽 a} → X) → X
-  (a ？ t ∶ f) with decide a
-  ... | inj₁ 𝕥 = t {𝕥}
-  ... | inj₂ 𝕗 = f {𝕗}
+  infix -10 if_then_else_
+  if_then_else_ : (a : A) ⦃ _ : P a ⦄ → ({𝕋 a} → X) → ({𝔽 a} → X) → X
+  if a then t else f =
+    case decide a of λ where
+      (inj₁ 𝕥) → t {𝕥}
+      (inj₂ 𝕗) → f {𝕗}
 
   toBool : (a : A) ⦃ _ : P a ⦄ → Bool
-  toBool a = a ？ true ∶ false
+  toBool a = if a then true else false
 open ToBool′ ⦃...⦄ public
 
 ToBool : (A : Set ℓ) (𝕋 𝔽 : A → Set ℓ′) → Set (ℓ ⊔ˡ ℓ′)

--- a/src/Ledger/Address.lagda
+++ b/src/Ledger/Address.lagda
@@ -91,22 +91,22 @@ payCred (inj₂ record {pay = pay}) = pay
 netId (inj₁ record {net = net}) = net
 netId (inj₂ record {net = net}) = net
 
-isVKey? : ∀ c → Dec (isVKey c)
-isVKey? (inj₁ h) = yes (VKeyisVKey h)
-isVKey? (inj₂ _) = no  (λ ())
+instance
+  Dec-isVKey : isVKey ⁇¹
+  Dec-isVKey {x = c} .dec with c
+  ... | inj₁ h = yes (VKeyisVKey h)
+  ... | inj₂ _ = no  λ ()
 
-isVKeyAddr? : ∀ a → Dec (isVKeyAddr a)
-isVKeyAddr? = isVKey? ∘ payCred
+  Dec-isScript : isScript ⁇¹
+  Dec-isScript {x = x} .dec with x
+  ... | inj₁ _ = no λ ()
+  ... | inj₂ y = yes (SHisScript y)
 
-isScript? : ∀ c → Dec (isScript c)
-isScript? (inj₁ _) = no λ ()
-isScript? (inj₂ y) = yes (SHisScript y)
-
-isScriptAddr? : ∀ a → Dec (isScriptAddr a)
-isScriptAddr? = isScript? ∘ payCred
-
-isScriptRwdAddr? : ∀ a → Dec (isScriptRwdAddr a)
-isScriptRwdAddr? = isScript? ∘ RwdAddr.stake
+_ = isVKey ⁇¹ ∋ it
+_ = isVKeyAddr ⁇¹ ∋ it
+_ = isScript ⁇¹ ∋ it
+_ = isScriptAddr ⁇¹ ∋ it
+_ = isScriptRwdAddr ⁇¹ ∋ it
 
 getScriptHash : ∀ a → isScriptAddr a → ScriptHash
 getScriptHash (inj₁ _) (SHisScript sh) = sh
@@ -114,7 +114,8 @@ getScriptHash (inj₂ _) (SHisScript sh) = sh
 
 instance abstract
   unquoteDecl DecEq-BaseAddr DecEq-BootstrapAddr DecEq-RwdAddr = derive-DecEq
-    ((quote BaseAddr     , DecEq-BaseAddr) ∷
-    (quote BootstrapAddr , DecEq-BootstrapAddr) ∷
-    (quote RwdAddr       , DecEq-RwdAddr) ∷ [])
+    ( (quote BaseAddr      , DecEq-BaseAddr)
+    ∷ (quote BootstrapAddr , DecEq-BootstrapAddr)
+    ∷ (quote RwdAddr       , DecEq-RwdAddr)
+    ∷ [] )
 \end{code}

--- a/src/Ledger/Gov.lagda
+++ b/src/Ledger/Gov.lagda
@@ -54,19 +54,13 @@ private variable
   a : GovAction
   prev : NeedsHash a
   k : ℕ
-
--- could be implemented using a function of type:
---   ∀ {a} {A : Set a} → (A → Maybe A) → List A → List A
-modifyMatch : ∀ {a} {A : Set a} → (A → Bool) → (A → A) → List A → List A
-modifyMatch P f = map (λ x → if P x then f x else x)
 \end{code}
 \emph{Functions used in the GOV rules}
 \begin{code}
 addVote : GovState → GovActionID → GovRole → Credential → Vote → GovState
-addVote s aid r kh v =
-  modifyMatch
-    (λ (x , _) → aid ≡ᵇ x)
-    (λ (gid , s') → gid , record s' { votes = insert (votes s') (r , kh) v }) s
+addVote s aid r kh v = map modifyVotes s
+  where modifyVotes = λ (gid , s') → gid , record s'
+          { votes = gid ≡ aid ？ insert (votes s') (r , kh) v ∶ votes s'}
 
 addAction : GovState
           → Epoch → GovActionID → RwdAddr → (a : GovAction) → NeedsHash a

--- a/src/Ledger/Gov.lagda
+++ b/src/Ledger/Gov.lagda
@@ -60,7 +60,7 @@ private variable
 addVote : GovState → GovActionID → GovRole → Credential → Vote → GovState
 addVote s aid r kh v = map modifyVotes s
   where modifyVotes = λ (gid , s') → gid , record s'
-          { votes = gid ≡ aid ？ insert (votes s') (r , kh) v ∶ votes s'}
+          { votes = if gid ≡ aid then insert (votes s') (r , kh) v else votes s'}
 
 addAction : GovState
           → Epoch → GovActionID → RwdAddr → (a : GovAction) → NeedsHash a

--- a/src/Ledger/PPUp.lagda
+++ b/src/Ledger/PPUp.lagda
@@ -3,14 +3,10 @@
 \begin{code}[hide]
 {-# OPTIONS --safe #-}
 
-open import Algebra
-open import Algebra.Literals
-import Data.Unit.Polymorphic
 open import Agda.Builtin.FromNat
-import Data.Nat as ℕ
-open import Data.Nat.Properties using (m+1+n≢m)
-open import Data.Nat.Literals
-open import Data.Product.Properties
+open import Algebra; open import Algebra.Literals
+import Data.Product.Properties as ×
+import Data.Nat as ℕ; import Data.Nat.Properties as ℕ; import Data.Nat.Literals as ℕ
 
 open import Ledger.Prelude hiding (_*_)
 open import Ledger.Transaction
@@ -22,9 +18,7 @@ open Semiring-Lit Slotʳ
 
 private variable m n : ℕ
 
-instance
-  _ = Data.Nat.Literals.number
-  _ = Data.Unit.Polymorphic.tt
+instance _ = ℕ.number
 \end{code}
 \begin{figure*}[h]
 \begin{code}
@@ -66,7 +60,7 @@ instance
                                            canFollowMinor → ¬p₁ refl
   ... | no ¬p    | yes refl = yes canFollowMinor
   ... | yes refl | no ¬p    = yes canFollowMajor
-  ... | yes refl | yes p    = ⊥-elim $ m+1+n≢m m $ ×-≡,≡←≡ p .proj₁
+  ... | yes refl | yes p    = ⊥-elim $ ℕ.m+1+n≢m m $ ×.×-≡,≡←≡ p .proj₁
 
 data _⊢_⇀⦇_,PPUP⦈_ : PPUpdateEnv → PPUpdateState → Maybe Update → PPUpdateState → Set where
 \end{code}

--- a/src/Ledger/PPUp/Properties.agda
+++ b/src/Ledger/PPUp/Properties.agda
@@ -13,7 +13,6 @@ private
   open import Agda.Builtin.FromNat
   open import Algebra; open Semiring Slotʳ hiding (refl)
   open import Algebra.Literals; open Semiring-Lit Slotʳ
-  import Data.Unit.Polymorphic as Poly⊤; instance _ = Poly⊤.tt
 
   Current-Property : PPUpdateEnv → Update → Set
   Current-Property Γ (pup , e) = let open PPUpdateEnv Γ in

--- a/src/Ledger/Prelude.agda
+++ b/src/Ledger/Prelude.agda
@@ -17,6 +17,7 @@ open import Ledger.Prelude.Base public
 
 open import Data.Product.Ext public
 open import Data.Maybe.Properties.Ext public
+open import Interface.ToBool public
 open import Interface.HasAdd public
 open import Interface.HasAdd.Instance public
 open import Interface.HasSubtract public

--- a/src/Ledger/ScriptValidation.agda
+++ b/src/Ledger/ScriptValidation.agda
@@ -114,24 +114,27 @@ UTxOSH  = TxIn ⇀ (TxOut × ScriptHash)
 
 scriptOutWithHash : TxIn → TxOut → Maybe (TxOut × ScriptHash)
 scriptOutWithHash txin (addr , r) =
-  isScriptAddr addr
-    ？ (λ {p} → just ((addr , r) , getScriptHash addr p))
-    ∶ nothing
+  if isScriptAddr addr then
+    (λ {p} → just ((addr , r) , getScriptHash addr p))
+  else
+    nothing
 
 scriptOutsWithHash : UTxO → UTxOSH
 scriptOutsWithHash utxo = mapMaybeWithKeyᵐ scriptOutWithHash utxo
 
 spendScripts : TxIn → UTxOSH → Maybe (ScriptPurpose × ScriptHash)
 spendScripts txin utxo =
-  txin ∈ dom utxo
-    ？ (λ {p} → just (Spend txin , proj₂ (lookupᵐ utxo txin)))
-    ∶ nothing
+  if txin ∈ dom utxo then
+    (λ {p} → just (Spend txin , proj₂ (lookupᵐ utxo txin)))
+  else
+    nothing
 
 rwdScripts : RwdAddr → Maybe (ScriptPurpose × ScriptHash)
 rwdScripts a =
-  isScriptRwdAddr a
-    ？ (λ where {SHisScript sh} → just (Rwrd a , sh))
-    ∶ nothing
+  if isScriptRwdAddr a then
+    (λ where {SHisScript sh} → just (Rwrd a , sh))
+  else
+    nothing
 
 certScripts : DCert → Maybe (ScriptPurpose × ScriptHash)
 certScripts d with ¿ DelegateOrDeReg d ¿

--- a/src/Ledger/Set/Theory.agda
+++ b/src/Ledger/Set/Theory.agda
@@ -16,7 +16,7 @@ abstract
   List-Modelᵈ = L.List-Modelᵈ
 
 open Theoryᵈ List-Modelᵈ public
-  renaming (Set to ℙ_; filter to filterˢ; map to mapˢ)
+  renaming (Set to ℙ_; filter to filterˢ?; map to mapˢ)
   hiding (_∈_; _∉_)
 
 open import Interface.IsSet th public
@@ -24,8 +24,8 @@ open import Interface.IsSet th public
 abstract
   open import Axiom.Set.Properties th using (card-≡ᵉ)
 
-  to-sp : {A : Set} {P : A → Set} → Decidable¹ P → specProperty P
-  to-sp = id
+  to-sp : {A : Set} (P : A → Set) → ⦃ P ⁇¹ ⦄ → specProperty P
+  to-sp _ = dec¹
 
   finiteness : ∀ {A} (X : Theory.Set th A) → finite X
   finiteness = Theoryᶠ.finiteness List-Modelᶠ
@@ -54,7 +54,8 @@ open import Axiom.Set.Rel th public
   hiding (_∣'_; _↾'_; dom; range)
 
 open import Axiom.Set.Map th public
-  renaming (Map to infixr 1 _⇀_)
+  renaming ( Map to infixr 1 _⇀_
+           ; filterᵐ to filterᵐ?; filterKeys to filterKeys?; _↾'_ to _↾'?_ )
 
 open import Axiom.Set.TotalMap th public
 open import Axiom.Set.TotalMapOn th
@@ -93,14 +94,22 @@ module Properties where
   module _ {A : Set} ⦃ _ : DecEq A ⦄ where
     open Intersectionᵖ {A} ∈-sp public
 
-_ᶠᵐ : {A B : Set} → A ⇀ B → FinMap A B
+private variable A B : Set
+
+_ᶠᵐ : A ⇀ B → FinMap A B
 (R , uniq) ᶠᵐ = (R , uniq , finiteness _)
 
-_ᶠˢ : {A : Set} → ℙ A → FinSet A
+_ᶠˢ : ℙ A → FinSet A
 X ᶠˢ = X , finiteness _
 
-filterᵐ? : ∀ {A B} {P : A × B → Set} → (∀ x → Dec (P x)) → A ⇀ B → A ⇀ B
-filterᵐ? P? = filterᵐ (to-sp P?)
+filterˢ : (P : A → Set) ⦃ _ : P ⁇¹ ⦄ → ℙ A → ℙ A
+filterˢ P = filterˢ? (to-sp P)
 
-filterᵐᵇ : ∀ {A B} → (A × B → Bool) → A ⇀ B → A ⇀ B
-filterᵐᵇ P = filterᵐ? (λ x → P x ≟ true)
+filterᵐ : (P : A × B → Set) ⦃ _ : P ⁇¹ ⦄ → (A ⇀ B) → (A ⇀ B)
+filterᵐ P = filterᵐ? (to-sp P)
+
+filterKeys : (P : A → Set) ⦃ _ : P ⁇¹ ⦄ → (A ⇀ B) → (A ⇀ B)
+filterKeys P = filterKeys? (to-sp P)
+
+_↾'_ : A ⇀ B → (P : B → Set) ⦃ _ : P ⁇¹ ⦄ → A ⇀ B
+s ↾' P = s ↾'? to-sp P

--- a/src/Ledger/Transaction.lagda
+++ b/src/Ledger/Transaction.lagda
@@ -174,9 +174,10 @@ the transaction body are:
 
   lookupScriptHash : ScriptHash → Tx → Maybe Script
   lookupScriptHash sh tx =
-    sh ∈ mapˢ proj₁ (m ˢ)
-      ？ just (lookupᵐ m sh)
-      ∶ nothing
+    if sh ∈ mapˢ proj₁ (m ˢ) then
+      just (lookupᵐ m sh)
+    else
+      nothing
     where m = setToHashMap $ tx .Tx.wits .TxWitnesses.scripts
 
   isP2Script : Script → Bool

--- a/src/Ledger/Transaction.lagda
+++ b/src/Ledger/Transaction.lagda
@@ -164,21 +164,19 @@ the transaction body are:
   getValue (_ , v , _) = v
 
   txinsVKey : ℙ TxIn → UTxO → ℙ TxIn
-  txinsVKey txins utxo = txins ∩ dom (utxo ↾' to-sp (isVKeyAddr? ∘ proj₁))
+  txinsVKey txins utxo = txins ∩ dom (utxo ↾' (isVKeyAddr ∘ proj₁))
 
   scriptOuts : UTxO → UTxO
-  scriptOuts utxo = filterᵐ (sp-∘ (to-sp isScriptAddr?)
-                             λ { (_ , addr , _) → addr}) utxo
+  scriptOuts utxo = filterᵐ (λ (_ , addr , _) → isScriptAddr addr) utxo
 
   txinsScript : ℙ TxIn → UTxO → ℙ TxIn
   txinsScript txins utxo = txins ∩ dom (proj₁ (scriptOuts utxo))
 
   lookupScriptHash : ScriptHash → Tx → Maybe Script
   lookupScriptHash sh tx =
-    ifᵈ sh ∈ mapˢ proj₁ (m ˢ) then
-      just $ lookupᵐ m sh
-    else
-      nothing
+    sh ∈ mapˢ proj₁ (m ˢ)
+      ？ just (lookupᵐ m sh)
+      ∶ nothing
     where m = setToHashMap $ tx .Tx.wits .TxWitnesses.scripts
 
   isP2Script : Script → Bool

--- a/src/Ledger/Utxo.lagda
+++ b/src/Ledger/Utxo.lagda
@@ -34,11 +34,12 @@ instance
 
 isPhaseTwoScriptAddress : Tx → Addr → Bool
 isPhaseTwoScriptAddress tx a =
-  isScriptAddr a
-    ？ (λ {p} → lookupScriptHash (getScriptHash a p) tx
-                 ？ (λ {s} → isP2Script s)
-                 ∶ false)
-    ∶ false
+  if isScriptAddr a then
+    (λ {p} → if lookupScriptHash (getScriptHash a p) tx
+                 then (λ {s} → isP2Script s)
+                 else false)
+  else
+    false
 
 totExUnits : Tx → ExUnits
 totExUnits tx = indexedSumᵐ ⦃ ExUnit-CommutativeMonoid ⦄ (λ x → x .proj₂ .proj₂) (tx .wits .txrdmrs ᶠᵐ)
@@ -88,9 +89,10 @@ module _ (let open Tx; open TxBody) where
 
   isAdaOnlyᵇ : Value → Bool
   isAdaOnlyᵇ v =
-    (policies v) ≡ᵉ coinPolicies
-      ？ true
-      ∶ false
+    if (policies v) ≡ᵉ coinPolicies then
+      true
+    else
+      false
 
   minfee : PParams → Tx → Coin
   minfee pp tx  = pp .a * tx .body .txsize + pp .b

--- a/src/Ledger/Utxow.lagda
+++ b/src/Ledger/Utxow.lagda
@@ -30,8 +30,8 @@ credsNeeded p utxo txb
   ∪  mapˢ (λ c → (Cert c , cwitness c)) (fromList txcerts)
   ∪  mapˢ (λ x → (Mint x , inj₂ x)) (policies mint)
   ∪  mapˢ (λ v → (Vote v , GovVote.credential v)) (fromList txvote)
-  ∪  (p ？ (λ {sh} → mapˢ (λ p → (Propose p , inj₂ sh)) (fromList txprop))
-        ∶ ∅)
+  ∪  (if p then (λ {sh} → mapˢ (λ p → (Propose p , inj₂ sh)) (fromList txprop))
+      else ∅)
   where open TxBody txb
 
 witsVKeyNeeded : Maybe ScriptHash → UTxO → TxBody → ℙ KeyHash

--- a/src/Ledger/Utxow.lagda
+++ b/src/Ledger/Utxow.lagda
@@ -30,9 +30,8 @@ credsNeeded p utxo txb
   ∪  mapˢ (λ c → (Cert c , cwitness c)) (fromList txcerts)
   ∪  mapˢ (λ x → (Mint x , inj₂ x)) (policies mint)
   ∪  mapˢ (λ v → (Vote v , GovVote.credential v)) (fromList txvote)
-  ∪  (case p of λ where
-       (just sh)  → mapˢ (λ p → (Propose p , inj₂ sh)) (fromList txprop)
-       nothing    → ∅)
+  ∪  (p ？ (λ {sh} → mapˢ (λ p → (Propose p , inj₂ sh)) (fromList txprop))
+        ∶ ∅)
   where open TxBody txb
 
 witsVKeyNeeded : Maybe ScriptHash → UTxO → TxBody → ℙ KeyHash

--- a/src/Prelude.agda
+++ b/src/Prelude.agda
@@ -10,7 +10,7 @@ open import Level public
 open import Function public
 
 open import Data.Bool public
-  hiding (_≟_; _≤_; _≤?_; _<_; _<?_)
+  hiding (_≟_; _≤_; _≤?_; _<_; _<?_; if_then_else_)
 open import Data.Empty public
 open import Data.List public
   hiding (align; alignWith; fromMaybe; map; zip; zipWith)

--- a/src/Prelude.agda
+++ b/src/Prelude.agda
@@ -19,7 +19,11 @@ open import Data.List.Membership.Propositional public
 open import Data.Maybe public
   hiding (_>>=_; align; alignWith; ap; fromMaybe; map; zip; zipWith)
 open import Data.Unit public
-  hiding (_≟_)
+  using (⊤; tt)
+open import Data.Unit.Polymorphic public
+  using ()
+  renaming (⊤ to ⊤↑; tt to tt↑)
+instance Poly-tt = tt↑
 open import Data.Sum public
   hiding (assocʳ; assocˡ; map; map₁; map₂; reduce; swap)
 open import Data.Product public

--- a/src/Reflection/Ext.agda
+++ b/src/Reflection/Ext.agda
@@ -4,6 +4,7 @@ module Reflection.Ext where
 open import Prelude
 open import PreludeMeta
 open import Data.Nat using (_≤ᵇ_)
+open import Data.Bool using (if_then_else_)
 
 open import Class.Core using (Type↑)
 

--- a/src/Tactic/DeriveComp.agda
+++ b/src/Tactic/DeriveComp.agda
@@ -104,6 +104,7 @@ curryPredProof (suc (suc (suc k))) t =
 computeFunctionBody : Term → Term → Term
 computeFunctionBody g result =
   quote if_then_else_ ∙⟦ g ∣ quote just ◆⟦ result ⟧ ∣ quote nothing ◆ ⟧
+  where open import Data.Bool
 
 generateFunctionClause : (List Term → Term) → STSConstr → Clause
 generateFunctionClause genPred c = let open STSConstr c in

--- a/src/latex/agda-latex-macros.sty
+++ b/src/latex/agda-latex-macros.sty
@@ -281,15 +281,13 @@
 \newcommand{\Info}{\AgdaInductiveConstructor{Info}\xspace}
 \newcommand{\inl}{\AgdaInductiveConstructor{inj₁}\xspace}
 \newcommand{\instance}{\AgdaKeyword{instance}\xspace}
-\newcommand{\isCC}{\AgdaFunction{isCC}\xspace}
-\newcommand{\isCCProp}{\AgdaFunction{isCCProp}\xspace}
-\newcommand{\isDRep}{\AgdaFunction{isDRep}\xspace}
-\newcommand{\isDRepProp}{\AgdaFunction{isDRepProp}\xspace}
+\newcommand{\govRole}{\AgdaFunction{govRole}\xspace}
+\newcommand{\IsCC}{\AgdaFunction{IsCC}\xspace}
+\newcommand{\IsDRep}{\AgdaFunction{IsDRep}\xspace}
+\newcommand{\IsSPO}{\AgdaFunction{IsSPO}\xspace}
 \newcommand{\isHashableSet}{\AgdaRecord{isHashableSet}\xspace}
 \newcommand{\isVKey}{\AgdaDatatype{isVKey}\xspace}
 \newcommand{\isScript}{\AgdaDatatype{isScript}\xspace}
-\newcommand{\isSPO}{\AgdaFunction{isSPO}\xspace}
-\newcommand{\isSPOProp}{\AgdaFunction{isSPOProp}\xspace}
 
 \newcommand{\just}{\AgdaInductiveConstructor{just}\xspace}
 


### PR DESCRIPTION

*Depends on #301*

---

- Introduces generalised branching on boolean-like things such as
  Bool/Maybe/Dec in `Interface.ToBool` and replaces all branching
variations with this approach uniformly.

- [Gov] More standard predicates isCC/isDRep/isSPO as inductive datatypes

- [Set/Map] hide decision procedures from the user-facing API

- [Script] Significant refactoring of `Ledger.Script.evalTimelock`:
  + Heal boolean blindness by replacing function (... -> Bool) with the
    proper decision procedure for `evalTimelock`
  + Extra lemma for List.Sublist in `Data.List.Relation.Binary.Sublist.Ext`
  + Factored out m-of-n predicate (+ its dec.proc.) in `Data.List.Relation.Unary.MOf`

- [Prelude] introduce polymorphic unit as ⊤↑/tt↑


