### PR TITLE
Explain symbols

### DIFF
--- a/src/Ledger/Address.lagda
+++ b/src/Ledger/Address.lagda
@@ -12,7 +12,7 @@ module Ledger.Address (
 
 We define credentials and various types of addresses here. A
 credential contains a hash, either of a verifying (public) key
-(\isVKey) or of a (\isScript).
+(\isVKey) or of a (\isScript).  (The \coproduct symbol denotes disjoint union.)
 
 \begin{figure*}[h!]
 \begin{AgdaAlign}

--- a/src/Ledger/Chain.lagda
+++ b/src/Ledger/Chain.lagda
@@ -122,9 +122,9 @@ data _⊢_⇀⦇_,NEWEPOCH⦈_ : NewEpochEnv → NewEpochState → Epoch → New
     ────────────────────────────────
     Γ ⊢ nes ⇀⦇ e ,NEWEPOCH⦈ nes
 \end{code}
-\caption{NEWEPOCH transition system}
+\caption{NEWEPOCH transition system\protect\footnotemark}
 \end{figure*}
-
+\footnotetext{The expression \AgdaBound{m}~\AgdaFunction{⁻¹}~\AgdaBound{B} denotes the inverse image of the set \AgdaBound{B} under the map \AgdaBound{m}.}
 \begin{code}[hide]
 -- TODO: do we still need this for anything?
 maybePurpose : DepositPurpose → (DepositPurpose × Credential) → Coin → Maybe Coin

--- a/src/Ledger/Gov.lagda
+++ b/src/Ledger/Gov.lagda
@@ -74,9 +74,10 @@ addAction s e aid addr a prev = s ∷ʳ (aid , record
   { votes = ∅ᵐ ; returnAddr = addr ; expiresIn = e ; action = a ; prevAction = prev })
 
 \end{code}
-\caption{Types and functions used in the GOV transition system}
+\caption{Types and functions used in the GOV transition system\protect\footnotemark}
 \label{defs:gov-defs}
 \end{figure*}
+\footnotetext{\AgdaBound{l}~\AgdaFunction{∷ʳ}~\AgdaBound{x} appends element \AgdaBound{x} to list \AgdaBound{l}.}
 \begin{figure*}
 \begin{code}[hide]
 data _⊢_⇀⦇_,GOV'⦈_ where

--- a/src/Ledger/Utxo.lagda
+++ b/src/Ledger/Utxo.lagda
@@ -165,9 +165,10 @@ feesOK pp tx utxo = minfee pp tx ≤ᵇ txfee
     collateralRange  = range    (utxo ∣ collateral)
     bal              = balance  (utxo ∣ collateral)
 \end{code}
-\caption{Functions used in UTxO rules, continued}
+\caption{Functions used in UTxO rules, continued\protect\footnotemark}
 \label{fig:functions:utxo2}
 \end{figure*}
+\footnotetext{\AgdaBound{m}~\AgdaFunction{∣}~\AgdaBound{X} denotes the restriction of the map \AgdaBound{m} to the subset \AgdaBound{X} of its domain.}
 \begin{code}[hide]
 instance
   unquoteDecl DecEq-DepositPurpose = derive-DecEq

--- a/src/latex/agda-latex-macros.sty
+++ b/src/latex/agda-latex-macros.sty
@@ -178,6 +178,7 @@
 \newcommand{\constMap}{\AgdaFunction{constMap}\xspace}
 \newcommand{\constitution}{\AgdaField{constitution}\xspace}
 \newcommand{\constructor}{\AgdaKeyword{constructor}\xspace}
+\newcommand{\coproduct}{\AgdaDatatype{⊎}\xspace}
 \newcommand{\credVoter}{\AgdaInductiveConstructor{credVoter}\xspace}
 \newcommand{\credential}{\AgdaField{credential}\xspace}
 \newcommand{\cupsupermsuperl}{\AgdaFunction{∪ˡ}\xspace}


### PR DESCRIPTION
# Description

Addresses the following items of issue #282:

- [x] `_⊎_` : sentence (in `Address.lagda`) before first figure in which it appears
- [x] `_∷ʳ_` : footnote (in `Gov.lagda`) to caption of figure in which it appears.
- [x] `_⁻¹` : footnote (in `Chain.lagda`) to caption of first figure in which it appears.
- [x] `_∣_` : footnote (in `Utxo.lagda`) to caption of first figure in which it appears.

# Checklist

- [X] Commit sequence broadly makes sense and commits have useful messages
- [X] Code is formatted according to [CONTRIBUTING.md](https://github.com/input-output-hk/formal-ledger-specifications/blob/master/CONTRIBUTING.md)
- [X] Self-reviewed the diff
