### PR TITLE
Rename `sucᵉ` → `_+ 1`

### DIFF
--- a/src/Interface/HasAdd.agda
+++ b/src/Interface/HasAdd.agda
@@ -1,8 +1,0 @@
-{-# OPTIONS --safe --cubical-compatible #-}
-module Interface.HasAdd where
-
-record HasAdd (A : Set) : Set where
-  infixl 7 _+_
-  field _+_ : A → A → A
-
-open HasAdd ⦃ ... ⦄ public

--- a/src/Interface/HasAggregate.agda
+++ b/src/Interface/HasAggregate.agda
@@ -1,0 +1,9 @@
+{-# OPTIONS --safe --cubical-compatible #-}
+
+module Interface.HasAggregate where
+
+record HasAggregate (A : Set){B : Set} : Set where
+  infixl 7 _+_
+  field _+_ : A → B → A
+
+open HasAggregate ⦃ ... ⦄ public

--- a/src/Interface/HasAggregate/Instance.agda
+++ b/src/Interface/HasAggregate/Instance.agda
@@ -1,13 +1,14 @@
 {-# OPTIONS --safe #-}
-module Interface.HasAdd.Instance where
 
-open import Interface.HasAdd
+module Interface.HasAggregate.Instance where
+
+open import Interface.HasAggregate
 open import Data.Integer as ℤ using (ℤ)
 open import Data.Nat     as ℕ using (ℕ)
 
 instance
-  addInt : HasAdd ℤ
+  addInt : HasAggregate ℤ
   addInt ._+_ = ℤ._+_
 
-  addNat : HasAdd ℕ
+  addNat : HasAggregate ℕ
   addNat ._+_ = ℕ._+_

--- a/src/Ledger/Chain.lagda
+++ b/src/Ledger/Chain.lagda
@@ -99,7 +99,7 @@ data _⊢_⇀⦇_,NEWEPOCH⦈_ : NewEpochEnv → NewEpochState → Epoch → New
         dState = record dState
           { rewards = rewards ∪⁺ refunds };
         gState = if not (null govSt') then gState' else record gState'
-          { dreps = mapValues sucᵉ dreps }
+          { dreps = mapValues (_+ 1) dreps }
         }
       utxoSt' = record utxoSt
         { fees = 0
@@ -111,14 +111,14 @@ data _⊢_⇀⦇_,NEWEPOCH⦈_ : NewEpochEnv → NewEpochState → Epoch → New
       acnt' = record acnt
         { treasury = treasury + fees + getCoin unclaimed + donations ∸ totWithdrawals }
     in
-    e ≡ sucᵉ lastEpoch
+    e ≡ lastEpoch + 1
     → record { currentEpoch = e ; treasury = treasury ; GState gState ; NewEpochEnv Γ }
         ⊢ ⟦ es , ∅ , false ⟧ʳ ⇀⦇ govSt' ,RATIFY⦈ fut'
     ────────────────────────────────
     Γ ⊢ nes ⇀⦇ e ,NEWEPOCH⦈ ⟦ e , acnt' , ls' , es , fut' ⟧ⁿᵉ
 
   NEWEPOCH-Not-New : ∀ {Γ} → let open NewEpochState nes in
-    e ≢ sucᵉ lastEpoch
+    e ≢ lastEpoch + 1
     ────────────────────────────────
     Γ ⊢ nes ⇀⦇ e ,NEWEPOCH⦈ nes
 \end{code}

--- a/src/Ledger/Chain/Properties.agda
+++ b/src/Ledger/Chain/Properties.agda
@@ -2,7 +2,7 @@
 
 open import Data.Nat.Properties hiding (_≟_)
 
-open import Ledger.Prelude
+open import Ledger.Prelude hiding (_+_)
 open import Ledger.Transaction
 open import Ledger.Abstract
 import Data.Maybe
@@ -19,6 +19,7 @@ open import Ledger.Chain txs abs
 open import Ledger.Ledger txs abs
 
 open Computational ⦃...⦄
+open HasAggregate ⦃...⦄
 
 module _ {Γ : NewEpochEnv} {nes : NewEpochState} {e : Epoch} where
 
@@ -30,7 +31,7 @@ module _ {Γ : NewEpochEnv} {nes : NewEpochState} {e : Epoch} where
 
   NEWEPOCH-total : ∃[ nes' ] Γ ⊢ nes ⇀⦇ e ,NEWEPOCH⦈ nes'
   NEWEPOCH-total =
-    case e ≟ sucᵉ lastEpoch of λ where
+    case e ≟ lastEpoch + 1 of λ where
       (no ¬p) → -, NEWEPOCH-Not-New ¬p
       (yes p) → -, NEWEPOCH-New p (pFut .proj₂)
     where pFut = RATIFY-total {record { currentEpoch = e ; treasury = treasury
@@ -38,7 +39,7 @@ module _ {Γ : NewEpochEnv} {nes : NewEpochState} {e : Epoch} where
                               {⟦ es , ∅ , false ⟧ʳ} {govSt'}
 
   NEWEPOCH-complete : ∀ nes' → Γ ⊢ nes ⇀⦇ e ,NEWEPOCH⦈ nes' → NEWEPOCH-total .proj₁ ≡ nes'
-  NEWEPOCH-complete nes' h with h | e ≟ sucᵉ lastEpoch
+  NEWEPOCH-complete nes' h with h | e ≟ lastEpoch + 1
   ... | NEWEPOCH-New next _    | no ¬next = ⊥-elim (¬next next)
   ... | NEWEPOCH-Not-New _     | no _     = refl
   ... | NEWEPOCH-New _ h       | yes _    = cong ⟦ _ , _ , _ , _ ,_⟧ⁿᵉ (RATIFY-complete h)

--- a/src/Ledger/Epoch.agda
+++ b/src/Ledger/Epoch.agda
@@ -52,11 +52,14 @@ record EpochStructure : Set₁ where
   suc n +ᵉ e = sucᵉ (n +ᵉ e)
 
   instance
-    addSlot : HasAdd Slot
+    addSlot : HasAggregate Slot
     addSlot ._+_ = _+ˢ_
 
-    addEpoch : HasAdd Epoch
+    addEpoch : HasAggregate Epoch
     addEpoch ._+_ e e' = epoch (firstSlot e + firstSlot e')
+
+    addNatEpoch : HasAggregate Epoch {ℕ}
+    addNatEpoch ._+_ = λ e n → n +ᵉ e
 
 record GlobalConstants : Set₁ where
   field  Network : Set; ⦃ DecEq-Netw ⦄ : DecEq Network

--- a/src/Ledger/Prelude.agda
+++ b/src/Ledger/Prelude.agda
@@ -20,8 +20,8 @@ open import Data.Maybe.Properties.Ext public
 open import Interface.Functor public
 open import Interface.Bifunctor public
 open import Interface.DecEq.Ext public
-open import Interface.HasAdd public
-open import Interface.HasAdd.Instance public
+open import Interface.HasAggregate public
+open import Interface.HasAggregate.Instance public
 open import Interface.HasSubtract public
 open import Interface.HasSubtract.Instance public
 open import Interface.HasOrder public

--- a/src/Ledger/TokenAlgebra.lagda
+++ b/src/Ledger/TokenAlgebra.lagda
@@ -56,7 +56,7 @@ record TokenAlgebra : Set₁ where
          ⦃ Dec-≤ᵗ ⦄      : ∀ {v v′} → Dec (v ≤ᵗ v′)
 
   instance
-    addValue : HasAdd Value
+    addValue : HasAggregate Value
     addValue = record { _+_ = _+ᵛ_ }
 \end{code}
 \emph{Helper functions}

--- a/src/Tactic/DeriveComp.agda
+++ b/src/Tactic/DeriveComp.agda
@@ -13,7 +13,7 @@ open import Interface.Monad.Instance
 open import Interface.ComputationalRelation
 open import Interface.DecEq.Ext
 open import Interface.Decidable.Instance
-open import Interface.HasAdd; open import Interface.HasAdd.Instance
+open import Interface.HasAggregate; open import Interface.HasAggregate.Instance
 open import Interface.HasSubtract; open import Interface.HasSubtract.Instance
 
 open import Reflection.Ext using (extendContextTel′)


### PR DESCRIPTION
# Description

Addresses one item of #282 

- [X] Give `HasAdd` a more general interface: `_+_ : A → B → A`; this makes it an aggregation as opposed to a sum.
- [X] Rename `HasAdd` to `HasAggregate`.
- [X] Rename some of the `sucᵉ` instances to `_+ 1` (it doesn't work for all of them).

# Checklist

- [X] Commit sequence broadly makes sense and commits have useful messages
- [X] Code is formatted according to [CONTRIBUTING.md](https://github.com/input-output-hk/formal-ledger-specifications/blob/master/CONTRIBUTING.md)
- [X] Self-reviewed the diff
