### PR TITLE
Add a version of the monoid solver that tries first without normalising

### DIFF
--- a/src/Ledger/Utxo/Properties.lagda
+++ b/src/Ledger/Utxo/Properties.lagda
@@ -17,7 +17,7 @@ open import Prelude; open Equivalence
 
 open import Tactic.Cong                 using (cong!)
 open import Tactic.EquationalReasoning  using (module ≡-Reasoning)
-open import Tactic.MonoidSolver         using (solve-macro)
+open import Tactic.MonoidSolver.NonNormalising using (solve-macro)
 open Tactic.EquationalReasoning.≡-Reasoning {A = ℕ} (solve-macro (quoteTerm +-0-monoid))
 
 open import Ledger.Prelude; open Properties; open Computational ⦃...⦄

--- a/src/Tactic/MonoidSolver/NonNormalising.agda
+++ b/src/Tactic/MonoidSolver/NonNormalising.agda
@@ -1,0 +1,28 @@
+{-# OPTIONS --safe #-}
+
+module Tactic.MonoidSolver.NonNormalising where
+
+open import Data.List    using ([]; _∷_)
+open import Data.Product using (_,_)
+open import Data.Maybe   using (nothing; just)
+open import Reflection
+open import Tactic.MonoidSolver hiding (solve-macro; solve)
+import Tactic.MonoidSolver as Solver
+
+-- The standard library MonoidSolver normalises the type of the hole
+-- before solving.  This can be very expensive in some scenarios. This
+-- version tries first without normalising and only if that fails does
+-- it resort to normalisation.
+solve-macro : Term → Term → TC _
+solve-macro mon hole = catchTC (do
+    hole′ ← inferType hole
+    names ← findMonoidNames mon
+    just (lhs , rhs) ← pure (getArgs hole′)
+      where nothing → typeError (termErr hole′ ∷ [])
+    let soln = constructSoln mon names lhs rhs
+    unify hole soln
+  ) (Solver.solve-macro mon hole)
+
+macro
+  solve : Term → Term → TC _
+  solve = solve-macro


### PR DESCRIPTION
This gives a significant speedup to the proofs in  `Ledger.Utxo.Properties` (from 30s total to 10s total).