### PR TITLE
Split `NEWEPOCH` into `EPOCH` and `NEWEPOCH`

### DIFF
--- a/src/Ledger/Chain.lagda
+++ b/src/Ledger/Chain.lagda
@@ -5,7 +5,6 @@
 
 open import Algebra
 open import Data.Nat.Properties using (+-0-monoid)
---open import Data.Nat.Properties using (+-0-monoid; +-0-commutativeMonoid)
 
 open import Ledger.Prelude; open Equivalence
 open import Ledger.Transaction
@@ -102,13 +101,16 @@ data
 \begin{figure*}[h]
 \begin{code}
   CHAIN :
-    let open ChainState s; open Block b; open NewEpochState newEpochState; open EnactState es in
+    let open ChainState s; open Block b; open NewEpochState newEpochState
+        open EpochState epochState; open EnactState es
+    in
        record { stakeDistrs = calculateStakeDistrs ls }
          ⊢ newEpochState ⇀⦇ epoch slot ,NEWEPOCH⦈ nes
     →  ⟦ slot , constitution .proj₁ .proj₂ , pparams .proj₁ , es ⟧ˡᵉ
-         ⊢ nes .NewEpochState.ls ⇀⦇ ts ,LEDGERS⦈ ls'
+         ⊢ ls ⇀⦇ ts ,LEDGERS⦈ ls'
     ────────────────────────────────
