### PR TITLE
CI: remove `free-disk-space`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,17 +15,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - run: |
-          sudo apt-get update
-      - name: Free disk space
-        uses: jlumbroso/free-disk-space@main
-        with:
-          android: true
-          dotnet: true
-          haskell: false
-          large-packages: false
-          docker-images: true
-          swap-storage: true
+      - run: sudo apt-get update
 
       - uses: actions/checkout@v3
 


### PR DESCRIPTION
Since we are importing IOG's nix cache, there is no longer need for that much storage to warranty a call to action `free-disk-size` which delays a CI run by a couple of minutes.
