### PR TITLE
Add `IsCommutativeMonoid'` typeclass

### DIFF
--- a/src/Axiom/Set/Sum.agda
+++ b/src/Axiom/Set/Sum.agda
@@ -6,6 +6,7 @@ open import Algebra using (CommutativeMonoid)
 
 open import Prelude hiding (ε)
 
+-- FIXME: this presents a much nicer interface if we use IsCommutativeMonoid' instead
 module Axiom.Set.Sum (th : Theory {lzero}) ⦃ M : CommutativeMonoid 0ℓ 0ℓ ⦄ where
 open Theory th
 open import Axiom.Set.Factor th
@@ -155,6 +156,3 @@ module _ ⦃ _ : DecEq A ⦄ ⦃ _ : DecEq B ⦄ where
 
             helper : toRel m ≡ᵉ toRel (m₁ ∪ˡᶠ m₂)
             helper = ≡ᵉ.trans (proj₁ m≡m₁∪m₂) (≡ᵉ.sym $ disjoint-∪ˡ-∪ disj-dom')
-
-  -- syntax indexedSumᵐ (λ a → x) m = ∑ᵐ[ a ← m ] x  -- (not used; leave for now?)
-  syntax indexedSumᵛ (λ a → x) m = ∑[ a ← m ] x

--- a/src/Interface/IsCommutativeMonoid.agda
+++ b/src/Interface/IsCommutativeMonoid.agda
@@ -2,23 +2,25 @@
 
 module Interface.IsCommutativeMonoid where
 
-open import Algebra
+open import Algebra using (IsCommutativeMonoid; CommutativeMonoid)
 open import Prelude
 
 record IsCommutativeMonoid' c ℓ Carrier : Set (sucˡ (c ⊔ˡ ℓ)) where
-  infixl 7 _∙_
   infix  4 _≈_
   field
     _≈_                 : Carrier → Carrier → Set ℓ
-    _∙_                 : Carrier → Carrier → Carrier
-    ε                   : Carrier
-    isCommutativeMonoid : IsCommutativeMonoid {c} _≈_ _∙_ ε
+    ⦃ semigroup ⦄       : Semigroup Carrier
+    ⦃ monoid ⦄          : Monoid Carrier
+    isCommutativeMonoid : IsCommutativeMonoid {c} _≈_ _◇_ ε
 
 fromCommMonoid' : ∀ {c ℓ Carrier} → IsCommutativeMonoid' c ℓ Carrier → CommutativeMonoid c ℓ
 fromCommMonoid' c = record { IsCommutativeMonoid' c }
 
 toCommMonoid' : ∀ {c ℓ} → (m : CommutativeMonoid c ℓ) → IsCommutativeMonoid' c ℓ (CommutativeMonoid.Carrier m)
-toCommMonoid' c = record { CommutativeMonoid c }
+toCommMonoid' c = record
+  { CommutativeMonoid c using (_≈_; isCommutativeMonoid)
+  ; semigroup = λ where ._◇_ → CommutativeMonoid._∙_ c
+  ; monoid    = λ where .ε   → CommutativeMonoid.ε c }
 
 open import Data.Nat.Properties using (+-0-commutativeMonoid)
 

--- a/src/Interface/IsCommutativeMonoid.agda
+++ b/src/Interface/IsCommutativeMonoid.agda
@@ -1,0 +1,26 @@
+{-# OPTIONS --safe #-}
+
+module Interface.IsCommutativeMonoid where
+
+open import Algebra
+open import Prelude
+
+record IsCommutativeMonoid' c ℓ Carrier : Set (sucˡ (c ⊔ˡ ℓ)) where
+  infixl 7 _∙_
+  infix  4 _≈_
+  field
+    _≈_                 : Carrier → Carrier → Set ℓ
+    _∙_                 : Carrier → Carrier → Carrier
+    ε                   : Carrier
+    isCommutativeMonoid : IsCommutativeMonoid {c} _≈_ _∙_ ε
+
+fromCommMonoid' : ∀ {c ℓ Carrier} → IsCommutativeMonoid' c ℓ Carrier → CommutativeMonoid c ℓ
+fromCommMonoid' c = record { IsCommutativeMonoid' c }
+
+toCommMonoid' : ∀ {c ℓ} → (m : CommutativeMonoid c ℓ) → IsCommutativeMonoid' c ℓ (CommutativeMonoid.Carrier m)
+toCommMonoid' c = record { CommutativeMonoid c }
+
+open import Data.Nat.Properties using (+-0-commutativeMonoid)
+
+instance
+  ℕ-commMonoid' = toCommMonoid' +-0-commutativeMonoid