-    _ ⊢ s ⇀⦇ b ,CHAIN⦈ record s { newEpochState = record nes { ls = ls' } }
+    _ ⊢ s ⇀⦇ b ,CHAIN⦈
+        record s { newEpochState = record nes { epochState = record epochState { ls = ls'} } }
 \end{code}
 \caption{CHAIN transition system}
 \end{figure*}

--- a/src/Ledger/Chain.lagda
+++ b/src/Ledger/Chain.lagda
@@ -5,6 +5,7 @@
 
 open import Algebra
 open import Data.Nat.Properties using (+-0-monoid)
+--open import Data.Nat.Properties using (+-0-monoid; +-0-commutativeMonoid)
 
 open import Ledger.Prelude; open Equivalence
 open import Ledger.Transaction
@@ -15,26 +16,13 @@ module Ledger.Chain
   (abs : AbstractFunctions txs) (open AbstractFunctions abs)
   where
 
-open import Ledger.Gov govStructure
 open import Ledger.Ledger txs abs
 open import Ledger.Ratify txs
 open import Ledger.Utxo txs abs
+open import Ledger.Epoch txs abs
 \end{code}
 \begin{figure*}[h]
 \begin{code}
-
-record NewEpochEnv : Set where
-  field stakeDistrs : StakeDistrs
-   -- TODO: compute this from LState instead
-
-record NewEpochState : Set where
-  constructor ⟦_,_,_,_,_⟧ⁿᵉ
-  field lastEpoch  : Epoch
-        acnt       : Acnt
-        ls         : LState
-        es         : EnactState
-        fut        : RatifyState
-
 record ChainState : Set where
   field newEpochState  : NewEpochState
 
@@ -42,7 +30,7 @@ record Block : Set where
   field ts    : List Tx
         slot  : Slot
 \end{code}
-\caption{Definitions for the NEWEPOCH and CHAIN transition systems}
+\caption{Definitions CHAIN transition system}
 The \AgdaRecord{Acnt} record has two fields, \AgdaField{treasury} and \AgdaField{reserves}, so
 the \AgdaBound{acnt} field in \AgdaRecord{NewEpochState} keeps track of the total assets that
 remain in treasury and reserves.
@@ -53,79 +41,9 @@ private variable
   b : Block
   ls' : LState
   nes : NewEpochState
-  e : Epoch
-  es' : EnactState
-  govSt' : GovState
-  d : Bool
-  fut' : RatifyState
 
 instance _ = +-0-monoid
 
--- The NEWEPOCH rule is actually multiple rules in one for the sake of simplicity:t also does what EPOCH used to do in previous eras
-data _⊢_⇀⦇_,NEWEPOCH⦈_ : NewEpochEnv → NewEpochState → Epoch → NewEpochState → Set where
-\end{code}
-\begin{figure*}[h]
-\begin{code}
-  NEWEPOCH-New : ∀ {Γ} → let
-      open NewEpochState nes hiding (es)
-      open RatifyState fut using (removed) renaming (es to esW)
-      -- ^ this rolls over the future enact state into es
-      open LState ls; open UTxOState utxoSt
-      open CertState certState
-      open PState pState; open DState dState; open GState gState
-      open Acnt acnt
-
-      trWithdrawals   = esW .EnactState.withdrawals
-      totWithdrawals  = ∑[ x ← trWithdrawals ] x
-
-      removedGovActions = flip concatMapˢ removed λ (gaid , gaSt) →
-        mapˢ (GovActionState.returnAddr gaSt ,_)
-             ((deposits ∣ ❴ GovActionDeposit gaid ❵) ˢ)
-      govActionReturns = aggregate₊ $ mapˢ (λ (a , _ , d) → a , d) removedGovActions ᶠˢ
-
-      es        = record esW { withdrawals = ∅ }
-      retired   = retiring ⁻¹ e
-      payout    = govActionReturns ∪⁺ trWithdrawals
-      refunds   = pullbackMap payout (λ x → record { net = NetworkId ; stake = x }) (dom rewards)
-      unclaimed = getCoin payout ∸ getCoin refunds
-
-      govSt' = filter (λ x → ¿ proj₁ x ∉ mapˢ proj₁ removed ¿) govSt
-
-      gState' = record gState { ccHotKeys = ccHotKeys ∣ ccCreds (es .EnactState.cc) }
-
-      certState' = record certState {
-        pState = record pState
-          { pools = pools ∣ retired ᶜ ; retiring = retiring ∣ retired ᶜ };
-        dState = record dState
-          { rewards = rewards ∪⁺ refunds };
-        gState = if not (null govSt') then gState' else record gState'
-          { dreps = mapValues sucᵉ dreps }
-        }
-      utxoSt' = record utxoSt
-        { fees = 0
-        ; deposits = deposits ∣ mapˢ (proj₁ ∘ proj₂) removedGovActions ᶜ
-        ; donations = 0
-        }
-      ls' = record ls
-        { govSt = govSt' ; utxoSt = utxoSt' ; certState = certState' }
-      acnt' = record acnt
-        { treasury = treasury + fees + unclaimed + donations ∸ totWithdrawals }
-    in
-    e ≡ sucᵉ lastEpoch
-    → record { currentEpoch = e ; treasury = treasury ; GState gState ; NewEpochEnv Γ }
-        ⊢ ⟦ es , ∅ , false ⟧ʳ ⇀⦇ govSt' ,RATIFY⦈ fut'
-    ────────────────────────────────
-    Γ ⊢ nes ⇀⦇ e ,NEWEPOCH⦈ ⟦ e , acnt' , ls' , es , fut' ⟧ⁿᵉ
-
-  NEWEPOCH-Not-New : ∀ {Γ} → let open NewEpochState nes in
-    e ≢ sucᵉ lastEpoch
-    ────────────────────────────────
-    Γ ⊢ nes ⇀⦇ e ,NEWEPOCH⦈ nes
-\end{code}
-\caption{NEWEPOCH transition system\protect\footnotemark}
-\end{figure*}
-\footnotetext{The expression \AgdaBound{m}~\AgdaFunction{⁻¹}~\AgdaBound{B} denotes the inverse image of the set \AgdaBound{B} under the map \AgdaBound{m}.}
-\begin{code}[hide]
 -- TODO: do we still need this for anything?
 maybePurpose : DepositPurpose → (DepositPurpose × Credential) → Coin → Maybe Coin
 maybePurpose prps (prps' , _) c with prps ≟ prps'

--- a/src/Ledger/Chain/Properties.agda
+++ b/src/Ledger/Chain/Properties.agda
@@ -9,43 +9,16 @@ module Ledger.Chain.Properties
   (abs : AbstractFunctions txs) (open AbstractFunctions abs)
   where
 
-open import Ledger.Ratify txs
-open import Ledger.Ledger.Properties txs abs
-open import Ledger.Ratify.Properties txs
 open import Ledger.Chain txs abs
-open import Ledger.Ledger txs abs
+open import Ledger.Epoch txs abs
+open import Ledger.Epoch.Properties txs abs
+open import Ledger.Ledger.Properties txs abs
 
 open Computational ⦃...⦄
 
 module _ {Γ : NewEpochEnv} {nes : NewEpochState} {e : Epoch} where
 
-  open NewEpochState nes hiding (es)
-  open RatifyState fut using (removed) renaming (es to esW)
-  open LState ls; open CertState certState; open Acnt acnt
-  es         = record esW { withdrawals = ∅ }
-  govSt'     = filter (λ x → ¿ ¬ proj₁ x ∈ mapˢ proj₁ removed ¿) govSt
-
-  NEWEPOCH-total : ∃[ nes' ] Γ ⊢ nes ⇀⦇ e ,NEWEPOCH⦈ nes'
-  NEWEPOCH-total =
-    case e ≟ sucᵉ lastEpoch of λ where
-      (no ¬p) → -, NEWEPOCH-Not-New ¬p
-      (yes p) → -, NEWEPOCH-New p (pFut .proj₂)
-    where pFut = RATIFY-total {record { currentEpoch = e ; treasury = treasury
-                                      ; GState gState ; NewEpochEnv Γ }}
-                              {⟦ es , ∅ , false ⟧ʳ} {govSt'}
-
-  NEWEPOCH-complete : ∀ nes' → Γ ⊢ nes ⇀⦇ e ,NEWEPOCH⦈ nes' → NEWEPOCH-total .proj₁ ≡ nes'
-  NEWEPOCH-complete nes' h with h | e ≟ sucᵉ lastEpoch
-  ... | NEWEPOCH-New next _    | no ¬next = ⊥-elim (¬next next)
-  ... | NEWEPOCH-Not-New _     | no _     = refl
-  ... | NEWEPOCH-New _ h       | yes _    = cong ⟦ _ , _ , _ , _ ,_⟧ⁿᵉ (RATIFY-complete h)
-  ... | NEWEPOCH-Not-New ¬next | yes next = ⊥-elim (¬next next)
-
 instance
-  Computational-NEWEPOCH : Computational _⊢_⇀⦇_,NEWEPOCH⦈_
-  Computational-NEWEPOCH .computeProof Γ s sig = just NEWEPOCH-total
-  Computational-NEWEPOCH .completeness Γ s sig s' h = cong just (NEWEPOCH-complete s' h)
-
   Computational-CHAIN : Computational _⊢_⇀⦇_,CHAIN⦈_
   Computational-CHAIN .computeProof Γ s b = do
     _ , neStep ← computeProof {STS = _⊢_⇀⦇_,NEWEPOCH⦈_} _ _ _

--- a/src/Ledger/Deleg.lagda
+++ b/src/Ledger/Deleg.lagda
@@ -4,7 +4,7 @@
 {-# OPTIONS --safe #-}
 
 open import Ledger.Prelude
-open import Ledger.GovStructure
+open import Ledger.Types.GovStructure
 
 module Ledger.Deleg (gs : _) (open GovStructure gs) where
 

--- a/src/Ledger/Deleg/Properties.agda
+++ b/src/Ledger/Deleg/Properties.agda
@@ -1,7 +1,7 @@
 {-# OPTIONS --safe #-}
 
 open import Ledger.Prelude
-open import Ledger.GovStructure
+open import Ledger.Types.GovStructure
 
 open import Data.Maybe.Properties
 open import Relation.Nullary.Decidable

--- a/src/Ledger/Epoch.lagda
+++ b/src/Ledger/Epoch.lagda
@@ -1,0 +1,112 @@
+\section{Epoch boundary}
+
+\begin{code}[hide]
+{-# OPTIONS --safe #-}
+
+open import Data.Nat.Properties using (+-0-monoid; +-0-commutativeMonoid)
+
+open import Ledger.Prelude
+open import Ledger.Abstract
+open import Ledger.Transaction
+
+module Ledger.Epoch
+  (txs : _) (open TransactionStructure txs)
+  (abs : AbstractFunctions txs) (open AbstractFunctions abs)
+  where
+
+open import Ledger.Gov govStructure
+open import Ledger.Ledger txs abs
+open import Ledger.Ratify txs
+open import Ledger.Utxo txs abs
+\end{code}
+\begin{figure*}[h]
+\begin{code}
+
+record NewEpochEnv : Set where
+  field stakeDistrs : StakeDistrs
+   -- TODO: compute this from LState instead
+
+record NewEpochState : Set where
+  constructor ⟦_,_,_,_,_⟧ⁿᵉ
+  field lastEpoch  : Epoch
+        acnt       : Acnt
+        ls         : LState
+        es         : EnactState
+        fut        : RatifyState
+\end{code}
+\caption{Definitions for the NEWEPOCH transition system}
+The \AgdaRecord{Acnt} record has two fields, \AgdaField{treasury} and \AgdaField{reserves}, so
+the \AgdaBound{acnt} field in \AgdaRecord{NewEpochState} keeps track of the total assets that
+remain in treasury and reserves.
+\end{figure*}
+\begin{code}[hide]
+private variable
+  nes : NewEpochState
+  e : Epoch
+  fut' : RatifyState
+
+instance _ = +-0-monoid; _ = +-0-commutativeMonoid
+
+data _⊢_⇀⦇_,NEWEPOCH⦈_ : NewEpochEnv → NewEpochState → Epoch → NewEpochState → Set where
+\end{code}
+\begin{figure*}[h]
+\begin{code}
+  NEWEPOCH-New : ∀ {Γ} → let
+      open NewEpochState nes hiding (es)
+      open RatifyState fut using (removed) renaming (es to esW)
+      -- ^ this rolls over the future enact state into es
+      open LState ls; open UTxOState utxoSt
+      open CertState certState
+      open PState pState; open DState dState; open GState gState
+      open Acnt acnt
+
+      trWithdrawals   = esW .EnactState.withdrawals
+      totWithdrawals  = ∑[ x ← trWithdrawals ] x
+
+      removedGovActions = flip concatMapˢ removed λ (gaid , gaSt) →
+        mapˢ (GovActionState.returnAddr gaSt ,_)
+             ((deposits ∣ ❴ GovActionDeposit gaid ❵) ˢ)
+      govActionReturns = aggregate₊ $ mapˢ (λ (a , _ , d) → a , d) removedGovActions ᶠˢ
+
+      es        = record esW { withdrawals = ∅ }
+      retired   = retiring ⁻¹ e
+      payout    = govActionReturns ∪⁺ trWithdrawals
+      refunds   = pullbackMap payout (λ x → record { net = NetworkId ; stake = x }) (dom rewards)
+      unclaimed = getCoin payout ∸ getCoin refunds
+
+      govSt' = filter (λ x → ¿ proj₁ x ∉ mapˢ proj₁ removed ¿) govSt
+
+      gState' = record gState { ccHotKeys = ccHotKeys ∣ ccCreds (es .EnactState.cc) }
+
+      certState' = record certState {
+        pState = record pState
+          { pools = pools ∣ retired ᶜ ; retiring = retiring ∣ retired ᶜ };
+        dState = record dState
+          { rewards = rewards ∪⁺ refunds };
+        gState = if not (null govSt') then gState' else record gState'
+          { dreps = mapValues sucᵉ dreps }
+        }
+      utxoSt' = record utxoSt
+        { fees = 0
+        ; deposits = deposits ∣ mapˢ (proj₁ ∘ proj₂) removedGovActions ᶜ
+        ; donations = 0
+        }
+      ls' = record ls
+        { govSt = govSt' ; utxoSt = utxoSt' ; certState = certState' }
+      acnt' = record acnt
+        { treasury = treasury + fees + unclaimed + donations ∸ totWithdrawals }
+    in
+    e ≡ sucᵉ lastEpoch
+    → record { currentEpoch = e ; treasury = treasury ; GState gState ; NewEpochEnv Γ }
+        ⊢ ⟦ es , ∅ , false ⟧ʳ ⇀⦇ govSt' ,RATIFY⦈ fut'
+    ────────────────────────────────
+    Γ ⊢ nes ⇀⦇ e ,NEWEPOCH⦈ ⟦ e , acnt' , ls' , es , fut' ⟧ⁿᵉ
+
+  NEWEPOCH-Not-New : ∀ {Γ} → let open NewEpochState nes in
+    e ≢ sucᵉ lastEpoch
+    ────────────────────────────────
+    Γ ⊢ nes ⇀⦇ e ,NEWEPOCH⦈ nes
+\end{code}
+\caption{NEWEPOCH transition system\protect\footnotemark}
+\end{figure*}
+\footnotetext{The expression \AgdaBound{m}~\AgdaFunction{⁻¹}~\AgdaBound{B} denotes the inverse image of the set \AgdaBound{B} under the map \AgdaBound{m}.}

--- a/src/Ledger/Epoch/Properties.agda
+++ b/src/Ledger/Epoch/Properties.agda
@@ -1,0 +1,46 @@
+{-# OPTIONS --safe #-}
+
+open import Ledger.Prelude
+open import Ledger.Transaction
+open import Ledger.Abstract
+
+module Ledger.Epoch.Properties
+  (txs : _) (open TransactionStructure txs)
+  (abs : AbstractFunctions txs) (open AbstractFunctions abs)
+  where
+
+open import Ledger.Epoch txs abs
+open import Ledger.Ledger txs abs
+open import Ledger.Ratify txs
+open import Ledger.Ratify.Properties txs
+
+open Computational ⦃...⦄
+
+module _ {Γ : NewEpochEnv} {nes : NewEpochState} {e : Epoch} where
+
+  open NewEpochState nes hiding (es)
+  open RatifyState fut using (removed) renaming (es to esW)
+  open LState ls; open CertState certState; open Acnt acnt
+  es         = record esW { withdrawals = ∅ }
+  govSt'     = filter (λ x → ¿ ¬ proj₁ x ∈ mapˢ proj₁ removed ¿) govSt
+
+  NEWEPOCH-total : ∃[ nes' ] Γ ⊢ nes ⇀⦇ e ,NEWEPOCH⦈ nes'
+  NEWEPOCH-total =
+    case e ≟ sucᵉ lastEpoch of λ where
+      (no ¬p) → -, NEWEPOCH-Not-New ¬p
+      (yes p) → -, NEWEPOCH-New p (pFut .proj₂)
+    where pFut = RATIFY-total {record { currentEpoch = e ; treasury = treasury
+                                      ; GState gState ; NewEpochEnv Γ }}
+                              {⟦ es , ∅ , false ⟧ʳ} {govSt'}
+
+  NEWEPOCH-complete : ∀ nes' → Γ ⊢ nes ⇀⦇ e ,NEWEPOCH⦈ nes' → NEWEPOCH-total .proj₁ ≡ nes'
+  NEWEPOCH-complete nes' h with h | e ≟ sucᵉ lastEpoch
+  ... | NEWEPOCH-New next _    | no ¬next = ⊥-elim (¬next next)
+  ... | NEWEPOCH-Not-New _     | no _     = refl
+  ... | NEWEPOCH-New _ h       | yes _    = cong ⟦ _ , _ , _ , _ ,_⟧ⁿᵉ (RATIFY-complete h)
+  ... | NEWEPOCH-Not-New ¬next | yes next = ⊥-elim (¬next next)
+
+instance
+  Computational-NEWEPOCH : Computational _⊢_⇀⦇_,NEWEPOCH⦈_
+  Computational-NEWEPOCH .computeProof Γ s sig = just NEWEPOCH-total
+  Computational-NEWEPOCH .completeness Γ s sig s' h = cong just (NEWEPOCH-complete s' h)

--- a/src/Ledger/Epoch/Properties.agda
+++ b/src/Ledger/Epoch/Properties.agda
@@ -16,29 +16,50 @@ open import Ledger.Ratify.Properties txs
 
 open Computational ⦃...⦄
 
-module _ {Γ : NewEpochEnv} {nes : NewEpochState} {e : Epoch} where
+module _ {Γ : NewEpochEnv} {eps : EpochState} {e : Epoch} where
 
-  open NewEpochState nes hiding (es)
+  open EpochState eps hiding (es)
   open RatifyState fut using (removed) renaming (es to esW)
   open LState ls; open CertState certState; open Acnt acnt
   es         = record esW { withdrawals = ∅ }
   govSt'     = filter (λ x → ¿ ¬ proj₁ x ∈ mapˢ proj₁ removed ¿) govSt
 
-  NEWEPOCH-total : ∃[ nes' ] Γ ⊢ nes ⇀⦇ e ,NEWEPOCH⦈ nes'
-  NEWEPOCH-total =
-    case e ≟ sucᵉ lastEpoch of λ where
-      (no ¬p) → -, NEWEPOCH-Not-New ¬p
-      (yes p) → -, NEWEPOCH-New p (pFut .proj₂)
+  EPOCH-total : ∃[ eps' ] Γ ⊢ eps ⇀⦇ e ,EPOCH⦈ eps'
+  EPOCH-total = -, EPOCH (pFut .proj₂)
     where pFut = RATIFY-total {record { currentEpoch = e ; treasury = treasury
                                       ; GState gState ; NewEpochEnv Γ }}
                               {⟦ es , ∅ , false ⟧ʳ} {govSt'}
 
-  NEWEPOCH-complete : ∀ nes' → Γ ⊢ nes ⇀⦇ e ,NEWEPOCH⦈ nes' → NEWEPOCH-total .proj₁ ≡ nes'
-  NEWEPOCH-complete nes' h with h | e ≟ sucᵉ lastEpoch
-  ... | NEWEPOCH-New next _    | no ¬next = ⊥-elim (¬next next)
-  ... | NEWEPOCH-Not-New _     | no _     = refl
-  ... | NEWEPOCH-New _ h       | yes _    = cong ⟦ _ , _ , _ , _ ,_⟧ⁿᵉ (RATIFY-complete h)
-  ... | NEWEPOCH-Not-New ¬next | yes next = ⊥-elim (¬next next)
+  EPOCH-complete : ∀ eps' → Γ ⊢ eps ⇀⦇ e ,EPOCH⦈ eps' → proj₁ EPOCH-total ≡ eps'
+  EPOCH-complete eps' (EPOCH p) = cong ⟦ _ , _ , _ ,_⟧ᵉ' (RATIFY-complete p)
+
+  abstract
+    EPOCH-total' : ∃[ eps' ] Γ ⊢ eps ⇀⦇ e ,EPOCH⦈ eps'
+    EPOCH-total' = EPOCH-total
+
+    EPOCH-complete' : ∀ eps' → Γ ⊢ eps ⇀⦇ e ,EPOCH⦈ eps' → proj₁ EPOCH-total' ≡ eps'
+    EPOCH-complete' = EPOCH-complete
+
+instance
+  Computational-EPOCH : Computational _⊢_⇀⦇_,EPOCH⦈_
+  Computational-EPOCH .computeProof Γ s sig = just EPOCH-total'
+  Computational-EPOCH .completeness Γ s sig s' h = cong just (EPOCH-complete' s' h)
+
+module _ {Γ : NewEpochEnv} {nes : NewEpochState} {e : Epoch} where
+
+  open NewEpochState nes
+
+  NEWEPOCH-total : ∃[ nes' ] Γ ⊢ nes ⇀⦇ e ,NEWEPOCH⦈ nes'
+  NEWEPOCH-total with e ≟ sucᵉ lastEpoch
+  ... | yes p = ⟦ e , proj₁ EPOCH-total' ⟧ⁿᵉ , NEWEPOCH-New p (EPOCH-total' .proj₂)
+  ... | no ¬p = -, NEWEPOCH-Not-New ¬p
+
+  NEWEPOCH-complete : ∀ nes' → Γ ⊢ nes ⇀⦇ e ,NEWEPOCH⦈ nes' → proj₁ NEWEPOCH-total ≡ nes'
+  NEWEPOCH-complete nes' h with e ≟ sucᵉ lastEpoch | h
+  ... | yes p | NEWEPOCH-New x x₁  rewrite EPOCH-complete' _ x₁ = refl
+  ... | yes p | NEWEPOCH-Not-New x = ⊥-elim $ x p
+  ... | no ¬p | NEWEPOCH-New x x₁  = ⊥-elim $ ¬p x
+  ... | no ¬p | NEWEPOCH-Not-New x = refl
 
 instance
   Computational-NEWEPOCH : Computational _⊢_⇀⦇_,NEWEPOCH⦈_

--- a/src/Ledger/Foreign/HSLedger.agda
+++ b/src/Ledger/Foreign/HSLedger.agda
@@ -15,9 +15,9 @@ import Foreign.Haskell as F
 import Ledger.Foreign.LedgerTypes as F
 
 open import Ledger.Crypto
-open import Ledger.Epoch
-open import Ledger.GovStructure
 open import Ledger.Transaction
+open import Ledger.Types.Epoch
+open import Ledger.Types.GovStructure
 
 open import Interface.HasOrder.Instance
 

--- a/src/Ledger/Gov.lagda
+++ b/src/Ledger/Gov.lagda
@@ -4,7 +4,7 @@
 {-# OPTIONS --safe #-}
 
 open import Ledger.Prelude
-open import Ledger.GovStructure
+open import Ledger.Types.GovStructure
 
 module Ledger.Gov (gs : _) (open GovStructure gs hiding (epoch)) where
 

--- a/src/Ledger/Gov/Properties.agda
+++ b/src/Ledger/Gov/Properties.agda
@@ -5,7 +5,7 @@ open import Data.List.Membership.Propositional.Properties
 open import Data.List.Relation.Unary.Any
 
 open import Ledger.Prelude hiding (Any; any?)
-open import Ledger.GovStructure
+open import Ledger.Types.GovStructure
 
 module Ledger.Gov.Properties (gs : _) (open GovStructure gs hiding (epoch)) where
 

--- a/src/Ledger/GovernanceActions.lagda
+++ b/src/Ledger/GovernanceActions.lagda
@@ -278,7 +278,6 @@ private variable
   q : ℚ
   dh : DocHash
   sh : Maybe ScriptHash
-  h : PPHash
   v : ProtVer
   wdrl : RwdAddr ⇀ Coin
   t : Coin

--- a/src/Ledger/GovernanceActions.lagda
+++ b/src/Ledger/GovernanceActions.lagda
@@ -18,7 +18,7 @@ open import Data.Rational using (ℚ; 0ℚ; 1ℚ)
 open import Tactic.Derive.DecEq
 
 open import Ledger.Prelude hiding (yes; no)
-open import Ledger.GovStructure
+open import Ledger.Types.GovStructure
 
 module Ledger.GovernanceActions (gs : _) (open GovStructure gs) where
 
@@ -47,13 +47,13 @@ record Anchor : Set where
          hash  : DocHash
 
 data GovAction : Set where
-  NoConfidence     :                                           GovAction
-  NewCommittee     : Credential ⇀ Epoch → ℙ Credential → ℚ  →  GovAction
-  NewConstitution  : DocHash → Maybe ScriptHash             →  GovAction
-  TriggerHF        : ProtVer                                →  GovAction
-  ChangePParams    : PParamsUpdate                          →  GovAction
-  TreasuryWdrl     : (RwdAddr ⇀ Coin)                       →  GovAction
-  Info             :                                           GovAction
+  NoConfidence     :                                             GovAction
+  NewCommittee     : (Credential ⇀ Epoch) → ℙ Credential → ℚ  →  GovAction
+  NewConstitution  : DocHash → Maybe ScriptHash               →  GovAction
+  TriggerHF        : ProtVer                                  →  GovAction
+  ChangePParams    : PParamsUpdate                            →  GovAction
+  TreasuryWdrl     : (RwdAddr ⇀ Coin)                         →  GovAction
+  Info             :                                             GovAction
 
 actionWellFormed : GovAction → Bool
 actionWellFormed (ChangePParams x)  = ppdWellFormed x

--- a/src/Ledger/GovernanceActions/Properties.agda
+++ b/src/Ledger/GovernanceActions/Properties.agda
@@ -3,7 +3,7 @@
 open import Data.Nat.Properties using (+-0-monoid)
 
 open import Ledger.Prelude
-open import Ledger.GovStructure
+open import Ledger.Types.GovStructure
 
 module Ledger.GovernanceActions.Properties (gs : _) (open GovStructure gs) where
 

--- a/src/Ledger/PDF.lagda
+++ b/src/Ledger/PDF.lagda
@@ -65,6 +65,7 @@ open import Ledger.EssentialAgda
 \include{Ledger/Utxow}
 \include{Ledger/Ledger}
 \include{Ledger/Ratify}
+\include{Ledger/Epoch}
 \include{Ledger/Chain}
 
 \section{Properties}

--- a/src/Ledger/PDF.lagda
+++ b/src/Ledger/PDF.lagda
@@ -14,13 +14,13 @@ module Ledger.PDF where
 open import Ledger.BaseTypes
 open import Ledger.Introduction
 open import Ledger.Crypto
-open import Ledger.Epoch
+open import Ledger.Types.Epoch
 open import Ledger.Address
 open import Ledger.Script
 open import Ledger.ScriptValidation
 open import Ledger.PParams
 
-open import Ledger.GovStructure
+open import Ledger.Types.GovStructure
 open import Ledger.GovernanceActions
 open import Ledger.Deleg
 

--- a/src/Ledger/PParams.lagda
+++ b/src/Ledger/PParams.lagda
@@ -14,9 +14,9 @@ open import Relation.Nullary.Decidable
 open import Tactic.Derive.DecEq
 
 open import Ledger.Prelude
-open import Ledger.Epoch
 open import Ledger.Crypto
 open import Ledger.Script
+open import Ledger.Types.Epoch
 
 module Ledger.PParams
   (crypto : Crypto )

--- a/src/Ledger/PParams.lagda
+++ b/src/Ledger/PParams.lagda
@@ -26,13 +26,18 @@ module Ledger.PParams
 
 private variable
   m n : ℕ
-
-record Acnt : Set where
-  field treasury reserves : Coin
 \end{code}
+
+The \AgdaRecord{Acnt} record has two fields, \AgdaField{treasury} and \AgdaField{reserves}, so
+the \AgdaBound{acnt} field in \AgdaRecord{NewEpochState} keeps track of the total assets that
+remain in treasury and reserves.
+
 \begin{figure*}[h!]
 \begin{AgdaAlign}
 \begin{code}
+record Acnt : Set where
+  field treasury reserves : Coin
+
 ProtVer : Set
 ProtVer = ℕ × ℕ
 

--- a/src/Ledger/Script.lagda
+++ b/src/Ledger/Script.lagda
@@ -14,8 +14,8 @@ open import Tactic.Derive.DecEq
 open import Tactic.Inline
 
 open import Ledger.Prelude hiding (All; Any; all?; any?; _∷ʳ_; uncons; _⊆_)
-open import Ledger.Epoch
 open import Ledger.Crypto
+open import Ledger.Types.Epoch
 
 module Ledger.Script
   (crypto : _) (open Crypto crypto)

--- a/src/Ledger/Transaction.lagda
+++ b/src/Ledger/Transaction.lagda
@@ -13,8 +13,8 @@ import Data.Maybe.Base as M
 open import Ledger.Prelude
 
 open import Ledger.Crypto
-open import Ledger.Epoch
-open import Ledger.GovStructure
+open import Ledger.Types.Epoch
+open import Ledger.Types.GovStructure
 import Ledger.PParams
 import Ledger.Script
 import Ledger.GovernanceActions

--- a/src/Ledger/Types/Epoch.agda
+++ b/src/Ledger/Types/Epoch.agda
@@ -1,6 +1,6 @@
 {-# OPTIONS --safe #-}
 
-module Ledger.Epoch where
+module Ledger.Types.Epoch where
 
 open import Ledger.Prelude hiding (compare; Rel)
 

--- a/src/Ledger/Types/GovStructure.agda
+++ b/src/Ledger/Types/GovStructure.agda
@@ -1,11 +1,11 @@
 {-# OPTIONS --safe #-}
 
-module Ledger.GovStructure where
+module Ledger.Types.GovStructure where
 
 open import Class.DecEq
-open import Ledger.Epoch
 open import Ledger.Crypto
 open import Ledger.Script
+open import Ledger.Types.Epoch
 import Ledger.PParams
 
 record GovStructure : Set₁ where


### PR DESCRIPTION
# Description

This matches how it's done in the Shelley spec, and makes things a little simpler. I also went and simplified `EPOCH` as much as I could. Closes #287.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] Code is formatted according to [CONTRIBUTING.md](https://github.com/input-output-hk/formal-ledger-specifications/blob/master/CONTRIBUTING.md)
- [x] Self-reviewed the diff
