### PR TITLE
CI: record typechecking times

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -62,17 +62,18 @@ jobs:
       - name: Build formalLedger
         id: formalLedger
         run: |
-          d=$(nix-build -A formalLedger)
+          mkdir -p outputs
+          d=$(nix-build -A formalLedger -j1 -o outputs/formalLedger)
           dRet=$(echo "$d" | tr '\n' ' ')
           closure=$(nix-store --query --requisites --include-outputs $dRet)
           cRet=$(echo "$closure" | tr '\n' ' ')
           echo "derivation=$dRet" >> $GITHUB_OUTPUT
           echo "closure=$cRet" >> $GITHUB_OUTPUT
+          rsync -r --include={'**/*.time'} outputs/formalLedger*/* docs/
 
       - name: Build ledger
         id: ledger
         run: |
-          mkdir -p outputs
           d=$(nix-build -A ledger -j1 -o outputs/ledger)
           dRet=$(echo "$d" | tr '\n' ' ')
           closure=$(nix-store --query --requisites --include-outputs $dRet)
@@ -128,6 +129,13 @@ jobs:
         with:
           name: PDF specs
           path: docs/pdfs/*.pdf
+
+      - name: Upload typechecking times
+        if: github.event_name == 'pull_request'
+        uses: actions/upload-artifact@v3
+        with:
+          name: Typechecking durations
+          path: docs/*.time
 
       - name: Generate main website
         if: github.ref == 'refs/heads/master'

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ src/latex/MidnightExample/*
 src/latex/bclogo.sty
 
 dist/
+
+*.time

--- a/default.nix
+++ b/default.nix
@@ -72,10 +72,13 @@ rec {
     src = ./src;
     meta = { };
     buildInputs = deps;
+    buildPhase = ''
+      bash typeCheck.sh
+    '';
     postInstall = ''
-      cp -r latex/ Makefile $out
+      cp -r latex/ Makefile typecheck.time $out
       sh checkTypeChecked.sh
-      '';
+    '';
     extraExtensions = [ "hs" "cabal" ];
   };
 

--- a/src/checkTypeChecked.sh
+++ b/src/checkTypeChecked.sh
@@ -1,26 +1,11 @@
 #!/bin/sh
 
-checkTypeChecked()
-{
-res=0
-
-for file in $(find . -name '*.agda')
-do
-    if ! [ -f "${file%.agda}.agdai" ]; then
-        echo "${file%.agda}.agdai doesn't exist"
-        res=1
-    fi
+echo "Checking that all Agda files have been typechecked..."
+for agdaFn in $(find . -name '*.*agda'); do
+  agdaiFn="${agdaFn%.*agda}.agdai"
+  if ! [ -f $agdaiFn ]; then
+    echo "        FAIL: $agdaiFn doesn't exist"
+    exit 1
+  fi
 done
-
-for file in $(find . -name '*.lagda')
-do
-    if ! [ -f "${file%.lagda}.agdai" ]; then
-        echo "${file%.lagda}.agdai doesn't exist"
-        res=1
-    fi
-done
-
-return $res
-}
-
-checkTypeChecked
+echo "        PASS: all Agda files have been typechecked"

--- a/src/typeCheck.sh
+++ b/src/typeCheck.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+shopt -s globstar
+
+out="${1:-typecheck.time}"
+touch $out
+
+function displayTimeDiff {
+  diff=$(($1 - $2))
+  echo "$(($diff / 60))m$(($diff % 60))s"
+}
+
+# Typecheck Agda files (if not already checked)
+sh ./checkTypeChecked.sh
+if [ "$?" != 0 ]; then
+  echo "Not all Agda files have been typechecked, checking from scratch..."
+  start=$(date +%s)
+  echo "  start: $start"
+  echo $AGDA
+  ${AGDA:-agda} Everything.agda
+  end=$(date +%s)
+  echo "  end: $end"
+  total="$(displayTimeDiff $end $start)"
+  echo "  TOTAL: ${total}"
+fi
+# Record relative durations of each module
+echo "Writing individual times to: $out..."
+noStartMsg='Agda files have already been typechecked; start counting after the first module'
+echo "TOTAL: ${total:-??? ($noStartMsg)}" > $out
+is=$(ls -hltr --full-time **/*.agdai | awk '{
+  printf("%s>%s %s\n", $9, $6, $7)
+}')
+cur=$start
+while IFS= read -r i; do
+  agdaiFn=$(echo $i | cut -d'>' -f1)
+  tv=$(echo "$i" | cut -d'>' -f2 | tr '%' '\n')
+  t=$(date "+%s" -d "$tv")
+  echo "${agdaiFn%.agdai}: $(displayTimeDiff $t ${cur:-t})" >> $out
+  cur=$t
+done <<< "$is"%


### PR DESCRIPTION
This PR introduces a `typeCheck.sh` script that measure the total time of typechecking `Everything.agda` and then records individual module times under `typecheck.time` (by looking at the modification dates of `.agdai` files).

That way, we can check that our changes do not terribly slow down typechecking by looking at the generated file in the `gh-pages` branch (or the CI artifact attached to the current PR).

Moreover, we can run the script through our whole (git) history to discover previously introduced regressions, but that can be done independently offline.

@WhatisRT has mentioned that the [ledger team](https://github.com/input-output-hk/cardano-ledger) actually creates nice graphs from such time durations, which we should definitely investigate to track typechecking performance across history. (@WhatisRT  could you provide more concrete details/links and open a new issue to track this feature?)