--- a/src/Ledger/Chain.lagda
+++ b/src/Ledger/Chain.lagda
@@ -4,7 +4,7 @@
 {-# OPTIONS --safe #-}
 
 open import Algebra
-open import Data.Nat.Properties using (+-0-monoid; +-0-commutativeMonoid)
+open import Data.Nat.Properties using (+-0-monoid)
 
 open import Ledger.Prelude; open Equivalence
 open import Ledger.Transaction
@@ -59,7 +59,7 @@ private variable
   d : Bool
   fut' : RatifyState
 
-instance _ = +-0-monoid; _ = +-0-commutativeMonoid
+instance _ = +-0-monoid
 
 -- The NEWEPOCH rule is actually multiple rules in one for the sake of simplicity:t also does what EPOCH used to do in previous eras
 data _⊢_⇀⦇_,NEWEPOCH⦈_ : NewEpochEnv → NewEpochState → Epoch → NewEpochState → Set where
@@ -76,7 +76,7 @@ data _⊢_⇀⦇_,NEWEPOCH⦈_ : NewEpochEnv → NewEpochState → Epoch → New
       open Acnt acnt
 
       trWithdrawals   = esW .EnactState.withdrawals
-      totWithdrawals  = ∑[ x ← trWithdrawals ᶠᵐ ] x
+      totWithdrawals  = ∑[ x ← trWithdrawals ] x
 
       removedGovActions = flip concatMapˢ removed λ (gaid , gaSt) →
         mapˢ (GovActionState.returnAddr gaSt ,_)

--- a/src/Ledger/Foreign/HSLedger.agda
+++ b/src/Ledger/Foreign/HSLedger.agda
@@ -56,13 +56,13 @@ module Implementation where
 
   PlutusScript = ⊤
   ExUnits      = ℕ × ℕ
-  ExUnit-CommutativeMonoid = CommutativeMonoid 0ℓ 0ℓ ∋ record
+  ExUnit-CommutativeMonoid = IsCommutativeMonoid' 0ℓ 0ℓ ExUnits ∋ (toCommMonoid' record
     { Carrier = ExUnits
     ; _≈_ = _≈ᵖ_
     ; _∙_ = _∙ᵖ_
     ; ε = zero , zero
     ; isCommutativeMonoid = pairOpRespectsComm +-0-isCommutativeMonoid
-    } where open import Algebra.PairOp ℕ zero _≡_ _+_
+    }) where open import Algebra.PairOp ℕ zero _≡_ _+_
   _≥ᵉ_ : ExUnits → ExUnits → Set
   _≥ᵉ_ = _≡_
   CostModel    = ⊥
@@ -72,23 +72,22 @@ module Implementation where
   open import Ledger.TokenAlgebra ℕ
   coinTokenAlgebra : TokenAlgebra
   coinTokenAlgebra = λ where
-    .Value-CommutativeMonoid   → +-0-commutativeMonoid
-    .coin                      → id
-    .inject                    → id
-    .policies                  → λ _ → ∅
-    .size                      → λ x → 1 -- there is only ada in this token algebra
-    ._≤ᵗ_                      → _≤_
-    .AssetName                 → String
-    .specialAsset              → "Ada"
-    .property                  → λ _ → refl
-    .coinIsMonoidHomomorphism → λ where
-      .isMagmaHomomorphism → λ where
-        .isRelHomomorphism → record {cong = id}
-        .homo → λ _ _ → refl
-      .ε-homo → refl
+    .Value                      → ℕ
+    .Value-IsCommutativeMonoid' → it
+      -- ^ Agda bug? Without this line, `coinIsMonoidHomomorphism` doesn't type check anymore
+    .coin                       → id
+    .inject                     → id
+    .policies                   → λ _ → ∅
+    .size                       → λ x → 1 -- there is only ada in this token algebra
+    ._≤ᵗ_                       → _≤_
+    .AssetName                  → String
+    .specialAsset               → "Ada"
+    .property                   → λ _ → refl
+    .coinIsMonoidHomomorphism   → Id.isMonoidHomomorphism _ refl
    where open TokenAlgebra
          open Algebra.Morphism.IsMonoidHomomorphism
          open Algebra.Morphism.IsMagmaHomomorphism
+         import Algebra.Morphism.Construct.Identity as Id
 
   TxId            = ℕ
   Ix              = ℕ

--- a/src/Ledger/GovernanceActions.lagda
+++ b/src/Ledger/GovernanceActions.lagda
@@ -12,7 +12,7 @@ We introduce three distinct bodies that have specific functions in the new gover
 \begin{code}[hide]
 {-# OPTIONS --safe #-}
 
-open import Data.Nat.Properties using (+-0-commutativeMonoid; +-0-monoid)
+open import Data.Nat.Properties using (+-0-monoid)
 open import Data.Rational using (ℚ; 0ℚ; 1ℚ)
 
 open import Tactic.Derive.DecEq
@@ -287,7 +287,6 @@ private variable
 
 instance
   _ = +-0-monoid
-  _ = +-0-commutativeMonoid
   unquoteDecl DecEq-GovRole = derive-DecEq ((quote GovRole , DecEq-GovRole) ∷ [])
   unquoteDecl DecEq-Vote    = derive-DecEq ((quote Vote    , DecEq-Vote)    ∷ [])
   unquoteDecl DecEq-VDeleg  = derive-DecEq ((quote VDeleg  , DecEq-VDeleg)  ∷ [])
@@ -329,7 +328,7 @@ data _⊢_⇀⦇_,ENACT⦈_ : EnactEnv → EnactState → GovAction → EnactSta
                 record  s { pparams = applyUpdate (s .pparams .proj₁) up , gid }
 
   Enact-Wdrl : let newWdrls = s .withdrawals ∪⁺ wdrl in
-    ∑[ x ← newWdrls ᶠᵐ ] x ≤ t
+    ∑[ x ← newWdrls ] x ≤ t
     ───────────────────────────────────────
     ⟦ gid , t , e ⟧ᵉ ⊢  s ⇀⦇ TreasuryWdrl wdrl  ,ENACT⦈
                 record  s { withdrawals  = newWdrls }

--- a/src/Ledger/GovernanceActions/Properties.agda
+++ b/src/Ledger/GovernanceActions/Properties.agda
@@ -1,6 +1,6 @@
 {-# OPTIONS --safe #-}
 
-open import Data.Nat.Properties using (+-0-commutativeMonoid; +-0-monoid)
+open import Data.Nat.Properties using (+-0-monoid)
 
 open import Ledger.Prelude
 open import Ledger.GovStructure
@@ -13,7 +13,6 @@ open EnactState
 
 instance
   _ = +-0-monoid
-  _ = +-0-commutativeMonoid
 
 open Computational ⦃...⦄
 instance
@@ -22,7 +21,7 @@ instance
     NoConfidence             → just (_ , Enact-NoConf)
     (NewCommittee new rem q) →
       case ¿ ∀[ term ∈ range new ]
-               term ≤ (s .pparams .proj₁ .PParams.ccMaxTermLength +ᵉ e) ¿ of λ where
+               term ≤ s .pparams .proj₁ .PParams.ccMaxTermLength +ᵉ e ¿ of λ where
       (yes p) → just (-, Enact-NewComm p)
       (no ¬p) → nothing
     (NewConstitution dh sh)  → just (-, Enact-NewConst)
@@ -30,7 +29,7 @@ instance
     (ChangePParams up)       → just (-, Enact-PParams)
     Info                     → just (-, Enact-Info)
     (TreasuryWdrl wdrl) →
-      case ¿ ∑[ x ← (s .withdrawals ∪⁺ wdrl) ᶠᵐ ] x ≤ t ¿ of λ where
+      case ¿ ∑[ x ← s .withdrawals ∪⁺ wdrl ] x ≤ t ¿ of λ where
         (yes p)             → just (-, Enact-Wdrl p)
         (no _)              → nothing
   Computational-ENACT .completeness ⟦ _ , t , e ⟧ᵉ s action _ p
@@ -39,12 +38,12 @@ instance
   ... | .NewCommittee new rem q | Enact-NewComm p
     rewrite dec-yes
       (¿ ∀[ term ∈ range new ] term
-           ≤ (s .pparams .proj₁ .PParams.ccMaxTermLength +ᵉ e) ¿) p .proj₂
+           ≤ s .pparams .proj₁ .PParams.ccMaxTermLength +ᵉ e ¿) p .proj₂
       = refl
   ... | .NewConstitution dh sh  | Enact-NewConst = refl
   ... | .TriggerHF v            | Enact-HF       = refl
   ... | .ChangePParams up       | Enact-PParams  = refl
   ... | .Info                   | Enact-Info     = refl
   ... | .TreasuryWdrl wdrl      | Enact-Wdrl p
-    rewrite dec-yes (¿ (∑[ x ← (s .withdrawals ∪⁺ wdrl) ᶠᵐ ] x) ≤ t ¿) p .proj₂
+    rewrite dec-yes (¿ ∑[ x ← s .withdrawals ∪⁺ wdrl ] x ≤ t ¿) p .proj₂
     = refl

--- a/src/Ledger/Prelude.agda
+++ b/src/Ledger/Prelude.agda
@@ -15,21 +15,22 @@ open import Prelude public
 
 open import Ledger.Prelude.Base public
 
-open import Data.Product.Ext public
 open import Data.Maybe.Properties.Ext public
-open import Interface.ToBool public
+open import Data.Product.Ext public
+open import Interface.ComputationalRelation public
 open import Interface.HasAdd public
 open import Interface.HasAdd.Instance public
-open import Interface.HasSubtract public
-open import Interface.HasSubtract.Instance public
 open import Interface.HasOrder public
 open import Interface.HasOrder.Instance public
+open import Interface.HasSubtract public
+open import Interface.HasSubtract.Instance public
 open import Interface.Hashable public
-open import Interface.ComputationalRelation public
+open import Interface.IsCommutativeMonoid public
+open import Interface.ToBool public
+open import Ledger.Interface.HasCoin public
 open import MyDebugOptions public
 open import Tactic.Premises public
 
-open import Ledger.Interface.HasCoin public
 open import Ledger.Set renaming (∅ to ∅ˢ; ❴_❵ to ❴_❵ˢ) public
 open import Interface.HasSingleton th public
 open import Interface.HasEmptySet th public

--- a/src/Ledger/Ratify.lagda
+++ b/src/Ledger/Ratify.lagda
@@ -97,7 +97,6 @@ _∧_ = _×_
 
 instance
   _ = +-0-commutativeMonoid
-  _ = +-0-monoid
 \end{code}
 \begin{figure*}[h!]
 \begin{code}
@@ -167,24 +166,24 @@ mostStakeDRepDist-0 = (proj₂ ∘ Equivalence.from ∈-filter)
 
 -- TODO: maybe this can be proven easier with the maximum?
 mostStakeDRepDist-∅ : ∀ {dist} → ∃[ N ] mostStakeDRepDist dist N ˢ ≡ᵉ ∅
-mostStakeDRepDist-∅ {dist} = suc (∑[ x ← dist ᶠᵐ ] x) , Properties.∅-least
+mostStakeDRepDist-∅ {dist} = suc (∑[ x ← dist ] x) , Properties.∅-least
   (⊥-elim ∘ uncurry helper ∘ Equivalence.from ∈-filter)
   where
     open ≤-Reasoning
 
-    helper : ∀ {k v} → v > ∑[ x ← dist ᶠᵐ ] x → (k , v) ∉ dist
+    helper : ∀ {k v} → v > ∑[ x ← dist ] x → (k , v) ∉ dist
     helper {k} {v} v>sum kv∈dist = 1+n≰n $ begin-strict
       v
         ≡˘⟨ indexedSum-singleton' $ finiteness ❴ k , v ❵ ⟩
-      ∑[ x ← ❴ k , v ❵ ᶠᵐ ] x
+      ∑[ x ← ❴ k , v ❵ ] x
         ≡˘⟨ indexedSumᵐ-cong {x = (dist ∣ ❴ k ❵) ᶠᵐ} {y = ❴ k , v ❵ ᶠᵐ}
           $ res-singleton' {m = dist} kv∈dist ⟩
-      ∑[ x ← (dist ∣ ❴ k ❵) ᶠᵐ ] x
+      ∑[ x ← (dist ∣ ❴ k ❵) ] x
         ≤⟨ m≤m+n _ _ ⟩
-      ∑[ x ← (dist ∣ ❴ k ❵) ᶠᵐ ] x +ℕ ∑[ x ← (dist ∣ ❴ k ❵ ᶜ) ᶠᵐ ] x
+      ∑[ x ← (dist ∣ ❴ k ❵) ] x +ℕ ∑[ x ← (dist ∣ ❴ k ❵ ᶜ) ] x
         ≡˘⟨ indexedSumᵐ-partition {m = dist ᶠᵐ} {(dist ∣ ❴ k ❵) ᶠᵐ} {(dist ∣ ❴ k ❵ ᶜ) ᶠᵐ}
           $ res-ex-disj-∪ Properties.Dec-∈-singleton ⟩
-      ∑[ x ← dist ᶠᵐ ] x
+      ∑[ x ← dist ] x
         <⟨ v>sum ⟩
       v ∎
 
@@ -350,8 +349,8 @@ abstract
   acceptedStakeRatio r cc dists votes = acceptedStake /₀ totalStake
     where
       acceptedStake totalStake : Coin
-      acceptedStake = ∑[ x ← (getStakeDist r cc dists ∣ votedYesHashes votes r) ᶠᵐ ]      x
-      totalStake    = ∑[ x ←  getStakeDist r cc dists ∣ votedAbstainHashes votes r ᶜ ᶠᵐ ] x
+      acceptedStake = ∑[ x ←  getStakeDist r cc dists ∣ votedYesHashes votes r ]       x
+      totalStake    = ∑[ x ←  getStakeDist r cc dists ∣ votedAbstainHashes votes r ᶜ ] x
 
   acceptedBy : RatifyEnv → EnactState → GovActionState → GovRole → Set
   acceptedBy Γ (record { cc = cc , _; pparams = pparams , _ }) gs role =

--- a/src/Ledger/Script.lagda
+++ b/src/Ledger/Script.lagda
@@ -31,20 +31,12 @@ record P1ScriptStructure : Set₁ where
 
 record PlutusStructure : Set₁ where
   field Dataʰ : HashableSet
-        Language PlutusScript CostModel Prices LangDepView : Set
-        ExUnit-CommutativeMonoid  : CommutativeMonoid 0ℓ 0ℓ
-        ⦃ Hashable-PlutusScript ⦄ : Hashable PlutusScript ScriptHash
-        ⦃ DecEq-PlutusScript    ⦄ : DecEq PlutusScript
-        ⦃ DecEq-CostModel       ⦄ : DecEq CostModel
-        ⦃ DecEq-LangDepView     ⦄ : DecEq LangDepView
-
-  open CommutativeMonoid ExUnit-CommutativeMonoid public
-    using ()
-    renaming (_≈_ to _≈ᵉ_; ε to εᵉ; Carrier to ExUnits; refl to reflᵉ; _∙_ to _+ᵉˣ_)
-
-  instance
-    CommMonoid'-ExUnits : IsCommutativeMonoid' _ _ ExUnits
-    CommMonoid'-ExUnits = toCommMonoid' ExUnit-CommutativeMonoid
+        Language PlutusScript CostModel Prices LangDepView ExUnits : Set
+        ⦃ ExUnit-CommutativeMonoid ⦄ : IsCommutativeMonoid' 0ℓ 0ℓ ExUnits
+        ⦃ Hashable-PlutusScript    ⦄ : Hashable PlutusScript ScriptHash
+        ⦃ DecEq-PlutusScript       ⦄ : DecEq PlutusScript
+        ⦃ DecEq-CostModel          ⦄ : DecEq CostModel
+        ⦃ DecEq-LangDepView        ⦄ : DecEq LangDepView
 
   field  _≥ᵉ_              : ExUnits → ExUnits → Set
          ⦃ DecEq-ExUnits ⦄ : DecEq ExUnits

--- a/src/Ledger/Script.lagda
+++ b/src/Ledger/Script.lagda
@@ -42,6 +42,9 @@ record PlutusStructure : Set₁ where
     using ()
     renaming (_≈_ to _≈ᵉ_; ε to εᵉ; Carrier to ExUnits; refl to reflᵉ; _∙_ to _+ᵉˣ_)
 
+  instance
+    CommMonoid'-ExUnits : IsCommutativeMonoid' _ _ ExUnits
+    CommMonoid'-ExUnits = toCommMonoid' ExUnit-CommutativeMonoid
 
   field  _≥ᵉ_              : ExUnits → ExUnits → Set
          ⦃ DecEq-ExUnits ⦄ : DecEq ExUnits

--- a/src/Ledger/Set/Theory.agda
+++ b/src/Ledger/Set/Theory.agda
@@ -15,6 +15,9 @@ abstract
   List-Modelᵈ : Theoryᵈ
   List-Modelᵈ = L.List-Modelᵈ
 
+private variable
+  A B C : Set
+
 open Theoryᵈ List-Modelᵈ public
   renaming (Set to ℙ_; filter to filterˢ?; map to mapˢ)
   hiding (_∈_; _∉_)
@@ -27,27 +30,27 @@ abstract
   to-sp : {A : Set} (P : A → Set) → ⦃ P ⁇¹ ⦄ → specProperty P
   to-sp _ = dec¹
 
-  finiteness : ∀ {A} (X : Theory.Set th A) → finite X
+  finiteness : ∀ (X : Theory.Set th A) → finite X
   finiteness = Theoryᶠ.finiteness List-Modelᶠ
 
-  lengthˢ : ∀ {A 𝕊} ⦃ _ : DecEq A ⦄ ⦃ _ : IsSet 𝕊 A ⦄ → 𝕊 → ℕ
+  lengthˢ : ∀ {𝕊} ⦃ _ : DecEq A ⦄ ⦃ _ : IsSet 𝕊 A ⦄ → 𝕊 → ℕ
   lengthˢ X = Theoryᶠ.lengthˢ List-Modelᶠ (toSet X)
 
-  lengthˢ-≡ᵉ :  ∀ {A 𝕊} ⦃ _ : DecEq A ⦄ ⦃ _ : IsSet 𝕊 A ⦄ → (X Y : 𝕊)
+  lengthˢ-≡ᵉ :  ∀ {𝕊} ⦃ _ : DecEq A ⦄ ⦃ _ : IsSet 𝕊 A ⦄ → (X Y : 𝕊)
     → toSet X ≡ᵉ toSet Y
     → lengthˢ X ≡ lengthˢ Y
   lengthˢ-≡ᵉ X Y X≡Y =
     card-≡ᵉ (-, Theoryᶠ.DecEq⇒strongly-finite List-Modelᶠ (toSet X))
             (-, Theoryᶠ.DecEq⇒strongly-finite List-Modelᶠ (toSet Y)) X≡Y
 
-  lengthˢ-∅ : ∀ {A} ⦃ _ : DecEq A ⦄ → lengthˢ {A} ∅ ≡ 0
+  lengthˢ-∅ : ∀ ⦃ _ : DecEq A ⦄ → lengthˢ {A} ∅ ≡ 0
   lengthˢ-∅ = refl
 
-  setToList : {A : Set} → ℙ A → List A
+  setToList : ℙ A → List A
   setToList = id
 
   instance
-    DecEq-ℙ : {A : Set} ⦃ _ : DecEq A ⦄ → DecEq (ℙ A)
+    DecEq-ℙ : ⦃ _ : DecEq A ⦄ → DecEq (ℙ A)
     DecEq-ℙ = L.Decˡ.DecEq-Set
 
 open import Axiom.Set.Rel th public
@@ -67,7 +70,7 @@ open import Axiom.Set.Sum th public
 open import Axiom.Set.Map.Dec List-Modelᵈ public
 open import Axiom.Set.Factor List-Model public
 
-module _ {A : Set} ⦃ _ : DecEq A ⦄ where
+module _ ⦃ _ : DecEq A ⦄ where
   open Restriction {A} ∈-sp public
     renaming (_∣_ to _∣ʳ_; _∣_ᶜ to _∣ʳ_ᶜ)
 
@@ -81,20 +84,18 @@ module _ {A : Set} ⦃ _ : DecEq A ⦄ where
   open Lookupᵐ {A} ∈-sp public
   open Lookupᵐᵈ {A} ∈-sp public
 
-module _ {A B : Set} ⦃ _ : DecEq A ⦄ ⦃ _ : DecEq B ⦄ where
-  open Intersectionᵐ {A} {B} ∈-sp public
+open import Algebra
 
-  open import Algebra using (CommutativeMonoid)
+module _ ⦃ _ : DecEq A ⦄ ⦃ _ : DecEq B ⦄ where
+  open Intersectionᵐ {A} {B} ∈-sp public
 
   module _ ⦃ M : CommutativeMonoid 0ℓ 0ℓ ⦄ where
     open IndexedSumUnionᵐ {A} {B} ∈-sp (_∈? _) public
 
 module Properties where
   open import Axiom.Set.Properties th public
-  module _ {A : Set} ⦃ _ : DecEq A ⦄ where
+  module _ ⦃ _ : DecEq A ⦄ where
     open Intersectionᵖ {A} ∈-sp public
-
-private variable A B : Set
 
 _ᶠᵐ : A ⇀ B → FinMap A B
 (R , uniq) ᶠᵐ = (R , uniq , finiteness _)
@@ -113,3 +114,10 @@ filterKeys P = filterKeys? (to-sp P)
 
 _↾'_ : A ⇀ B → (P : B → Set) ⦃ _ : P ⁇¹ ⦄ → A ⇀ B
 s ↾' P = s ↾'? to-sp P
+
+open import Interface.IsCommutativeMonoid
+
+indexedSumᵛ' : ⦃ DecEq A ⦄ → ⦃ DecEq B ⦄ → ⦃ IsCommutativeMonoid' 0ℓ 0ℓ C ⦄ → (B → C) → A ⇀ B → C
+indexedSumᵛ' f m = indexedSumᵛ ⦃ fromCommMonoid' it ⦄ f (m ᶠᵐ)
+
+syntax indexedSumᵛ' (λ a → x) m = ∑[ a ← m ] x

--- a/src/Ledger/TokenAlgebra.lagda
+++ b/src/Ledger/TokenAlgebra.lagda
@@ -37,6 +37,10 @@ record TokenAlgebra : Set₁ where
     using (_≈_ ; ε ; monoid ; rawMonoid)
     renaming (Carrier to Value ; refl to reflᵛ ; _∙_ to _+ᵛ_)
 
+  instance
+    CommMonoid'-Value : IsCommutativeMonoid' _ _ Value
+    CommMonoid'-Value = toCommMonoid' Value-CommutativeMonoid
+
   open MonoidMorphisms (rawMonoid) (Monoid.rawMonoid +-0-monoid) public
 \end{code}
 \begin{code}

--- a/src/Ledger/TokenAlgebra.lagda
+++ b/src/Ledger/TokenAlgebra.lagda
@@ -26,20 +26,18 @@ open import Relation.Unary       using (Pred)
 \begin{AgdaSuppressSpace}
 \begin{code}
 record TokenAlgebra : Set₁ where
-  field  Value-CommutativeMonoid : CommutativeMonoid 0ℓ 0ℓ
+  field  Value : Set
+         ⦃ Value-IsCommutativeMonoid' ⦄ : IsCommutativeMonoid' 0ℓ 0ℓ Value
 
   MemoryEstimate : Set
   MemoryEstimate = ℕ
 
 \end{code}
 \begin{code}[hide]
+  Value-CommutativeMonoid = fromCommMonoid' Value-IsCommutativeMonoid'
   open CommutativeMonoid Value-CommutativeMonoid public
     using (_≈_ ; ε ; monoid ; rawMonoid)
-    renaming (Carrier to Value ; refl to reflᵛ ; _∙_ to _+ᵛ_)
-
-  instance
-    CommMonoid'-Value : IsCommutativeMonoid' _ _ Value
-    CommMonoid'-Value = toCommMonoid' Value-CommutativeMonoid
+    renaming (_∙_ to _+ᵛ_)
 
   open MonoidMorphisms (rawMonoid) (Monoid.rawMonoid +-0-monoid) public
 \end{code}

--- a/src/Ledger/TokenAlgebra/ValueSet.lagda
+++ b/src/Ledger/TokenAlgebra/ValueSet.lagda
@@ -156,6 +156,8 @@ We are now in a position to define the commutative monoid.
   Vcm .isCommutativeMonoid .isMonoid  = ≋-⊕-ι-isMonoid
   Vcm .isCommutativeMonoid .comm      = ⊕-comm
 
+  instance _ = toCommMonoid' Vcm
+
   Value-TokenAlgebra :
     (specialPolicy : PolicyId)
     (specialAsset : AssetName)
@@ -163,8 +165,7 @@ We are now in a position to define the commutative monoid.
     --------------------------------------
     → TokenAlgebra
   Value-TokenAlgebra specialPolicy specialAsset size = record
-    { Value-CommutativeMonoid   = Vcm
-    ; coin                      = totalMap↠coin
+    { coin                      = totalMap↠coin
     ; inject                    = coin↪totalMap
     ; policies                  = policies
     ; size                      = size

--- a/src/Ledger/Utxo.lagda
+++ b/src/Ledger/Utxo.lagda
@@ -8,7 +8,7 @@
 
 open import Algebra              using (CommutativeMonoid)
 open import Data.Integer.Ext     using (posPart; negPart)
-open import Data.Nat.Properties  using (+-0-monoid; +-0-commutativeMonoid)
+open import Data.Nat.Properties  using (+-0-monoid)
 import Data.Maybe as M
 import Data.Sum.Relation.Unary.All as Sum
 
@@ -24,13 +24,10 @@ module Ledger.Utxo
   where
 
 instance
-  _ = TokenAlgebra.Value-CommutativeMonoid tokenAlgebra
   _ = +-0-monoid
-  _ = +-0-commutativeMonoid
-  _ = ExUnit-CommutativeMonoid
 
   HasCoin-Map : ∀ {A} → ⦃ DecEq A ⦄ → HasCoin (A ⇀ Coin)
-  HasCoin-Map .getCoin s = indexedSumᵛ ⦃ +-0-commutativeMonoid ⦄ id (s ᶠᵐ)
+  HasCoin-Map .getCoin s = ∑[ x ← s ] x
 
 isPhaseTwoScriptAddress : Tx → Addr → Bool
 isPhaseTwoScriptAddress tx a =
@@ -42,7 +39,7 @@ isPhaseTwoScriptAddress tx a =
     false
 
 totExUnits : Tx → ExUnits
-totExUnits tx = indexedSumᵐ ⦃ ExUnit-CommutativeMonoid ⦄ (λ x → x .proj₂ .proj₂) (tx .wits .txrdmrs ᶠᵐ)
+totExUnits tx = ∑[ (_ , eu) ← tx .wits .txrdmrs ] eu
   where open Tx; open TxWitnesses
 
 -- utxoEntrySizeWithoutVal = 27 words (8 bytes)
@@ -79,7 +76,7 @@ module _ (let open Tx; open TxBody) where
   outs tx = mapKeys (tx .txid ,_) (tx .txouts)
 
   balance : UTxO → Value
-  balance utxo = indexedSumᵛ ⦃ Value-CommutativeMonoid ⦄ getValue (utxo ᶠᵐ)
+  balance utxo = ∑[ x ← utxo ] getValue x
 
   cbalance : UTxO → Coin
   cbalance utxo = coin (balance utxo)


### PR DESCRIPTION
# Description

This sits between `CommutativeMonoid` and `IsCommutativeMonoid`. It doesn't bundle the carrier but everything else. It is a lot better behaved as a typeclass than the other two, and enables a bunch of cleanup.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] Code is formatted according to [CONTRIBUTING.md](https://github.com/input-output-hk/formal-ledger-specifications/blob/master/CONTRIBUTING.md)
- [x] Self-reviewed the diff
